### PR TITLE
scrollIntoView for iframes, with fallback

### DIFF
--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -1826,7 +1826,11 @@ window.App = (function () {
                     self.elements.reticule.css("background-color", self.palette[newColor]);
                     if (newColor !== -1) {
                         $($(".palette-color[data-idx=" + newColor + "],.palette-color[data-idx=-1]")).addClass("active"); //Select both the new color AND the deselect button. Signifies more that it's a deselect button rather than a "delete pixel" button
-                        $(`.palette-color[data-idx="${newColor}"]`)[0].scrollIntoView({block:"nearest", inline:"nearest"});
+                        try {
+                            $(`.palette-color[data-idx="${newColor}"]`)[0].scrollIntoView({block:"nearest", inline:"nearest"});
+                        } catch (e) {
+                            $(`.palette-color[data-idx="${newColor}"]`)[0].scrollIntoView(false);
+                        }
                     }
                 },
                 place: function (x, y) {

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -1826,7 +1826,7 @@ window.App = (function () {
                     self.elements.reticule.css("background-color", self.palette[newColor]);
                     if (newColor !== -1) {
                         $($(".palette-color[data-idx=" + newColor + "],.palette-color[data-idx=-1]")).addClass("active"); //Select both the new color AND the deselect button. Signifies more that it's a deselect button rather than a "delete pixel" button
-                        $(`.palette-color[data-idx="${newColor}"]`)[0].scrollIntoView();
+                        $(`.palette-color[data-idx="${newColor}"]`)[0].scrollIntoView({block:"nearest", inline:"nearest"});
                     }
                 },
                 place: function (x, y) {


### PR DESCRIPTION
As per discussion in the Avogadro server, these changes aim to make selecting a palette color not cause vertical scrolling on a parent document when pxls.space is iframe'd.