### PR TITLE
Fix pixel gap between info drawer button

### DIFF
--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -255,7 +255,7 @@ button.button.dark:disabled {
     transform: translateZ(-1em);
     transform-style: preserve-3d;
     z-index: 11;
-    top: 100%;
+    top: 99.9%; /* I hate it, but it works. */
     background: #333;
     padding: 10px;
     margin: 0;


### PR DESCRIPTION
![gap](https://user-images.githubusercontent.com/19217244/54728123-4cd5eb00-4b52-11e9-95ae-712a0c036378.PNG)
![gap_fixed](https://user-images.githubusercontent.com/19217244/54728127-50697200-4b52-11e9-8727-2f37ab689a69.PNG)

I hate this bug, and I hate this fix. It works though.