### PR TITLE
Configurable option to disable chat for canvas ban

### DIFF
--- a/resources/reference.conf
+++ b/resources/reference.conf
@@ -189,6 +189,7 @@ chat {
     staffRainbow: true
     defaultColorIndex: 5
     characterLimit: 256
+    canvasBanRespected: false
 }
 
 userIdleTimeout: 30m

--- a/src/main/java/space/pxls/server/PacketHandler.java
+++ b/src/main/java/space/pxls/server/PacketHandler.java
@@ -405,7 +405,7 @@ public class PacketHandler {
             String nonce = App.getDatabase().createChatMessage(0, nowMS / 1000L, message, "");
             server.broadcast(new ServerChatMessage(new ChatMessage(nonce, "CONSOLE", nowMS / 1000L, message, null, null, 0)));
         } else {
-            if (user.isChatbanned()) return;
+            if (!user.canChat()) return;
             if (message.trim().length() == 0) return;
             if (user.isRenameRequested(false)) return;
             int remaining = RateLimitFactory.getTimeRemaining(DBChatMessage.class, String.valueOf(user.getId()));

--- a/src/main/java/space/pxls/server/WebHandler.java
+++ b/src/main/java/space/pxls/server/WebHandler.java
@@ -56,7 +56,7 @@ public class WebHandler {
     }
     private String resourceToString (String r) {
         try {
-            InputStream in = getClass().getResourceAsStream(r); 
+            InputStream in = getClass().getResourceAsStream(r);
             BufferedReader br = new BufferedReader(new InputStreamReader(in));
             String s = "";
             String line;
@@ -828,7 +828,7 @@ public class WebHandler {
                             user.getBanReason(),
                             user.getLogin().split(":")[0],
                             user.isOverridingCooldown(),
-                            user.isChatbanned(),
+                            user.canChat(),
                             App.getDatabase().getChatBanReason(user.getId()),
                             user.isPermaChatbanned(),
                             user.getChatbanExpiryTime(),
@@ -1056,7 +1056,8 @@ public class WebHandler {
             (int) App.getConfig().getInt("stacking.maxStacked"),
             services,
             App.getRegistrationEnabled(),
-            Math.min(App.getConfig().getInt("chat.characterLimit"), 2048)
+            Math.min(App.getConfig().getInt("chat.characterLimit"), 2048),
+            App.getConfig().getBoolean("chat.canvasBanRespected")
         )));
     }
 

--- a/src/main/java/space/pxls/server/packets/http/CanvasInfo.java
+++ b/src/main/java/space/pxls/server/packets/http/CanvasInfo.java
@@ -15,9 +15,10 @@ public class CanvasInfo {
     public Integer maxStacked;
     public Map<String, AuthService> authServices;
     public Boolean registrationEnabled;
+    public Boolean chatRespectsCanvasBan;
     public Integer chatCharacterLimit;
 
-    public CanvasInfo(String canvasCode, Integer width, Integer height, List<String> palette, String captchaKey, Integer heatmapCooldown, Integer maxStacked, Map<String, AuthService> authServices, Boolean registrationEnabled, Integer chatCharacterLimit) {
+    public CanvasInfo(String canvasCode, Integer width, Integer height, List<String> palette, String captchaKey, Integer heatmapCooldown, Integer maxStacked, Map<String, AuthService> authServices, Boolean registrationEnabled, Integer chatCharacterLimit, boolean chatRespectsCanvasBan) {
         this.canvasCode = canvasCode;
         this.width = width;
         this.height = height;
@@ -28,6 +29,7 @@ public class CanvasInfo {
         this.authServices = authServices;
         this.registrationEnabled = registrationEnabled;
         this.chatCharacterLimit = chatCharacterLimit;
+        this.chatRespectsCanvasBan = chatRespectsCanvasBan;
     }
 
     public String getCanvasCode() {
@@ -68,5 +70,9 @@ public class CanvasInfo {
 
     public Integer getChatCharacterLimit() {
         return chatCharacterLimit;
+    }
+
+    public Boolean getChatRespectsCanvasBan() {
+        return chatRespectsCanvasBan;
     }
 }

--- a/src/main/java/space/pxls/user/User.java
+++ b/src/main/java/space/pxls/user/User.java
@@ -283,6 +283,13 @@ public class User {
         setBanExpiryTime(timeFromNowSeconds, false);
     }
 
+    public boolean canChat() {
+        if (App.getConfig().getBoolean("chat.canvasBanRespected") && isBanned()) {
+            return false;
+        }
+        return !isChatbanned();
+    }
+
     public boolean isChatbanned() {
         return this.isPermaChatbanned || this.chatbanExpiryTime > System.currentTimeMillis();
     }


### PR DESCRIPTION
A configurable option has been added to the chat section which disables
a canvas banned user's ability to send chat messages.
The existing chatban UI elements have been updated to reflect when a
user is canvas banned.