### PR TITLE
Added ability to set a Discord name (name#discrim) for pixel and lookups

### DIFF
--- a/resources/public/admin/admin.js
+++ b/resources/public/admin/admin.js
@@ -194,6 +194,7 @@
                         ["Login", data.login],
                         ["Role", data.role],
                         ["Rename Requested", data.renameRequested ? "Yes" : "No"],
+                        ["Discord Name", data.discordName || "(not set)"],
                         ["Banned", bannedStr],
                         ["Chatbanned", chatbannedStr]
                     ];

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -240,7 +240,7 @@
                 <h2>Pixel Ready Alert Settings</h2>
             </header>
             <div class="pad-wrapper">
-                <p class="alertLocationWrapper"><label for="txtAlertLocation">Alert URL:</label><input type="text" placeholder="notify.wav" id="txtAlertLocation"></p>
+                <p class="longTextInputWrapper"><label for="txtAlertLocation">Alert URL:</label><input type="text" placeholder="notify.wav" id="txtAlertLocation"></p>
                 <div class="ButtonBar">
                     <button id="btnForceAudioUpdate" class="button">Update</button>
                     <button id="btnAlertAudioTest" class="button">Test</button>
@@ -263,6 +263,18 @@
                     <label><input id="cbChatSettings24h" type="checkbox" />24 Hour Timestamps</label>
                     <label><input id="cbChatSettingsBadgesToggle" type="checkbox" />Show pixel-placed badges</label>
                     <label>Font Size: <input type="number" min="1" max="72" id="cbChatSettingsFontSize"> <button id="cbChatSettingsFontSizeConfirm" class="button"><i class="fas fa-check"></i></button></label>
