### PR TITLE
Attempt to Workaround for Chrome-based browsers offsetting the canvas by a pixel

### DIFF
--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -288,12 +288,14 @@
                         </div>
                     </div>
 
-                    <label class="vertical-spacing"><input type="checkbox" id="color-brightness-toggle"> Enable Color Brightness</label>
-                    <label class="text-orange fake-indent"><i class="fas fa-exclamation-triangle"></i> Warning: Known to cause fuzziness in Chrome on some Mac/Linux installs</label>
-                    <label class="fake-indent">Color Brightness: <input type="range" min="0" max="1" step="0.01" value="1" id="color-brightness"></label>
 
-                    <label id="chrome-canvas-offset-setting"><input id="chrome-canvas-offset-toggle" type="checkbox"/>Attempt to fix Canvas displacement bug in Chrome 78+</label>
                 </div>
+                <div>
+                    <p><label class="vertical-spacing"><input type="checkbox" id="color-brightness-toggle"> Enable Color Brightness</label></p>
+                    <p><label class="text-orange fake-indent"><i class="fas fa-exclamation-triangle"></i> Warning: Known to cause fuzziness in Chrome on some Mac/Linux installs</label></p>
+                    <p><label class="fake-indent">Color Brightness: <input type="range" min="0" max="1" step="0.01" value="1" id="color-brightness"></label></p>
+                </div>
+                <label id="chrome-canvas-offset-setting"><input id="chrome-canvas-offset-toggle" type="checkbox"/>Attempt to fix Canvas displacement bug in Chrome 78+</label>
             </div>
         </article>
         <article>

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -291,6 +291,8 @@
                     <label class="vertical-spacing"><input type="checkbox" id="color-brightness-toggle"> Enable Color Brightness</label>
                     <label class="text-orange fake-indent"><i class="fas fa-exclamation-triangle"></i> Warning: Known to cause fuzziness in Chrome on some Mac/Linux installs</label>
                     <label class="fake-indent">Color Brightness: <input type="range" min="0" max="1" step="0.01" value="1" id="color-brightness"></label>
+
+                    <label id="chrome-canvas-offset-setting"><input id="chrome-canvas-offset-toggle" type="checkbox"/>Attempt to fix Canvas displacement bug in Chrome 78+</label>
                 </div>
             </div>
         </article>

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -1129,6 +1129,10 @@ article .body {
     display: block;
 }
 
+.panel-body article input[type="range"] {
+    vertical-align: middle;
+}
+
 .no-p-margin p {
     margin: 0 !important;
 }


### PR DESCRIPTION
- Increase or decrease #board-container size depending on window and board size
- Ability to toggle workaround on and off

This is probably missing browsers like Safari and Opera, which might be affected by the bug but are discriminated out of the workaround for now.

Please test to see if this works for all canvas and window sizes (tested with odd and even of both).