### PR TITLE
Logging system tweaks

### DIFF
--- a/resources/log4j2.xml
+++ b/resources/log4j2.xml
@@ -6,7 +6,19 @@
 
         <File name="Pixels" fileName="logs/pixels.log">
             <PatternLayout>
-                <Pattern>%d %m%n</Pattern>
+                <Pattern>%d&#9;%m%n</Pattern>
+            </PatternLayout>
+        </File>
+
+        <File name="ShadowbannedPixels" fileName="logs/shadowbannedPixels.log">
+            <PatternLayout>
+                <Pattern>%d&#9;%m%n</Pattern>
+            </PatternLayout>
+        </File>
+
+        <File name="App" fileName="logs/app.log">
+            <PatternLayout>
+                <Pattern>%d&#9;%m%n</Pattern>
             </PatternLayout>
         </File>
     </Appenders>
@@ -17,6 +29,14 @@
 
         <Logger name="Pixels" level="INFO">
             <AppenderRef ref="Pixels"/>
+        </Logger>
+
+        <Logger name="App" level="INFO">
+            <AppenderRef ref="App"/>
+        </Logger>
+
+        <Logger name="ShadowbannedPixels" level="INFO">
+            <AppenderRef ref="ShadowbannedPixels"/>
         </Logger>
     </Loggers>
 </Configuration>

--- a/src/main/java/space/pxls/data/Database.java
+++ b/src/main/java/space/pxls/data/Database.java
@@ -63,8 +63,7 @@ public class Database implements Closeable {
         h = new DatabaseHandle();
         h.dao = dbi.open(DAO.class);
         h.lastUse = System.currentTimeMillis();
-        System.out.println("Creating new mariadb connection...");
-        System.out.println(h);
+        App.getLogger().debug("Created new MariDB handle", h, h, h);
         handles.put(t, h);
         return h.dao;
     }
