### PR TITLE
Fix rainbow name animation

### DIFF
--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -4348,7 +4348,7 @@ window.App = (function () {
 
                     //events/scaffolding
                     _selUsernameColor.value = user.getChatNameColor();
-                    uiHelper.styleElemWithChatNameColor(_selUsernameColor);
+                    uiHelper.styleElemWithChatNameColor(_selUsernameColor, user.getChatNameColor());
                     _selUsernameColor.addEventListener('change', function() {
                         socket.send({type: "UserUpdate", updates: {NameColor: String(this.value >> 0)}});
                     });

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -153,18 +153,17 @@ dd a {
 
 @keyframes rainbow-move {
     0% {
-        background-position-x: 66%;
+        background-position: 5px 0%;
     }
     100% {
-        background-position-x: 0%;
+        background-position: -500px 0%;
     }
 }
 
 .rainbow {
-    background-image: linear-gradient(45deg, violet, #308dff, aqua, green, yellow, orange, red, orange, yellow, green, aqua, #308dff, violet, violet, #308dff, aqua, green, yellow, orange, red, orange, yellow, green, aqua, #308dff, violet);
-    background-size: 600% 100%;
+    background-image: linear-gradient(45deg, violet, #308dff, cyan, green, yellow, orange, red, orange, yellow, green, cyan, #308dff, violet, violet);
+    background-size: 500px 100%;
     animation: rainbow-move 4s linear 1ms infinite;
-    background-position-x: 66%;
     transform: rotateZ(360deg); /* force rainbow rendering onto GPU if available */
 }
 


### PR DESCRIPTION
This PR brings the following:
- Fixes rainbows having a noticeable hitch on loop (reverts previous rainbow animation changes from 43e201228b80674ff6d0494f59a844ac432ffa8d)
- Fixes the 'color' dropdown in chat settings not displaying rainbow correctly on first open