### PR TITLE
Configurable default chat color

### DIFF
--- a/resources/reference.conf
+++ b/resources/reference.conf
@@ -179,6 +179,7 @@ chat {
     }
     trimInput: true
     staffRainbow: true
+    defaultColorIndex: 5
 }
 
 userIdleTimeout: 30m

--- a/src/main/java/space/pxls/App.java
+++ b/src/main/java/space/pxls/App.java
@@ -141,11 +141,21 @@ public class App {
         try {
             String[] token = line.split(" ");
             if (token[0].equalsIgnoreCase("reload")) {
-                cachedWhoamiOrigin = null;
-                loadConfig();
+                try {
+                    cachedWhoamiOrigin = null;
+                    loadConfig();
+                    System.out.println("Success!");
+                } catch (Exception x) {
+                    x.printStackTrace();
+                }
             } else if (token[0].equalsIgnoreCase("save")) {
-                saveMapForce();
-                saveMapBackup();
+                try {
+                    saveMapForce();
+                    saveMapBackup();
+                    System.out.println("Success!");
+                } catch (Exception x) {
+                    x.printStackTrace();
+                }
             } else if (token[0].equalsIgnoreCase("role")) {
                 User user = userManager.getByName(token[1]);
                 if (user != null) {

--- a/src/main/java/space/pxls/data/Database.java
+++ b/src/main/java/space/pxls/data/Database.java
@@ -84,7 +84,7 @@ public class Database {
                     "stacked INT DEFAULT 0," +
                     "is_rename_requested BOOL NOT NULL DEFAULT false," +
                     "discord_name VARCHAR(37)," +
-                    "chat_name_color INT NOT NULL DEFAULT 5)")
+                    "chat_name_color INT NOT NULL)")
                     .execute();
             // sessions
             handle.createUpdate("CREATE TABLE IF NOT EXISTS sessions ("+
@@ -632,10 +632,11 @@ public class Database {
      * @return The user.
      */
     public Optional<DBUser> createUser(String name, String login, String ip) {
-        jdbi.useHandle(handle -> handle.createUpdate("INSERT INTO users (username, login, signup_ip, last_ip) VALUES (:username, :login, :ip::INET, :ip::INET)")
+        jdbi.useHandle(handle -> handle.createUpdate("INSERT INTO users (username, login, signup_ip, last_ip, chat_name_color) VALUES (:username, :login, :ip::INET, :ip::INET, :chat_name_color)")
                 .bind("username", name)
                 .bind("login", login)
                 .bind("ip", ip)
+                .bind("chat_name_color", App.getConfig().getInt("chat.defaultColorIndex"))
                 .execute());
         return getUserByName(name);
     }


### PR DESCRIPTION
No more unreadable users in dark theme and local fixes like
```css
li.chat-line .user[style="color: #000000"] {
    color: #FFF !important;
}
```

P.S.: Please squish the commits to avoid filling master's history with such disgusting commits :$