### PR TITLE
Fix heatmap error and virginmap clearing

### DIFF
--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -1263,6 +1263,10 @@ window.App = (function () {
                     self._clear();
                 },
                 _clear: function () {
+                    // If the user hasn't opened the heatmap yet, we can't clear it!
+                    if (self.intView == null) {
+                        return;
+                    }
                     for (var i = 0; i < self.width * self.height; i++) {
                         self.intView[i] = 0;
                     }
@@ -1397,6 +1401,7 @@ window.App = (function () {
                         self.elements.virginmapLoadingBubble.hide();
                         socket.on("pixel", function (data) {
                             $.map(data.pixels, function (px) {
+                                self.ctx.fillStyle = "#000000";
                                 self.ctx.fillRect(px.x, px.y, 1, 1);
                             });
                         });


### PR DESCRIPTION
This commit fixes an error that occurs when attempting to clear the heatmap before it's been loaded, and fixes the virginmap placing new pixels as the virgin color.