### PR TITLE
Add a basic theming system

### DIFF
--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -44,6 +44,11 @@
             <div>
                 <h1>General settings</h1>
                 <div class="settingToggles">
+                    <label>Theme:
+                        <select id="themeSelect">
+                            <option value="-1" selected>Default</option>
+                        </select>
+                    </label>
                     <label><input id="audiotoggle" type="checkbox"/>Mute sound</label>
                     <label><input id="heatmaptoggle" type="checkbox"/>Turn on heatmap (toggle with <kbd>H</kbd>)</label>
                     <label><input id="virginmaptoggle" type="checkbox"/>Turn on virginmap (toggle with <kbd>X</kbd>)</label>

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -2414,9 +2414,17 @@ window.App = (function () {
                     txtAlertLocation: $("#txtAlertLocation"),
                     rangeAlertVolume: $("#rangeAlertVolume"),
                     lblAlertVolume: $("#lblAlertVolume"),
-                    btnForceAudioUpdate: $("#btnForceAudioUpdate")
+                    btnForceAudioUpdate: $("#btnForceAudioUpdate"),
+                    themeSelect: $("#themeSelect")
                 },
+                themes: [
+                    {
+                        name: "Dark",
+                        location: '/themes/dark.css'
+                    }
+                ],
                 init: function () {
+                    self._initThemes();
                     self._initStack();
                     self._initAudio();
                     var useMono = ls.get("monospace_lookup")
@@ -2517,6 +2525,39 @@ window.App = (function () {
                             }
                         })
                     }
+                },
+                _initThemes: function () {
+                    for (let i = 0; i < self.themes.length; i++) {
+                        self.themes[i].element = $('<link data-theme="' + i + '" rel="stylesheet" href="' + self.themes[i].location + '">');
+                        self.elements.themeSelect.append($("<option>", {
+                            value: i,
+                            text: self.themes[i].name
+                        }));
+                    }
+                    let currentTheme = ls.get('currentTheme');
+                    if (currentTheme == null || (currentTheme > self.themes.length || currentTheme < -1)) {
+                        // If currentTheme hasn't been set, or it's out of bounds, reset it to default (-1)
+                        ls.set('currentTheme', -1);
+                    } else {
+                        currentTheme = parseInt(currentTheme);
+                        if (currentTheme !== -1) {
+                            self.themes[currentTheme].element.appendTo(document.head);
+                            self.elements.themeSelect.val(currentTheme);
+                        }
+                    }
+                    self.elements.themeSelect.on("change", function() {
+                        let theme = parseInt(this.value);
+                        // If theme is -1, the user selected the default theme, so we should remove all other themes
+                        if (theme === -1) {
+                            console.log('Default theme - should reset!')
+                            // Default theme
+                            $('*[data-theme]').remove();
+                            ls.set('currentTheme', -1);
+                            return;
+                        }
+                        self.themes[theme].element.appendTo(document.head);
+                        ls.set('currentTheme', theme);
+                    })
                 },
                 _initStack: function () {
                     socket.on("pixels", function (data) {

--- a/resources/public/themes/dark.css
+++ b/resources/public/themes/dark.css
@@ -1,0 +1,111 @@
+/* TODO: Add sections, like in style.css */
+
+html, body {
+    background-color: #222;
+}
+
+kbd {
+    border: 1px solid #333;
+    background-color: #444;
+    color: #fff;
+}
+
+.message {
+    background-color: #333;
+    color: #eee;
+}
+
+.message select, .message textarea, .message input {
+    border: 2px solid #333;
+    background-color: #222;
+    color: #eee;
+}
+
+.button {
+    background-color: #bbb;
+}
+
+.button:hover {
+    border: 1px solid #844;
+}
+
+#lookup {
+    border: 1px solid #222;
+    background-color: #333;
+}
+
+#lookup .content {
+    color: #eee;
+}
+
+#lookup .content input {
+    border: 1px solid #333;
+    background-color: #222;
+    color: #eee;
+}
+
+#lookup .report-button {
+    border: 1px solid #333;
+}
+
+.drawer button {
+    border: 2px solid #333;
+    background-color: #555;
+    color: #eee;
+}
+
+.drawer select {
+    border: 2px solid #333;
+    background-color: #222;
+    color: #eee;
+}
+
+.palette-overlay {
+    background-color: rgba(0, 0, 0, 0.9);
+    color: #eee;
+}
+
+#palette {
+    background-color: rgba(0, 0, 0, 0.2);
+}
+
+#undo {
+    background-image: linear-gradient(to top, #0003, #0000);
+    color: #fff;
+}
+
+input[type="text"] {
+    border: 1px solid #333;
+    background-color: #222;
+    color: #eee;
+}
+
+/* Admin */
+
+.admin input {
+    border: 1px solid #333;
+    background-color: #222;
+}
+
+.admin-check {
+    border: 1px solid #222 !important;
+    background-color: #333 !important;
+}
+
+.admin-check div:not(.button) {
+    color: #eee;
+}
+
+.admin-check input {
+    border: 1px solid #333;
+    background-color: #222;
+    color: #eee;
+}
+
+/* Mobile */
+
+@media (max-width: 768px) {
+    .drawer-content > div:not(.close) {
+        border: 1px solid #444;
+    }
+}


### PR DESCRIPTION
This commit adds a basic host-provided theming system, along with a sample dark theme.

Sample images:
![Admin Check](https://user-images.githubusercontent.com/19217244/60765403-02786b80-a068-11e9-9813-1481333b655d.png)
![Alert](https://user-images.githubusercontent.com/19217244/60765404-02786b80-a068-11e9-87cb-565be277d19d.png)
![Lookup](https://user-images.githubusercontent.com/19217244/60765405-02786b80-a068-11e9-85e0-343cc55fd85f.png)
![Mod Drawer](https://user-images.githubusercontent.com/19217244/60765406-03110200-a068-11e9-813c-27b770ca564a.png)
![Report Menu](https://user-images.githubusercontent.com/19217244/60765407-03110200-a068-11e9-8849-f40a1cf9578d.png)
![Settings Drawer](https://user-images.githubusercontent.com/19217244/60765408-03110200-a068-11e9-9252-5ade8ef44de9.png)
