### PR TITLE
Move coords, user, p-count, etc. to single bubble

### DIFF
--- a/resources/public/admin/admin.css
+++ b/resources/public/admin/admin.css
@@ -3,6 +3,7 @@
 \*\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
 .admin {
+    z-index: 10;
     position: absolute;
     top: 40vh;
     background: #333;

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -9,15 +9,11 @@
     <style type="text/css">
         /** These MUST be here because the YUI compressor breaks calc() and is abandoned */
         body.panel-open.panel-right #ui .right {
-            right: calc(30% + 10px);
+            right: calc(30vw + 10px);
         }
 
         body.panel-open.panel-left #ui .left {
-            left: calc(30% + 10px);
-        }
-
-        body.panel-open #ui .left, body.panel-open #ui .right {
-            bottom: 70px;
+            left: calc(30vw + 10px);
         }
     </style>
     <link rel="stylesheet" href="style.css">
@@ -75,6 +71,29 @@
 </div>
 
 <div id="ui">
+    <div class="left">
+        <div class="bubble">
+            <div id="user-info">
+                <!-- TODO: link to position on stats page -->
+                <!-- TODO: later on, link to my.pxls.space profile -->
+                <span id="username"></span>
+                <a href="/logout" class="logout"><i class="fas fa-sign-out-alt" id="logout-icon"></i></a>
+                <br>
+            </div>
+            <span id="online-count">Waiting for online count...</span>
+            <br><br>
+            <div id="coords-info">
+                <a class="coords"></a>
+                <img src="lock.png" class="icon-lock" style="display: none;">
+            </div>
+            <div id="placement-info">
+                <span>Pixels available: </span><span id="placeable-count">N/A</span>
+                <br>
+                <span id="cooldown-timer"></span>
+            </div>
+        </div>
+    </div>
+
     <div class="ui-bar">
         <div id="undo"><span>Undo</span></div>
         <div id="login-overlay" class="palette-overlay">
@@ -84,18 +103,6 @@
         <div id="palette">
             <div id="cd-timer-overlay" class="palette-overlay"></div>
         </div>
