### PR TITLE
Change heat/virginmap clearing enabled toggle to h/vmap clear button

### DIFF
--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -47,7 +47,7 @@
                     <label><input id="audiotoggle" type="checkbox"/>Mute sound</label>
                     <label><input id="heatmaptoggle" type="checkbox"/>Turn on heatmap (toggle with <kbd>H</kbd>)</label>
                     <label><input id="virginmaptoggle" type="checkbox"/>Turn on virginmap (toggle with <kbd>X</kbd>)</label>
-                    <button id="hvmapClear">Clear heatmap and virginmap</button>(hotkey: <kbd>O</kbd>)
+                    <button id="hvmapClear">Clear heatmap and virginmap</button> (hotkey: <kbd>O</kbd>)
                     <label><input id="gridtoggle" type="checkbox"/>Turn on grid (toggle with <kbd>G</kbd>)</label>
                     <label><input id="stickyColorToggle" type="checkbox"/>Keep color selected</label>
                     <label><input id="monospaceToggle" type="checkbox"/>Toggle monospace font for lookups</label>

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -47,7 +47,7 @@
                     <label><input id="audiotoggle" type="checkbox"/>Mute sound</label>
                     <label><input id="heatmaptoggle" type="checkbox"/>Turn on heatmap (toggle with <kbd>H</kbd>)</label>
                     <label><input id="virginmaptoggle" type="checkbox"/>Turn on virginmap (toggle with <kbd>X</kbd>)</label>
-                    <label><input type="checkbox" id="hvmapClearable">Enable heatmap and virginmap clearing (hotkey: <kbd>O</kbd>)</label>
+                    <button id="hvmapClear">Clear heatmap and virginmap</button>(hotkey: <kbd>O</kbd>)
                     <label><input id="gridtoggle" type="checkbox"/>Turn on grid (toggle with <kbd>G</kbd>)</label>
                     <label><input id="stickyColorToggle" type="checkbox"/>Keep color selected</label>
                     <label><input id="monospaceToggle" type="checkbox"/>Toggle monospace font for lookups</label>

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -1260,9 +1260,7 @@ window.App = (function () {
                     });
                 },
                 clear: function () {
-                    if (ls.get("hvm_clearable") === true) {
-                        self._clear();
-                    }
+                    self._clear();
                 },
                 _clear: function () {
                     for (var i = 0; i < self.width * self.height; i++) {
@@ -1289,9 +1287,8 @@ window.App = (function () {
                     $("#heatmap-opacity").on("change input", function () {
                         self.setBackgroundOpacity(parseFloat(this.value));
                     });
-                    $("#hvmapClearable")[0].checked = ls.get("hvm_clearable");
-                    $("#hvmapClearable").change(function () {
-                        ls.set("hvm_clearable", this.checked);
+                    $("#hvmapClear").click(function () {
+                        self.clear();
                     });
                     $(window).keydown(function (evt) {
                         if (evt.key == "o" || evt.key == "O" || evt.which == 79) { //O key
@@ -1406,9 +1403,7 @@ window.App = (function () {
                     });
                 },
                 clear: function () {
-                    if (ls.get("hvm_clearable") === true) {
-                        self._clear();
-                    }
+                    self._clear();
                 },
                 _clear: function () {
                     self.ctx.putImageData(self.id, 0, 0);
@@ -1434,9 +1429,8 @@ window.App = (function () {
                     $("#virginmap-opacity").on("change input", function () {
                         self.setBackgroundOpacity(parseFloat(this.value));
                     });
-                    $("#hvmapClearable")[0].checked = ls.get("hvm_clearable");
-                    $("#hvmapClearable").change(function () {
-                        ls.set("hvm_clearable", this.checked);
+                    $("#hvmapClear").click(function () {
+                        self.clear();
                     });
                     $(window).keydown(function (evt) {
                         if (evt.key == "o" || evt.key == "O" || evt.which == 79) { //O key


### PR DESCRIPTION
This changes the heat/virginmap clearing enabled toggle to a heat/virginmap clear button.  This will allow mobile users to clear the heat/virginmap, and obviates storing a setting.

UX keyboard shortcut behavior remains, a button makes the function available to more platforms  
UI: this introduces a button, which may be visually jarring in a column of checkboxes (but theres slider and dropdowns as well, so :man_shrugging:
storage: ignores stored 'hvm_clearable' key, but does not call ls.remove to remove it.