### PR TITLE
Add per-service registration disable

### DIFF
--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -5638,27 +5638,37 @@ window.App = (function () {
                 webinit: function (data) {
                     self.elements.loginOverlay.find("a").click(function (evt) {
                         evt.preventDefault();
-                        self.elements.prompt.empty().append(
-                            $("<h1>").html("Sign&nbsp;in&nbsp;with..."),
-                            $("<ul>").append(
-                                $.map(data.authServices, function (a) {
-                                    return $("<li>").append(
-                                        $("<a>").attr("href", "/signin/" + a.id + "?redirect=1").text(a.name).click(function (evt) {
-                                            if (window.open(this.href, "_blank")) {
-                                                evt.preventDefault();
-                                                return;
-                                            }
-                                            ls.set("auth_same_window", true);
-                                        })
-                                    );
+
+                        const cancelButton = crel('button', {'class': 'button'}, 'Cancel');
+                        cancelButton.addEventListener('click', function() {
+                            self.elements.prompt.fadeOut(200);
+                        });
+
+                        self.elements.prompt[0].innerHTML = '';
+                        crel(self.elements.prompt[0],
+                            crel('h1', 'Sign in with...'),
+                            crel('ul',
+                                Object.values(data.authServices).map(service => {
+                                    const anchor = crel('a', {'href': `/signin/${service.id}?redirect=1`}, service.name);
+                                    anchor.addEventListener('click', function(e) {
+                                        if (window.open(this.href, '_blank')) {
+                                            e.preventDefault();
+                                            return;
+                                        }
+                                        ls.set('auth_same_window', true);
+                                    });
+                                    let toRet = crel('li', anchor);
+                                    if (!service.registrationEnabled) {
+                                        crel(toRet, crel('span', {'style': 'font-style: italic; font-size: .75em; font-weight: bold; color: red; margin-left: .5em'}, 'New Accounts Disabled'));
+                                    }
+                                    return toRet;
                                 })
                             ),
-                            $("<div>").addClass("buttons").append(
-                                $("<div>").addClass("button").text("Cancel").click(function () {
-                                    self.elements.prompt.fadeOut(200);
-                                })
+                            crel('div', {'class': 'buttons'},
+                                cancelButton
                             )
-                        ).fadeIn(200);
+                        );
+                        self.elements.prompt.fadeIn(200);
                     });
                 },
                 wsinit: function () {

--- a/resources/reference.conf
+++ b/resources/reference.conf
@@ -151,12 +151,16 @@ oauth {
     key: ""
     secret: ""
     minAge: 1d
+    enabled: true
+    registrationEnabled: true
   }
 
   // Create at https://console.developers.google.com/
   google {
     key: ""
     secret: ""
+    enabled: true
+    registrationEnabled: true
   }
 
   // Create at https://discordapp.com/developers/applications/me
@@ -164,18 +168,24 @@ oauth {
     key: ""
     secret: ""
     minAge: 1d
+    enabled: true
+    registrationEnabled: true
   }
 
   // Create at https://vk.com/apps?act=manage
   vk {
     key: ""
     secret: ""
+    enabled: true
+    registrationEnabled: true
   }
 
   // Create at https://www.tumblr.com/oauth/apps
   tumblr {
     key: ""
     secret: ""
+    enabled: true
+    registrationEnabled: true
   }
 }
 

--- a/src/main/java/space/pxls/App.java
+++ b/src/main/java/space/pxls/App.java
@@ -479,6 +479,10 @@ public class App {
 
         ChatFilter.getInstance().reload();
 
+        if (server != null) {
+            server.getWebHandler().reloadServicesEnabledState();
+        }
+
         try {
             Files.deleteIfExists(getStorageDir().resolve("index_cache.html"));
         } catch (IOException e) {

--- a/src/main/java/space/pxls/auth/DiscordAuthService.java
+++ b/src/main/java/space/pxls/auth/DiscordAuthService.java
@@ -11,7 +11,7 @@ import java.util.concurrent.TimeUnit;
 
 public class DiscordAuthService extends AuthService {
     public DiscordAuthService(String id) {
-        super(id);
+        super(id, App.getConfig().getBoolean("oauth.discord.enabled"), App.getConfig().getBoolean("oauth.discord.registrationEnabled"));
     }
 
     public String getRedirectUrl(String state) {
@@ -60,5 +60,11 @@ public class DiscordAuthService extends AuthService {
 
     public String getName() {
         return "Discord";
+    }
+
+    @Override
+    public void reloadEnabledState() {
+        this.enabled = App.getConfig().getBoolean("oauth.discord.enabled");
+        this.registrationEnabled = App.getConfig().getBoolean("oauth.discord.registrationEnabled");
     }
 }

--- a/src/main/java/space/pxls/auth/GoogleAuthService.java
+++ b/src/main/java/space/pxls/auth/GoogleAuthService.java
@@ -9,7 +9,7 @@ import space.pxls.App;
 
 public class GoogleAuthService extends AuthService {
     public GoogleAuthService(String id) {
-        super(id);
+        super(id, App.getConfig().getBoolean("oauth.google.enabled"), App.getConfig().getBoolean("oauth.google.registrationEnabled"));
     }
 
     @Override
@@ -60,5 +60,11 @@ public class GoogleAuthService extends AuthService {
 
     public String getName() {
         return "Google";
+    }
+
+    @Override
+    public void reloadEnabledState() {
+        this.enabled = App.getConfig().getBoolean("oauth.google.enabled");
+        this.registrationEnabled = App.getConfig().getBoolean("oauth.google.registrationEnabled");
     }
 }

--- a/src/main/java/space/pxls/auth/RedditAuthService.java
+++ b/src/main/java/space/pxls/auth/RedditAuthService.java
@@ -11,7 +11,7 @@ import java.util.concurrent.TimeUnit;
 
 public class RedditAuthService extends AuthService {
     public RedditAuthService(String id) {
-        super(id);
+        super(id, App.getConfig().getBoolean("oauth.reddit.enabled"), App.getConfig().getBoolean("oauth.reddit.registrationEnabled"));
     }
 
     public String getRedirectUrl(String state) {
@@ -59,5 +59,11 @@ public class RedditAuthService extends AuthService {
 
     public String getName() {
         return "Reddit";
+    }
+
+    @Override
+    public void reloadEnabledState() {
+        this.enabled = App.getConfig().getBoolean("oauth.reddit.enabled");
+        this.registrationEnabled = App.getConfig().getBoolean("oauth.reddit.registrationEnabled");
     }
 }

--- a/src/main/java/space/pxls/auth/TumblrAuthService.java
+++ b/src/main/java/space/pxls/auth/TumblrAuthService.java
@@ -14,7 +14,7 @@ import java.util.concurrent.TimeUnit;
 
 public class TumblrAuthService extends AuthService {
     public TumblrAuthService(String id) {
-        super(id);
+        super(id, App.getConfig().getBoolean("oauth.tumblr.enabled"), App.getConfig().getBoolean("oauth.tumblr.registrationEnabled"));
     }
 
     private transient Map<String, String> tokens = new ConcurrentHashMap<String, String>();
@@ -79,5 +79,11 @@ public class TumblrAuthService extends AuthService {
 
     public String getName() {
         return "Tumblr";
+    }
+
+    @Override
+    public void reloadEnabledState() {
+        this.enabled = App.getConfig().getBoolean("oauth.tumblr.enabled");
+        this.registrationEnabled = App.getConfig().getBoolean("oauth.tumblr.registrationEnabled");
     }
 }

--- a/src/main/java/space/pxls/auth/VKAuthService.java
+++ b/src/main/java/space/pxls/auth/VKAuthService.java
@@ -14,7 +14,7 @@ import java.util.concurrent.TimeUnit;
 
 public class VKAuthService extends AuthService {
     public VKAuthService(String id) {
-        super(id);
+        super(id, App.getConfig().getBoolean("oauth.vk.enabled"), App.getConfig().getBoolean("oauth.vk.registrationEnabled"));
     }
 
     public String getRedirectUrl(String state) {
@@ -24,7 +24,7 @@ public class VKAuthService extends AuthService {
         } catch (UnsupportedEncodingException e) {
             // do nothing
         }
-        
+
         return "https://oauth.vk.com/authorize?" +
             "client_id=" + App.getConfig().getString("oauth.vk.key") +
             "&response_type=code" +
@@ -74,5 +74,11 @@ public class VKAuthService extends AuthService {
 
     public String getName() {
         return "VK";
+    }
+
+    @Override
+    public void reloadEnabledState() {
+        this.enabled = App.getConfig().getBoolean("oauth.vk.enabled");
+        this.registrationEnabled = App.getConfig().getBoolean("oauth.vk.registrationEnabled");
     }
 }

--- a/src/main/java/space/pxls/server/UndertowServer.java
+++ b/src/main/java/space/pxls/server/UndertowServer.java
@@ -105,7 +105,7 @@ public class UndertowServer {
 
         if (user != null) {
             user.getConnections().add(channel);
-            
+
             // aaaaaaand update the useragent
             List<String> agentAr = exchange.getRequestHeaders().get(Headers.USER_AGENT.toString());
             String agent = "";
@@ -147,7 +147,7 @@ public class UndertowServer {
 
                 // old thing, will auto-shadowban
                 if (type.equals("place")) obj = App.getGson().fromJson(jsonObj, ClientPlace.class);
-                
+
                 // lol
                 if (type.equals("placepixel")) obj = App.getGson().fromJson(jsonObj, ClientBanMe.class);
 
@@ -239,5 +239,9 @@ public class UndertowServer {
 
     public Undertow getServer() {
         return server;
+    }
+
+    public WebHandler getWebHandler() {
+        return webHandler;
     }
 }


### PR DESCRIPTION
Two new config variables have been added to oauth services - enabled,
and registrationEnabled. If enabled === false, then it won't show up in
the available list. If registrationEnabled === false, new account
registrations will be blocked (while still allowing login). New UI
elements have been added to the login process to show visually when
service registrations are disabled. The registration DOM generation was
migrated to crel() in the process.