### PR TITLE
Update Undertow

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
         <dependency>
             <groupId>io.undertow</groupId>
             <artifactId>undertow-core</artifactId>
-            <version>1.4.12.Final</version>
+            <version>2.0.1.Final</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Versions of Undertow >= 1.4.0 and < 1.4.17 have been marked as vulnerable to possible web-cache poisoning, XSS attacks, and breaches of sensitive information. See CVE-2017-2666 for more: https://nvd.nist.gov/vuln/detail/CVE-2017-2666