### PR TITLE
Reworked panel code and styles to adapt the color palette width to the new "halfwidth" panels

### DIFF
--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -2667,8 +2667,7 @@ window.App = (function () {
                                 if (selector.is(":visible")) {
                                     selector.fadeOut(200);
                                 } else if (openPanels.length) {
-                                    openPanels.removeClass('open');
-                                    document.body.classList.remove('panel-left-open', 'panel-right-open');
+                                    openPanels.each((i, elem) => panels.close(elem));
                                 } else {
                                     place.switch(-1);
                                 }
@@ -2942,7 +2941,7 @@ window.App = (function () {
                 _setOpenState: (panel, state, exclusive = true) => {
                     state = !!state;
 
-                    let panelDescriptor = panel
+                    let panelDescriptor = panel;
                     if (panel instanceof HTMLElement) {
                         panelDescriptor = panel.dataset['panel'];
                     } else {
@@ -2950,7 +2949,7 @@ window.App = (function () {
                     }
 
                     if (panel) {
-                        const panelPosition = panel.classList.contains('right') ? 'right' : 'left'
+                        const panelPosition = panel.classList.contains('right') ? 'right' : 'left';
 
                         if (state) {
                             if (exclusive) {

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -1076,21 +1076,33 @@ article .body {
     margin: 0 !important;
 }
 
-body.panel-right-open .ui-bar {
-    left: 0;
+body.panel-open .ui-bar {
     width: 70%;
     transition: width ease-out .25s;
 }
 
-body.panel-left-open .ui-bar {
+body.panel-open.panel-left .ui-bar {
     right: 0;
-    width: 70%;
-    transition: width ease-out .25s;
 }
 
-body.panel-left-open.panel-right-open .ui-bar {
+body.panel-open.panel-left.panel-left-halfwidth .ui-bar,
+body.panel-open.panel-right.panel-right-halfwidth .ui-bar {
+    width: 50%;
+}
+
+body.panel-left.panel-right .ui-bar {
     left: 30%;
     width: 40%;
+}
+
+body.panel-left.panel-left-halfwidth.panel-right .ui-bar {
+    left: 50%;
+    width: 20%;
+}
+
+body.panel-left.panel-right.panel-right-halfwidth .ui-bar {
+    right: 50%;
+    width: 20%;
 }
 
 /* CHAT */


### PR DESCRIPTION
Not the best, but it allows for changing colors while chatting and consulting the FAQ, in the strange case that's what someone wants to do.
![image](https://user-images.githubusercontent.com/6181929/67644153-91eaa880-f8fd-11e9-8507-622e8e5877c9.png)


Also, fixed a bug where toggling panels with keybinds wouldn't trigger the `pxls:panel:*` jQuery events. Consequently, fixed a bug when opening chat with "B" wouldn't clear new messages alerts