### PR TITLE
Add checkbox to hide sensitive info in lookup

### DIFF
--- a/resources/public/admin/admin.js
+++ b/resources/public/admin/admin.js
@@ -359,6 +359,7 @@
                     App.lookup.registerHook({
                         id: "login",
 						name: "Login",
+						sensitive: true,
 						get: data => {
                             var addMonoClass = localStorage.getItem("monospace_lookup") === "true" ? " useMono" : ""
                             return $("<div class=\"monoVal" + addMonoClass + "\">").text(data.login)
@@ -366,6 +367,7 @@
                     }, {
                         id: "user_agent",
 						name: "User Agent",
+						sensitive: true,
 						get: data => {
                             var addMonoClass = localStorage.getItem("monospace_lookup") === "true" ? " useMono" : ""
                             return $("<div class=\"monoVal" + addMonoClass + "\">").text(data.userAgent)
@@ -373,10 +375,12 @@
                     }, {
 						id: "alert",
 						name: "Send Alert",
+						sensitive: true,
 						get: data => sendAlert(data.username),
 					}, {
                         id: "admin_actions",
                         name: "Mod Actions",
+                        sensitive: true,
                         get: data => $("<span>").append(
 							genButton("Ban (24h)").click(() => {
 								ban.ban_24h(data.username, function () {


### PR DESCRIPTION
This commit adds a checkbox to the bottom of the lookup panel, which
hides sensitive information when toggled. The checkbox only appears when
sensitive information is present.