### PR TITLE
Show link to userinfo page for admin lookups and user checks

### DIFF
--- a/resources/public/admin/admin.js
+++ b/resources/public/admin/admin.js
@@ -23,6 +23,10 @@
 				evt.stopPropagation();
 			});
         },
+        genUserInfoLink = function(username) {
+            const userInfoURL = "https://admin." + location.host + "/userinfo/" + username;
+            return $("<a>").text(username).attr("href", userInfoURL).attr("target", "_blank");
+        },
         ban = (function() {
             var self = {
                 elements: {
@@ -184,7 +188,7 @@
                     }
                     chatbannedStr = data.chatbanIsPerma ? `Yes (permanent)` : (data.chatBanned ? `Yes` : `No`);
                     var items = [
-                        ["Username", data.username],
+                        ["Username", genUserInfoLink(data.username)],
                         ["Login", data.login],
                         ["Role", data.role],
                         ["Rename Requested", data.renameRequested ? "Yes" : "No"],
@@ -206,7 +210,7 @@
                         $.map(items, function (o) {
                             return $("<div>").append(
                                 $("<b>").text(o[0]+": "),
-                                $("<span>").text(o[1])
+                                typeof o[1] === "string" ? $("<span>").text(o[1]) : o[1]
                             );
                         }),
                         $("<div>").append(sendAlert(data.username)),
@@ -357,6 +361,9 @@
                  * Register hooks for admin-specific lookups.
                  */
                 init: function () {
+                    App.lookup.replaceHook("username", {
+                        get: data => genUserInfoLink(data.username)
+                    });
                     App.lookup.registerHook({
                         id: "login",
 						name: "Login",

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -717,13 +717,13 @@ window.App = (function () {
                             case "E":
                                 self.nudgeScale(1);
                                 break;
-                            case "KeyQ":        // Q
-                            case "Minus":       // -
-                            case "NumpadSubtact":   // numpad -
-                            case 81:            // Q
-                            case 109:           // numpad -
-                            case 173:           // -
-                            case 189:           // -
+                            case "KeyQ":             // Q
+                            case "Minus":            // -
+                            case "NumpadSubtract":   // numpad -
+                            case 81:                 // Q
+                            case 109:                // numpad -
+                            case 173:                // -
+                            case 189:                // -
                             case "q":
                             case "Q":
                             case "-":
@@ -2202,6 +2202,8 @@ window.App = (function () {
                  * @param {Object} hooks Information about the hook.
                  * @param {String} hooks.id An ID for the hook.
                  * @param {String} hooks.name A user-facing name for the hook.
+                 * @param {Boolean} hooks.sensitive Whenever the hook contains sensitive information.
+                 * @param {Boolean} hooks.backgroundCompatible Whenever the hook should appear even if the pixel is background.
                  * @param {Function} hooks.get A function that returns the text information shown in the lookup.
                  * @param {Object} hooks.css An object mapping CSS rules to values for the hook value.
                  */
@@ -2216,6 +2218,26 @@ window.App = (function () {
                             css: hook.css || {},
                         };
                     }));
+                },
+                /**
+                 * Replace a hook by its ID.
+                 * @param {String} hookId The ID of the hook to replace.
+                 * @param {Object} newHook Information about the hook.
+                 * @param {String} newHook.name New user-facing name for the hook.
+                 * @param {Boolean} newHook.sensitive Whenever the new hook contains sensitive information.
+                 * @param {Boolean} newHook.backgroundCompatible Whenever the new hook should appear even if the pixel is background.
+                 * @param {Function} newHook.get A function that returns the text information shown in the lookup.
+                 * @param {Object} newHook.css An object mapping CSS rules to values for the new hook value.
+                 */
+                replaceHook: function(hookId, newHook) {
+                    delete newHook.id;
+                    for (let idx in self.hooks) {
+                        const hook = self.hooks[idx];
+                        if (hook.id === hookId) {
+                            self.hooks[idx] = Object.assign(hook, newHook);
+                            return;
+                        }
+                    }
                 },
                 /**
                  * Unregisters a hook by its ID.
@@ -2246,7 +2268,9 @@ window.App = (function () {
                                 return null;
                             }
 
-                            const value = typeof get === "object" ? get : $("<span>").text(get);
+                            const value = typeof get === "object"
+                                ? (get instanceof Node ? $(get) : get)
+                                : $("<span>").text(get);
 
                             let _retVal = $("<div data-sensitive=\"" + hook.sensitive + "\">").append(
                                 $("<b>").text(hook.name + ": "),
@@ -2383,6 +2407,7 @@ window.App = (function () {
                 init: self.init,
                 registerHandle: self.registerHandle,
                 registerHook: self.registerHook,
+                replaceHook: self.replaceHook,
                 unregisterHook: self.unregisterHook,
                 runLookup: self.runLookup,
                 clearHandle: self.clearHandle
@@ -4810,6 +4835,9 @@ window.App = (function () {
         lookup: {
             registerHook: function () {
                 return lookup.registerHook(...arguments);
+            },
+            replaceHook: function () {
+                return lookup.replaceHook(...arguments);
             },
             unregisterHook: function () {
                 return lookup.unregisterHook(...arguments);


### PR DESCRIPTION
- Adds a new hook related function: `replaceHook(hookId, newHook)`
- admin.js now replaces the username hook for lookups with a link to the user info page

Also:
- Fixed typo on `<body>` keydown event ("NumpadSubtact" -> "NumpadSubtract")
- Allow lookup hook's `get` function to return a DOM Node