-    </div>
-
-    <div class="left">
-        <div id="coords" class="bubble"><img src="lock.png" class="icon-lock" style="display: none;"> <span class="coords-text"></span></div>
-        <div id="heatmapLoadingBubble" class="bubble orange-bubble fat-bubble">Loading heatmap...</div>
-        <div id="virginmapLoadingBubble" class="bubble orange-bubble fat-bubble">Loading virginmap...</div>
-        <div id="cd-timer-bubble" class="bubble"></div>
-        <div id="placeableInfoBubble" class="bubble">Pixels available: <span id="placeableCount-bubble">0/0</span></div>
-    </div>
-    <div class="right">
-        <div id="userinfo" class="bubble"><span class="name"></span> <a href="/logout" class="logout">logout</a></div>
-        <div id="online" class="bubble"></div>
     </div>
 </div>
 

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -2756,7 +2756,8 @@ window.App = (function () {
                     enabled: true,
                 },
                 elements: {
-                    stackCount: $("#placeableCount-bubble, #placeableCount-cursor"),
+                    stackCount: $("#placeable-count, #placeableCount-cursor"),
+                    coords: $("#coords-info .coords"),
                     txtAlertLocation: $("#txtAlertLocation"),
                     rangeAlertVolume: $("#rangeAlertVolume"),
                     lblAlertVolume: $("#lblAlertVolume"),
@@ -2779,6 +2780,8 @@ window.App = (function () {
                     self._initAudio();
                     self._initAccount();
                     self._initBanner();
+
+                    self.elements.coords.click(() => coords.copyCoords(true));
 
                     var useMono = ls.get("monospace_lookup");
                     if (typeof useMono === 'undefined') {
@@ -5025,9 +5028,8 @@ window.App = (function () {
             var self = {
                 elements: {
                     palette: $("#palette"),
-                    timer_bubble: $("#cd-timer-bubble"),
                     timer_overlay: $("#cd-timer-overlay"),
-                    timer: null
+                    timer: $("#cooldown-timer")
                 },
                 isOverlay: false,
                 hasFiredNotification: true,
@@ -5045,8 +5047,9 @@ window.App = (function () {
 
                     if (self.runningTimer === false) {
                         self.isOverlay = ls.get("auto_reset") === true;
-                        self.elements.timer = self.isOverlay ? self.elements.timer_overlay : self.elements.timer_bubble;
-                        self.elements.timer_bubble.hide();
+                        if (self.isOverlay) {
+                            self.elements.timer = self.elements.timer_overlay;
+                        }
                         self.elements.timer_overlay.hide();
                     }
 
@@ -5123,8 +5126,7 @@ window.App = (function () {
                 },
                 init: function () {
                     self.title = document.title;
-                    self.elements.timer_bubble.hide();
-                    self.elements.timer_overlay.hide();
+                    self.elements.timer.hide();
 
                     $(window).focus(function () {
                         self.focus = true;
@@ -5159,9 +5161,9 @@ window.App = (function () {
         coords = (function () {
             var self = {
                 elements: {
-                    coordsWrapper: $("#coords"),
-                    coords: $("#coords .coords-text"),
-                    lockIcon: $("#coords .icon-lock")
+                    coordsWrapper: $("#coords-info"),
+                    coords: $("#coords-info .coords"),
+                    lockIcon: $("#coords-info .icon-lock")
                 },
                 mouseCoords: null,
                 init: function () {
@@ -5192,32 +5194,42 @@ window.App = (function () {
                     }
 
                     $(window).keydown(event => {
-                        if (!event.ctrlKey && (event.key === "c" || event.key === "C" || event.keyCode === 67) && navigator.clipboard && self.mouseCoords) {
-                            navigator.clipboard.writeText(self.getLinkToCoords(self.mouseCoords.x, self.mouseCoords.y));
-                            self.elements.coordsWrapper.addClass("copyPulse");
-                            setTimeout(() => {
-                                self.elements.coordsWrapper.removeClass("copyPulse");
-                            }, 200);
+                        if (!event.ctrlKey && (event.key === "c" || event.key === "C" || event.keyCode === 67)) {
+                            self.copyCoords();
                         }
                     });
+                },
+                copyCoords: function (useHash = false) {
+                    if (!navigator.clipboard || !self.mouseCoords) {
+                        return;
+                    }
+                    let x = useHash ? query.get('x') : self.mouseCoords.x;
+                    let y = useHash ? query.get('y') : self.mouseCoords.y;
+                    let scale = useHash ? query.get('scale') : 20;
+                    navigator.clipboard.writeText(self.getLinkToCoords(x, y, scale));
+                    self.elements.coordsWrapper.addClass("copyPulse");
+                    setTimeout(() => {
+                        self.elements.coordsWrapper.removeClass("copyPulse");
+                    }, 200);
                 },
                 /**
                  * Returns a link to the website at a specific position.
                  * @param {number} x The X coordinate for the link to have.
                  * @param {number} y The Y coordinate for the link to have.
                  */
-                getLinkToCoords: (x = 0, y = 0) => {
+                getLinkToCoords: (x = 0, y = 0, scale = 20) => {
                     var append = "";
                     query.has("template") ? append += "&template=" + query.get("template") : 0;
                     query.has("tw") ? append += "&tw=" + query.get("tw") : 0;
                     query.has("oo") ? append += "&oo=" + query.get("oo") : 0;
                     query.has("ox") ? append += "&ox=" + query.get("ox") : 0;
                     query.has("oy") ? append += "&oy=" + query.get("oy") : 0;
-                    return `${location.origin}/#x=${Math.floor(x)}&y=${Math.floor(y)}&scale=20${append}`;
+                    return `${location.origin}/#x=${Math.floor(x)}&y=${Math.floor(y)}&scale=${scale}${append}`;
                 }
             };
             return {
                 init: self.init,
+                copyCoords: self.copyCoords,
                 getLinkToCoords: self.getLinkToCoords,
                 lockIcon: self.elements.lockIcon,
             };
@@ -5226,8 +5238,8 @@ window.App = (function () {
         user = (function () {
             var self = {
                 elements: {
-                    users: $("#online"),
-                    userInfo: $("#userinfo"),
+                    users: $("#online-count"),
+                    userInfo: $("#user-info"),
                     loginOverlay: $("#login-overlay"),
                     userMessage: $("#user-message"),
                     prompt: $("#prompt"),
@@ -5365,7 +5377,7 @@ window.App = (function () {
                         self.renameRequested = data.renameRequested;
                         uiHelper.setDiscordName(data.discordName || "");
                         self.elements.loginOverlay.fadeOut(200);
-                        self.elements.userInfo.find("span.name").text(data.username);
+                        self.elements.userInfo.find("span#username").text(data.username);
                         if (data.method == 'ip') {
                             self.elements.userInfo.hide();
                         } else {

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -534,10 +534,10 @@ button.button.dark:disabled {
 }
 
 .ui-bar {
-    position: fixed;
+    position: relative;
     z-index: 6;
-    bottom: 0;
-    width: 100%;
+    width: 100vw;
+    left: 0;
 }
 
 .palette-overlay {
@@ -555,13 +555,6 @@ button.button.dark:disabled {
     display: flex;
     align-items: center;
     justify-content: center;
-}
-
-#cooldown-timer {
-    z-index: 7;
-    font-size: 24px;
-    pointer-events: none;
-    user-select: none;
 }
 
 #palette {
@@ -705,25 +698,40 @@ body:not(.show-placeable-bubble) #placeableInfoBubble {
     padding: 16px 24px;
 }
 
-#coords {
+.coords {
     transition: 0.2s;
 }
 
 .copyPulse {
-    background-color: rgba(0, 211, 221, 0.7);
+    color: rgba(0, 211, 221, 0.7);
+}
+
+#ui {
+    position: fixed;
+    bottom: 0;
+    user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    -webkit-user-select: none;
+    pointer-events: none;
+    z-index: 9;
+}
+
+#ui > * {
+    pointer-events: all;
 }
 
 #ui .left {
-    position: fixed;
-    left: 10px;
-    bottom: 10px;
+    position: relative;
+    left: 1rem;
+    bottom: 1rem;
     z-index: 9;
 }
 
 #ui .right {
-    position: fixed;
-    right: 10px;
-    bottom: 10px;
+    position: relative;
+    right: 1rem;
+    bottom: 1rem;
     z-index: 9;
 }
 
@@ -1104,32 +1112,34 @@ article .body {
 }
 
 body.panel-open .ui-bar {
-    width: 70%;
-    transition: width ease-out .25s;
+    width: 70vw;
+    transition: width .25s, left .25s;
+    left: 0;
 }
 
 body.panel-open.panel-left .ui-bar {
+    left: 30vw;
     right: 0;
 }
 
 body.panel-open.panel-left.panel-left-halfwidth .ui-bar,
 body.panel-open.panel-right.panel-right-halfwidth .ui-bar {
-    width: 50%;
+    width: 50vw;
 }
 
 body.panel-left.panel-right .ui-bar {
-    left: 30%;
-    width: 40%;
+    left: 30vw;
+    width: 40vw;
 }
 
 body.panel-left.panel-left-halfwidth.panel-right .ui-bar {
-    left: 50%;
-    width: 20%;
+    left: 50vw;
+    width: 20vw;
 }
 
 body.panel-left.panel-right.panel-right-halfwidth .ui-bar {
-    right: 50%;
-    width: 20%;
+    right: 50vw;
+    width: 20vw;
 }
 
 /* CHAT */
@@ -1717,33 +1727,20 @@ ul.chat-body .chat-line[data-nonce].has-ping.-scrolled-to {
     }
 }
 
-@media (max-width: 1600px) {
-    #ui .left, #ui .right {
-        bottom: 70px;
-        transition: bottom .25s ease-in-out;
-    }
-
-    body.undo-visible #ui .left, body.undo-visible #ui .right {
-        bottom: 112px;
-    }
-}
-
 @media (max-width: 768px) {
     .palette {
         width: 100%;
     }
 
     #ui .left {
-        top: 88px;
         left: 16px;
-        bottom: auto;
+        bottom: 16px;
         right: auto;
     }
 
     #ui .right {
-        top: 48px;
         left: 16px;
-        bottom: auto;
+        bottom: 16px;
         right: auto;
     }
 


### PR DESCRIPTION
This PR moves coordinates, user info, available pixel count, cooldown timer, and online count to a single bubble. This will make further development (and animation work) easier.

![image](https://user-images.githubusercontent.com/19217244/69900993-48b5ca80-137b-11ea-871a-2c22bf113dc2.png)