@@ -74,8 +73,7 @@ public class Database implements Closeable {
             DatabaseHandle d = handles.get(t);
             if (d.lastUse + (1000 * 60 * 5)  < System.currentTimeMillis()) {
                 // ok destroy it
-                System.out.println("Destroying mariadb connection...");
-                System.out.println(d.dao);
+                App.getLogger().debug("Destroying MariaDB connection");
                 d.dao.close();
                 handles.remove(t);
             }

--- a/src/main/java/space/pxls/server/PacketHandler.java
+++ b/src/main/java/space/pxls/server/PacketHandler.java
@@ -157,14 +157,14 @@ public class PacketHandler {
         DBPixelPlacement lastPixel = App.getDatabase().getPixelByID(thisPixel.secondaryId);
         if (lastPixel != null) {
             App.getDatabase().putUserUndoPixel(lastPixel, user, thisPixel.id);
-            App.putPixel(lastPixel.x, lastPixel.y, lastPixel.color, user, false, "(user undo)", false);
+            App.putPixel(lastPixel.x, lastPixel.y, lastPixel.color, user, false, channel.getSourceAddress().getAddress().getHostAddress(), false, "user undo");
             broadcastPixelUpdate(lastPixel.x, lastPixel.y, lastPixel.color);
             ackUndo(user, lastPixel.x, lastPixel.y);
             sendAvailablePixels(user, "undo");
         } else {
             byte defaultColor = App.getDefaultColor(thisPixel.x, thisPixel.y);
             App.getDatabase().putUserUndoPixel(thisPixel.x, thisPixel.y, defaultColor, user, thisPixel.id);
-            App.putPixel(thisPixel.x, thisPixel.y, defaultColor, user, false, "(user undo)", false);
+            App.putPixel(thisPixel.x, thisPixel.y, defaultColor, user, false, channel.getSourceAddress().getAddress().getHostAddress(), false, "user undo");
             broadcastPixelUpdate(thisPixel.x, thisPixel.y, defaultColor);
             ackUndo(user, thisPixel.x, thisPixel.y);
             sendAvailablePixels(user, "undo");
@@ -229,7 +229,7 @@ public class PacketHandler {
                     }
                     if (user.isShadowBanned()) {
                         // ok let's just pretend to set a pixel...
-                        System.out.println("shadowban pixel!");
+                        App.logShadowbannedPixel(cp.getX(), cp.getY(), cp.getColor(), user.getName(), ip);
                         ServerPlace msg = new ServerPlace(Collections.singleton(new ServerPlace.Pixel(cp.getX(), cp.getY(), cp.getColor())));
                         for (WebSocketChannel ch : user.getConnections()) {
                             server.send(ch, msg);
@@ -239,7 +239,7 @@ public class PacketHandler {
                         }
                     } else {
                         boolean mod_action = user.isOverridingCooldown();
-                        App.putPixel(cp.getX(), cp.getY(), cp.getColor(), user, mod_action, ip, true);
+                        App.putPixel(cp.getX(), cp.getY(), cp.getColor(), user, mod_action, ip, true, "");
                         App.saveMap();
                         broadcastPixelUpdate(cp.getX(), cp.getY(), cp.getColor());
                         ackPlace(user, cp.getX(), cp.getY());

--- a/src/main/java/space/pxls/server/WebHandler.java
+++ b/src/main/java/space/pxls/server/WebHandler.java
@@ -278,10 +278,10 @@ public class WebHandler {
         List<String> reports = new ArrayList<String>();
         if (App.getDatabase().haveDupeIp(ip, user.getId())) {
             reports.add("Duplicate IP");
-            System.out.println("dupe ip");
+//            App.getLogger().debug("dupe ip");
         }
         if (reports.size() > 0) {
-            System.out.println("have reports");
+//            App.getLogger().debug("have reports");
             String msg = "Potential dupe user. Reasons:\n\n";
             for (String r : reports) {
                 msg += r+"\n";

--- a/src/main/java/space/pxls/user/User.java
+++ b/src/main/java/space/pxls/user/User.java
@@ -300,12 +300,12 @@ public class User {
             return;
         }
         long delta = (System.currentTimeMillis()-lastPixelTime) / 1000;
-        //System.out.println("=======");
+        //App.getLogger().debug("=======");
         while(true) {
             int target = (curCD * multiplier) * (2 + getStacked() + addToN(getStacked()));
-            //System.out.print(delta);
-            //System.out.print(" : ");
-            //System.out.println(target);
+            //App.getLogger().debug(delta);
+            //App.getLogger().debug(" : ");
+            //App.getLogger().debug(target);
             if (delta >= target && getStacked() < maxStacked) {
                 setStacked(getStacked() + 1);
                 if (sendRes) {


### PR DESCRIPTION
**This change is not retroactive and should not be merged until a canvas reset.**

This PR brings the following:
* Move app logging to its own log handler
* Convert pixel logger to TSV
* Always attach an action to the pixel logger
* Log shadowbanned pixels in their own file for monitoring

These are basically just QoL updates for our current logging system in terms of parsing and data displayed.
This is achieved by updating pixel logging into a tab-separated format, as well as ensuring there's always an `action` column attached.

This PR also removes `clearing old sessions` from the pixel log, and moves most app logging to an actual logger, as well as logs shadowbanned pixels in their own file for monitoring.

Example new log structure:
```
DATE	USER_NAME	X	Y	COLOR	IP	ACTION


2019-03-19 02:14:30,239	<server>	0	0	4		console nuke
2019-03-19 02:14:40,305	USER	0	0	5	192.168.1.1	user place
2019-03-19 02:14:53,760	USER	1	1	5	192.168.1.1	mod overwrite
2019-03-19 02:15:56,043	USER	164	217	5		rollback
2019-03-19 02:16:06,081	USER	164	217	4		rollback undo
```
`console nuke` is the `nuke` command from console
`user place` is a normal user pixel place
`mod overwrite` is a mod using the 'Override CD' setting
`rollback` is a ban rollback (removed placed pixels on permaban/etc)
`rollback undo` is an unban rollback (restored pixels after unban).

The difference being IPs are no longer empty on undo, and actions (undo/nuke), etc are always displayed in the rightmost column. This makes parsing for staff reasons much cleaner, and general consumption much easier.