### PR TITLE
Resolving conflict with evt.code and jQuery version used

### DIFF
--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -616,7 +616,7 @@ window.App = (function () {
                     });
 
                     $(document.body).on("keydown", function (evt) {
-                        switch (evt.code || evt.keyCode || evt.which || evt.key) {
+                        switch (evt.originalEvent.code || evt.keyCode || evt.which || evt.key) {
                             case "KeyW":        // W
                             case "ArrowUp":
                             case 38:            // Arrow Up


### PR DESCRIPTION
This change should resolve a conflict with the use of <keyboardEvent>.code and the version of the jQuery library used; the jQuery-modified event object does not include .code .  This causes that part of the switch statement to always be skipped as it reads 'undefined'.  As a result, some log-standing bugs - like the Mute key on some keyboards with some browsers causing the canvas to zoom out - still rear their head.

This change causes .code to be read from the original event object instead.  If not available (old browser or platform) it will still skip to the next test.
This change was not tested within a pxls config context, so please review carefully and make sure that all the .code events for possible keys do match up? :x