+                </div>
+            </div>
+        </article>
+        <article>
+            <header class="slim darker">
+                <h2>Account Settings</h2>
+            </header>
+            <div class="pad-wrapper">
+                <p class="longTextInputWrapper"><label for="txtDiscordName">Public Discord Name:</label><input type="text" placeholder="pxlslover#1337" id="txtDiscordName"></p>
+                <div class="ButtonBar">
+                    <button id="btnDiscordNameSet" class="button">Set</button>
+                    <button id="btnDiscordNameRemove" class="button">Remove</button>
                 </div>
             </div>
         </article>

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -2285,9 +2285,9 @@ window.App = (function () {
                     // Register default hooks
                     self.registerHook(
                         {
-														id: "coords",
-														name: "Coords",
-														get: data => $("<a>").text("(" + data.x + ", " + data.y + ")").attr("href", coords.getLinkToCoords(data.x, data.y)),
+                            id: "coords",
+                            name: "Coords",
+                            get: data => $("<a>").text("(" + data.x + ", " + data.y + ")").attr("href", coords.getLinkToCoords(data.x, data.y)),
                         }, {
                             id: "username",
                             name: "Username",
@@ -2321,14 +2321,14 @@ window.App = (function () {
                             name: "Pixels",
                             get: data => data.pixel_count,
                         }, {
-														id: "pixels_alltime",
-														name: "Alltime Pixels",
-														get: data => data.pixel_count_alltime,
+                            id: "pixels_alltime",
+                            name: "Alltime Pixels",
+                            get: data => data.pixel_count_alltime,
                         }, {
-													id: "discord_name",
-													name: "Discord",
-													get: data => data.discordName,
-											 }
+                            id: "discord_name",
+                            name: "Discord",
+                            get: data => data.discordName,
+                        }
                     );
 
                     self.elements.lookup.hide();
@@ -2768,7 +2768,7 @@ window.App = (function () {
                     self.elements.stackCount.text(`${placeable}/${self.maxStacked}`);
                 },
                 setDiscordName(name) {
-                		self.elements.txtDiscordName.val(name);
+                    self.elements.txtDiscordName.val(name);
                 },
                 getAvailable() {
                     return self._available;

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -2206,7 +2206,7 @@ window.App = (function () {
                         if (data) {
                             return $.map(self.hooks, function (hook) {
                                 const get = hook.get(data);
-                                if (!get) {
+                                if (get == null) {
                                 	return null;
                                 }
 

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -2206,6 +2206,10 @@ window.App = (function () {
                         if (data) {
                             return $.map(self.hooks, function (hook) {
                                 const get = hook.get(data);
+                                if (!get) {
+                                	return null;
+                                }
+
                                 const value = typeof get === "object" ? get : $("<span>").text(get);
 
                                 let _retVal = $("<div data-sensitive=\"" + hook.sensitive + "\">").append(
@@ -2281,9 +2285,9 @@ window.App = (function () {
                     // Register default hooks
                     self.registerHook(
                         {
-                            id: "coords",
-                            name: "Coords",
-                            get: data => $("<a>").text("(" + data.x + ", " + data.y + ")").attr("href", coords.getLinkToCoords(data.x, data.y)),
+														id: "coords",
+														name: "Coords",
+														get: data => $("<a>").text("(" + data.x + ", " + data.y + ")").attr("href", coords.getLinkToCoords(data.x, data.y)),
                         }, {
                             id: "username",
                             name: "Username",
@@ -2317,10 +2321,14 @@ window.App = (function () {
                             name: "Pixels",
                             get: data => data.pixel_count,
                         }, {
-                            id: "pixels_alltime",
-                            name: "Alltime Pixels",
-                            get: data => data.pixel_count_alltime,
-                        }
+														id: "pixels_alltime",
+														name: "Alltime Pixels",
+														get: data => data.pixel_count_alltime,
+                        }, {
+													id: "discord_name",
+													name: "Discord",
+													get: data => data.discordName,
+											 }
                     );
 
                     self.elements.lookup.hide();
@@ -2500,7 +2508,8 @@ window.App = (function () {
                     rangeAlertVolume: $("#rangeAlertVolume"),
                     lblAlertVolume: $("#lblAlertVolume"),
                     btnForceAudioUpdate: $("#btnForceAudioUpdate"),
-                    themeSelect: $("#themeSelect")
+                    themeSelect: $("#themeSelect"),
+                    txtDiscordName: $("#txtDiscordName"),
                 },
                 themes: [
                     {
@@ -2512,6 +2521,7 @@ window.App = (function () {
                     self._initThemes();
                     self._initStack();
                     self._initAudio();
+                    self._initAccount();
                     var useMono = ls.get("monospace_lookup")
                     if (typeof useMono === 'undefined') {
                         ls.set("monospace_lookup", true);
@@ -2703,6 +2713,39 @@ window.App = (function () {
                         self.elements.txtAlertLocation.val("");
                     });
                 },
+                _initAccount: function() {
+										self.elements.txtDiscordName.keydown(function (evt) {
+												if (evt.key == "Enter" || evt.which === 13) {
+														self.handleDiscordNameSet();
+												}
+												evt.stopPropagation();
+										});
+										$("#btnDiscordNameSet").click(() => {
+												self.handleDiscordNameSet()
+										});
+										$("#btnDiscordNameRemove").click(() => {
+												self.setDiscordName("")
+												self.handleDiscordNameSet()
+										});
+                },
+                handleDiscordNameSet() {
+                		const name = self.elements.txtDiscordName.val();
+
+                		//TODO confirm with user
+										$.post({
+												type: "POST",
+												url: "/setDiscordName",
+												data: {
+														discordName: name
+												},
+												success: function () {
+														alert.show("Discord name updated successfully");
+												},
+												error: function (data) {
+														alert.show("Couldn't change discord name: " + data.responseJSON.details);
+												}
+										});
+                },
                 updateAudio: function (url) {
                     try {
                         if (!url) url = "notify.wav";
@@ -2724,6 +2767,9 @@ window.App = (function () {
                 setPlaceableText(placeable) {
                     self.elements.stackCount.text(`${placeable}/${self.maxStacked}`);
                 },
+                setDiscordName(name) {
+                		self.elements.txtDiscordName.val(name);
+                },
                 getAvailable() {
                     return self._available;
                 }
@@ -2736,6 +2782,7 @@ window.App = (function () {
                 getAvailable: self.getAvailable,
                 setPlaceableText: self.setPlaceableText,
                 setMax: self.setMax,
+                setDiscordName: self.setDiscordName,
                 updateAudio: self.updateAudio
             };
         })(),
@@ -4246,6 +4293,7 @@ window.App = (function () {
                         self.username = data.username;
                         self.loggedIn = true;
                         self.renameRequested = data.renameRequested;
+                        uiHelper.setDiscordName(data.discordName || "")
                         self.elements.loginOverlay.fadeOut(200);
                         self.elements.userInfo.find("span.name").text(data.username);
                         if (data.method == 'ip') {

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -90,11 +90,11 @@ kbd {
     text-indent: 0.75em;
 }
 
-.alertLocationWrapper {
+.longTextInputWrapper {
     max-width: 100% !important;
 }
 
-.alertLocationWrapper > input[type='text'] {
+.longTextInputWrapper > input[type='text'] {
     width: 100% !important;
     margin-bottom: 2px;
 }

--- a/resources/reference.conf
+++ b/resources/reference.conf
@@ -43,6 +43,11 @@ server {
       count: 2
       time: 1s
     }
+
+    discordNameChange {
+      count: 1
+      time: 1h
+    }
   }
 }
 

--- a/src/main/java/space/pxls/data/DAO.java
+++ b/src/main/java/space/pxls/data/DAO.java
@@ -108,7 +108,7 @@ public interface DAO extends Closeable {
     @SqlQuery("SELECT *, users.* FROM pixels LEFT JOIN users ON pixels.who = users.id WHERE x = :x AND y = :y ORDER BY time DESC LIMIT 1")
     DBPixelPlacement getPixel(@Bind("x") int x, @Bind("y") int y);
 
-    @SqlQuery("SELECT pixels.id, pixels.x, pixels.y, pixels.color, pixels.time, users.username, users.pixel_count, users.pixel_count_alltime, users.login FROM pixels LEFT JOIN users ON pixels.who = users.id WHERE x = :x AND y = :y AND most_recent ORDER BY time DESC LIMIT 1")
+    @SqlQuery("SELECT pixels.id, pixels.x, pixels.y, pixels.color, pixels.time, users.username, users.pixel_count, users.pixel_count_alltime, users.login, users.discord_name FROM pixels LEFT JOIN users ON pixels.who = users.id WHERE x = :x AND y = :y AND most_recent ORDER BY time DESC LIMIT 1")
     DBPixelPlacementUser getPixelUser(@Bind("x") int x, @Bind("y") int y);
 
     @SqlQuery("SELECT *, users.* FROM pixels LEFT JOIN users on pixels.who = users.id WHERE pixels.id = :id")
@@ -135,7 +135,8 @@ public interface DAO extends Closeable {
             "user_agent VARCHAR(512) NOT NULL DEFAULT ''," +
             "pixel_count INT UNSIGNED NOT NULL DEFAULT 0," +
             "pixel_count_alltime INT UNSIGNED NOT NULL DEFAULT 0," +
-            "is_rename_requested TINYINT NOT NULL DEFAULT 0)")
+            "is_rename_requested TINYINT NOT NULL DEFAULT 0," +
+            "discord_name VARCHAR(37))")
     void createUsersTable();
 
     @SqlQuery("SELECT EXISTS(SELECT 1 FROM users WHERE (last_ip = INET6_ATON(:ip) OR signup_ip = INET6_ATON(:ip)) AND id <> :uid)")
@@ -197,6 +198,9 @@ public interface DAO extends Closeable {
 
     @SqlUpdate("UPDATE users SET username = :name WHERE id = :uid")
     void updateUsername(@Bind("uid") int who, @Bind("name") String new_username);
+
+    @SqlUpdate("UPDATE users SET discord_name = :name WHERE id = :uid")
+    void setDiscordName(@Bind("uid") int who, @Bind("name") String discordName);
 
     @SqlUpdate("CREATE TABLE IF NOT EXISTS sessions ("+
             "id INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT,"+

--- a/src/main/java/space/pxls/data/DBPixelPlacement.java
+++ b/src/main/java/space/pxls/data/DBPixelPlacement.java
@@ -26,8 +26,9 @@ public class DBPixelPlacement {
     public final boolean banned;
     public final boolean undoAction;
     public final String userAgent;
+    public final String discordName;
 
-    public DBPixelPlacement(int id, int x, int y, int color, int secondaryId, long time, int userId, String username, String login, Role role, long ban_expiry, int pixel_count, int pixel_count_alltime, String ban_reason, boolean banned, boolean undoAction, String userAgent) {
+    public DBPixelPlacement(int id, int x, int y, int color, int secondaryId, long time, int userId, String username, String login, Role role, long ban_expiry, int pixel_count, int pixel_count_alltime, String ban_reason, boolean banned, boolean undoAction, String userAgent, String discordName) {
         this.id = id;
         this.x = x;
         this.y = y;
@@ -45,6 +46,7 @@ public class DBPixelPlacement {
         this.banned = banned;
         this.undoAction = undoAction;
         this.userAgent = userAgent;
+        this.discordName = discordName;
     }
 
     public static class Mapper implements ResultSetMapper<DBPixelPlacement> {
@@ -74,7 +76,8 @@ public class DBPixelPlacement {
                     r.getString("users.ban_reason"),
                     banned,
                     r.getBoolean("undo_action"),
-                    r.getString("user_agent")
+                    r.getString("user_agent"),
+                    r.getString("users.discord_name")
             );
         }
     }

--- a/src/main/java/space/pxls/data/DBPixelPlacementUser.java
+++ b/src/main/java/space/pxls/data/DBPixelPlacementUser.java
@@ -16,8 +16,9 @@ public class DBPixelPlacementUser {
     public final String username;
     public final int pixel_count;
     public final int pixel_count_alltime;
+    public final String discord_name;
 
-    public DBPixelPlacementUser(int id, int x, int y, int color, long time, String username, int pixel_count, int pixel_count_alltime) {
+    public DBPixelPlacementUser(int id, int x, int y, int color, long time, String username, int pixel_count, int pixel_count_alltime, String discord_name) {
         this.id = id;
         this.x = x;
         this.y = y;
@@ -26,6 +27,7 @@ public class DBPixelPlacementUser {
         this.username = username;
         this.pixel_count = pixel_count;
         this.pixel_count_alltime = pixel_count_alltime;
+        this.discord_name = discord_name;
     }
 
     public static class Mapper implements ResultSetMapper<DBPixelPlacementUser> {
@@ -41,7 +43,8 @@ public class DBPixelPlacementUser {
                     time == null ? 0 : time.getTime(),
                     r.getString("users.login").startsWith("ip:") ? "-snip-" : r.getString("users.username"),
                     r.getInt("pixel_count"),
-                    r.getInt("pixel_count_alltime")
+                    r.getInt("pixel_count_alltime"),
+                    r.getString("users.discord_name")
             );
         }
     }

--- a/src/main/java/space/pxls/data/DBUser.java
+++ b/src/main/java/space/pxls/data/DBUser.java
@@ -19,8 +19,9 @@ public class DBUser {
     public boolean isPermaChatbanned;
     public long chatbanExpiry;
     public boolean isRenameRequested;
+    public String discordName;
 
-    public DBUser(int id, int stacked, String username, String login, long cooldownExpiry, Role role, long banExpiry, boolean isPermaChatbanned, long chatbanExpiry, boolean isRenameRequested) {
+    public DBUser(int id, int stacked, String username, String login, long cooldownExpiry, Role role, long banExpiry, boolean isPermaChatbanned, long chatbanExpiry, boolean isRenameRequested, String discordName) {
         this.id = id;
         this.stacked = stacked;
         this.username = username;
@@ -31,6 +32,7 @@ public class DBUser {
         this.isPermaChatbanned = isPermaChatbanned;
         this.chatbanExpiry = chatbanExpiry;
         this.isRenameRequested = isRenameRequested;
+        this.discordName = discordName;
     }
 
     public static class Mapper implements ResultSetMapper<DBUser> {
@@ -49,7 +51,8 @@ public class DBUser {
                     ban == null ? 0 : ban.getTime(),
                     r.getBoolean("perma_chat_banned"),
                     chatban == null ? 0 : chatban.getTime(),
-                    r.getBoolean("is_rename_requested")
+                    r.getBoolean("is_rename_requested"),
+                    r.getString("discord_name")
             );
         }
     }

--- a/src/main/java/space/pxls/data/Database.java
+++ b/src/main/java/space/pxls/data/Database.java
@@ -324,6 +324,13 @@ public class Database implements Closeable {
         getHandle().updateUsername(who_id, new_username);
     }
 
+    /**
+     * Sets the public Discord username of the user.
+     * @param who_id The ID of the user to update.
+     * @param discordName The new discord username.
+     */
+    public void setDiscordName(int who_id, String discordName) { getHandle().setDiscordName(who_id, discordName); }
+
     public String getUserBanReason(int id) {
         return getHandle().getUserBanReason(id).ban_reason;
     }

--- a/src/main/java/space/pxls/server/PacketHandler.java
+++ b/src/main/java/space/pxls/server/PacketHandler.java
@@ -68,7 +68,8 @@ public class PacketHandler {
                     App.getDatabase().getChatbanReasonForUser(user.getId()),
                     user.isPermaChatbanned(),
                     user.getChatbanExpiryTime(),
-                    user.isRenameRequested(true)
+                    user.isRenameRequested(true),
+                    user.getDiscordName()
             ));
             sendAvailablePixels(channel, user, "auth");
         }

--- a/src/main/java/space/pxls/server/SocketPackets.kt
+++ b/src/main/java/space/pxls/server/SocketPackets.kt
@@ -44,7 +44,8 @@ data class ServerUserInfo(
         val chatbanReason: String? = "",
         val chatbanIsPerma: Boolean,
         val chatbanExpiry: Long,
-        val renameRequested: Boolean) {
+        val renameRequested: Boolean,
+        val discordName: String?) {
     val type = "userinfo"
 }
 

--- a/src/main/java/space/pxls/server/UndertowServer.java
+++ b/src/main/java/space/pxls/server/UndertowServer.java
@@ -58,6 +58,7 @@ public class UndertowServer {
                 .addPrefixPath("/users", webHandler::users)
                 .addPrefixPath("/auth", new RateLimitingHandler(webHandler::auth, "http:auth", (int) App.getConfig().getDuration("server.limits.auth.time", TimeUnit.SECONDS), App.getConfig().getInt("server.limits.auth.count")))
                 .addPrefixPath("/signup", new RateLimitingHandler(webHandler::signUp, "http:signUp", (int) App.getConfig().getDuration("server.limits.signup.time", TimeUnit.SECONDS), App.getConfig().getInt("server.limits.signup.count")))
+                .addPrefixPath("/setDiscordName", new RateLimitingHandler(webHandler::discordNameChange, "http:discordName", (int) App.getConfig().getDuration("server.limits.discordNameChange.time", TimeUnit.SECONDS), App.getConfig().getInt("server.limits.discordNameChange.count")))
                 .addPrefixPath("/admin/ban", new RoleGate(Role.TRIALMOD, webHandler::ban))
                 .addPrefixPath("/admin/unban", new RoleGate(Role.TRIALMOD, webHandler::unban))
                 .addPrefixPath("/admin/permaban", new RoleGate(Role.MODERATOR, webHandler::permaban))

--- a/src/main/java/space/pxls/user/User.java
+++ b/src/main/java/space/pxls/user/User.java
@@ -30,6 +30,7 @@ public class User {
     private boolean placingLock = false;
     private boolean isPermaChatbanned = false;
     private boolean isRenameRequested = false;
+    private String discordName;
     private long cooldownExpiry;
     private long lastPixelTime = 0;
     private long lastUndoTime = 0;
@@ -65,6 +66,7 @@ public class User {
         this.isPermaChatbanned = user.isPermaChatbanned;
         this.chatbanExpiryTime = user.chatbanExpiry;
         this.isRenameRequested = user.isRenameRequested;
+        this.discordName = user.discordName;
     }
 
     public int getId() {
@@ -498,6 +500,15 @@ public class User {
             return false;
         }
         return true;
+    }
+
+    public String getDiscordName() {
+        return discordName;
+    }
+
+    public void setDiscordName(String discordName) {
+        this.discordName = discordName;
+        App.getDatabase().setDiscordName(id, discordName);
     }
 
     /**


### PR DESCRIPTION
~~So I finally decided to install IntelliJ to do this~~

- This adds a new field to the users table: `discord_name VARCHAR(37)`
- User is forced to use "{name}#{discriminator}" syntax
- Name can be updated in settings tab, under "Account settings"
- Name appears on pixel lookups as well as admin lookups