### PR TITLE
Inverted palette scroll toggle, bugfix palette scroll on firefox

### DIFF
--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -53,6 +53,7 @@
                     <label><input id="monospaceToggle" type="checkbox"/>Toggle monospace font for lookups</label>
                     <label><input id="increasedZoomToggle" type="checkbox"/>Allow zoom values greater than 50x</label>
                     <label><input id="scrollSwitchToggle" type="checkbox"/>Enable scrolling on the palette to switch colors</label>
+                    <label style="text-indent:1em"><input id="scrollDirectionToggle" type="checkbox"/>Invert scroll direction</label>
                     <label>Heatmap BG Opacity: <input type="range" min="0" max="1" step="0.01" id="heatmap-opacity"></label>
                     <label>Virginmap BG Opacity: <input type="range" min="0" max="1" step="0.01" id="virginmap-opacity"></label>
                     <label>

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -2003,7 +2003,8 @@ window.App = (function () {
                     };
                     self.elements.palette.on("wheel", e => {
                         if (ls.get("scrollSwitchEnabled") !== true) return;
-                        let newVal = (self.color + (e.originalEvent.wheelDelta > 0 ? 1 : -1)) % self.palette.length; //if wheelDelta > 0, we're scrolling up (move forward) so add 1. otherwise subtract 1. we modulus wrap in case they're scrolling up past palette.length.
+                        let delta = e.originalEvent.deltaY * -40;
+                        let newVal = (self.color + ((delta > 0 ? 1 : -1) * (ls.get("scrollSwitchDirectionInverted") === true ? -1 : 1))) % self.palette.length;
                         self.switch(newVal <= -1 ? self.palette.length - 1 : newVal);
                     });
                 },
@@ -2449,6 +2450,11 @@ window.App = (function () {
                     $("#scrollSwitchToggle").prop("checked", ls.get("scrollSwitchEnabled") === true);
                     $("#scrollSwitchToggle").change(function () {
                         ls.set("scrollSwitchEnabled", this.checked === true);
+                    });
+
+                    $("#scrollDirectionToggle").prop("checked", ls.get("scrollSwitchDirectionInverted") === true);
+                    $("#scrollDirectionToggle").change(function() {
+                        ls.set("scrollSwitchDirectionInverted", this.checked === true);
                     });
 
                     $(window).keydown(function (evt) {


### PR DESCRIPTION
This PR brings the following:
* Fix a bug on Firefox where palette scrolling would only go one direction
* Add a setting to invert palette scrolling direction