### PR TITLE
Add the option to add numbers to palette entries (configurable)

### DIFF
--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -55,6 +55,7 @@
                     <label><input id="scrollSwitchToggle" type="checkbox"/>Enable scrolling on the palette to switch colors</label>
                     <label style="text-indent:1em"><input id="scrollDirectionToggle" type="checkbox"/>Invert scroll direction</label>
                     <label><input id="cbEnableMiddleMouseSelect" type="checkbox"> Enable middle mouse button selecting color from board</label>
+                    <label><input id="cbNumberedPalette" type="checkbox"> Add numbers to palette entries</label>
                     <label>Heatmap BG Opacity: <input type="range" min="0" max="1" step="0.01" id="heatmap-opacity"></label>
                     <label>Virginmap BG Opacity: <input type="range" min="0" max="1" step="0.01" id="virginmap-opacity"></label>
                     <label>

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -1873,6 +1873,9 @@ window.App = (function () {
                     }).show();
                     self.elements.cursor.show();
                 },
+                setNumberedPaletteEnabled: function(shouldBeNumbered) {
+                    self.elements.palette[0].classList.toggle('no-pills', !shouldBeNumbered);
+                },
                 setPalette: function (palette) {
                     self.palette = palette;
                     self.elements.palette.find(".palette-color").remove().end().append(
@@ -1882,6 +1885,9 @@ window.App = (function () {
                                 .addClass("palette-color")
                                 .addClass("ontouchstart" in window ? "touch" : "no-touch")
                                 .css("background-color", self.palette[idx])
+                                .append(
+                                    $("<span>").addClass("palette-number").text(idx)
+                                )
                                 .click(function () {
                                     if (ls.get("auto_reset") === false || timer.cooledDown()) {
                                         self.switch(idx);
@@ -2030,6 +2036,7 @@ window.App = (function () {
                 setPalette: self.setPalette,
                 getPaletteRGB: self.getPaletteRGB,
                 setAutoReset: self.setAutoReset,
+                setNumberedPaletteEnabled: self.setNumberedPaletteEnabled,
                 get color() {
                     return self.color;
                 }
@@ -2461,6 +2468,13 @@ window.App = (function () {
                     $("#cbEnableMiddleMouseSelect").prop("checked", ls.get("enableMiddleMouseSelect") === true)
                         .change(function() {
                             ls.set("enableMiddleMouseSelect", this.checked === true);
+                        });
+
+                    place.setNumberedPaletteEnabled(ls.get("enableNumberedPalette") === true);
+                    $("#cbNumberedPalette").prop("checked", ls.get("enableNumberedPalette") === true)
+                        .change(function() {
+                            ls.set("enableNumberedPalette", this.checked === true);
+                            place.setNumberedPaletteEnabled(this.checked === true);
                         });
 
                     $(window).keydown(function (evt) {

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -211,6 +211,25 @@ button.button.dark:disabled {
     margin-bottom: 10px;
 }
 
+.palette-number {
+    position: absolute;
+    transform: translate(-50%, -50%);
+    border-radius: 16px;
+    text-align: center;
+    background-color: #fff;
+    border: 1px solid #000;
+    width: 2em;
+    font-size: .75em;
+    user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    -webkit-user-select: none;
+}
+
+#palette.no-pills .palette-number {
+    display: none !important;
+}
+
 /*//////////////////////////*\
 | Info / Template Drawer
 \*\\\\\\\\\\\\\\\\\\\\\\\\\\*/
@@ -442,7 +461,7 @@ button.button.dark:disabled {
 
 #palette {
     z-index: 6;
-    padding: 10px 0 7px;
+    padding: 15px 0 7px;
     margin: 0 auto;
 
     overflow-x: auto;


### PR DESCRIPTION
This PR brings the following:
* Adds an option to the Settings panel to display numbered pills on palette entries corresponding to their IDX:
![image](https://user-images.githubusercontent.com/45169495/55271512-b5704680-527b-11e9-8344-417a1d984f6f.png)