### PR TITLE
Moderator Chat Lookup

### DIFF
--- a/resources/public/admin/admin.css
+++ b/resources/public/admin/admin.css
@@ -51,6 +51,8 @@
     top: 45vh;
     left: 50%;
     transform: translateX(-50%) translateY(-50%);
+    max-height: 100vh;
+    overflow-y: auto;
 }
 
 .admin-check .buttons {

--- a/resources/public/admin/admin.js
+++ b/resources/public/admin/admin.js
@@ -243,7 +243,8 @@
                         ),
                         crel('div',
                             crel('button', {'data-action': 'chatban', 'data-target': data.username, 'class': 'button', 'style': 'position: initial; right: auto; left: auto; bottom: auto;', onclick: admin.chat._handleActionClick}, 'Chat (un)ban'),
-                            crel('button', {'data-action': 'purge', 'data-target': data.username, 'class': 'button', 'style': 'position: initial; right: auto; left: auto; bottom: auto;', onclick: admin.chat._handleActionClick}, 'Chat purge')
+                            crel('button', {'data-action': 'purge', 'data-target': data.username, 'class': 'button', 'style': 'position: initial; right: auto; left: auto; bottom: auto;', onclick: admin.chat._handleActionClick}, 'Chat purge'),
+                            crel('button', {'data-action': 'lookup-chat', 'data-target': data.username, 'class': 'button', 'style': 'position: initial; right: auto; left: auto; bottom: auto;', onclick: admin.chat._handleActionClick}, 'Chat lookup')
                         ),
                         (admin.user.getRole() !== "TRIALMOD"
                                 ? crel('div',

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -3677,7 +3677,7 @@ window.App = (function () {
                                     crel('ul', {'class': 'chatban-history'},
                                         e.chatbans.map(chatban => {
                                             return crel('li', {'class': 'chatban'},
-                                                crel('h4', `${chatban.initiator_name} banned ${e.target.username}${chatban.type !== 'PERMA' ? '' : ''}`),
+                                                crel('h4', `${chatban.initiator_name} ${chatban.type === 'UNBAN' ? 'un' : ''}banned ${e.target.username}${chatban.type !== 'PERMA' ? '' : ''}`),
                                                 crel('table',
                                                     crel('tbody',
                                                         crel('tr',

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -3641,7 +3641,6 @@ window.App = (function () {
                         }, 100);
                     });
                     socket.on('chat_lookup', e => {
-                        const moment_format = `MMM Do 'YY, ${ls.get('chat.24h') === true  ? 'HH:mm:ss' : 'h:mm:ss a'}`;
                         if (e.target && Array.isArray(e.history) && Array.isArray(e.chatbans)) {
                             const now = moment(),
                                 is24h = ls.get('chat.24h') === true,

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -3640,6 +3640,81 @@ window.App = (function () {
                             }
                         }, 100);
                     });
+                    socket.on('chat_lookup', e => {
+                        const moment_format = `MMM Do 'YY, ${ls.get('chat.24h') === true  ? 'HH:mm:ss' : 'h:mm:ss a'}`;
+                        if (e.target && Array.isArray(e.history) && Array.isArray(e.chatbans)) {
+                            const now = moment(),
+                                is24h = ls.get('chat.24h') === true,
+                                shortFormat = `MMM Do YYYY, ${is24h ? 'HH:mm' : 'hh:mm A'}`,
+                                longFormat = `dddd, MMMM Do YYYY, ${is24h ? 'HH:mm:ss' : 'h:mm:ss a'}`;
+                            const dom = crel('div', {'class': 'halves'},
+                                crel('div', {'class': 'side chat-lookup-side'},
+                                    e.history.length > 0 ? ([ // array children are injected as fragments
+                                        crel('h3', {'style': 'text-align: center'}, `Last ${e.history.length} messages`),
+                                        crel('hr'),
+                                        crel('ul', {'class': 'chat-history chat-body'},
+                                            e.history.map(message => crel('li', {'class': `chat-line ${message.purged ? 'purged' : ''}`.trimRight()},
+                                                crel('span', {'title': moment(message.sent*1e3).format(longFormat)}, moment(message.sent*1e3).format(shortFormat)),
+                                                ' ',
+                                                (() => {
+                                                    let toRet = crel('span', {'class': 'user'}, e.target.username);
+                                                    uiHelper.styleElemWithChatNameColor(toRet, e.target.chatNameColor, 'color');
+                                                    return toRet;
+                                                })(),
+                                                ': ',
+                                                crel('span', {'class': 'content'}, message.content)
+                                            ))
+                                        )
+                                    ]) : ([
+                                        crel('h3', {'style': 'text-align: center'}, `Last Messages`),
+                                        crel('hr'),
+                                        crel('p', 'No message history')
+                                    ]),
+                                ),
+                                crel('div', {'class': 'side chat-lookup-side'},
+                                    crel('h3', {'style': 'text-align: center'}, 'Chat Bans'),
+                                    crel('hr'),
+                                    crel('ul', {'class': 'chatban-history'},
+                                        e.chatbans.map(chatban => {
+                                            return crel('li', {'class': 'chatban'},
+                                                crel('h4', `${chatban.initiator_name} banned ${e.target.username}${chatban.type !== 'PERMA' ? '' : ''}`),
+                                                crel('table',
+                                                    crel('tbody',
+                                                        crel('tr',
+                                                            crel('th', 'Reason:'),
+                                                            crel('td', chatban.reason || '$No reason provided$')
+                                                        ),
+                                                        crel('tr',
+                                                            crel('th', 'When:'),
+                                                            crel('td', moment(chatban.when*1e3).format(longFormat))
+                                                        ),
+                                                        chatban.type !== 'UNBAN' ? ([
+                                                            crel('tr',
+                                                                crel('th', 'Length:'),
+                                                                crel('td', (chatban.type.toUpperCase().trim() === 'PERMA') ? 'Permanent' : `${chatban.expiry-chatban.when}s`)
+                                                            ),
+                                                            (chatban.type.toUpperCase().trim() === 'PERMA') ? null : crel('tr',
+                                                                crel('th', 'Expiry:'),
+                                                                crel('td', moment(chatban.expiry*1e3).format(longFormat))
+                                                            ),
+                                                            crel('tr',
+                                                                crel('th', 'Purged:'),
+                                                                crel('td', String(chatban.purged))
+                                                            )
+                                                        ]) : null
+                                                    )
+                                                )
+                                            );
+                                        })
+                                    )
+                                )
+                            );
+                            modal.show(modal.buildDom(
+                                crel('h2', {'class': 'modal-title'}, 'Chat Lookup'),
+                                dom
+                            ));
+                        }
+                    });
                     const handleChatban = e => {
                         clearInterval(self.timeout.timer);
                         self.chatban.banStart = moment.now();
@@ -4814,8 +4889,8 @@ window.App = (function () {
                         let actionChatban = crel('li', {'data-action': 'chatban', 'data-nonce': nonce, onclick: self._handleActionClick}, 'Chat (un)ban');
                         let actionPurgeUser = crel('li', {'data-action': 'purge', 'data-nonce': nonce, onclick: self._handleActionClick}, 'Purge User');
                         let actionDeleteMessage = crel('li', {'data-action': 'delete', 'data-nonce': nonce, onclick: self._handleActionClick}, 'Delete');
-                        let actionModLookup = crel('li', {'data-action': 'lookup', 'data-nonce': nonce, onclick: self._handleActionClick}, 'Mod Lookup');
-                        let actionCopyNonce = crel('li', {'data-action': 'copy-nonce', 'data-nonce': nonce, onclick: self._handleActionClick}, 'Copy Nonce');
+                        let actionModLookup = crel('li', {'data-action': 'lookup-mod', 'data-nonce': nonce, onclick: self._handleActionClick}, 'Mod Lookup');
+                        let actionChatLookup = crel('li', {'data-action': 'lookup-chat', 'data-nonce': nonce, onclick: self._handleActionClick}, 'Chat Lookup');
 
                         crel(leftPanel, crel('p', {'class': 'popup-timestamp-header'}, moment.unix(closest.dataset.date >> 0).format(`MMM Do YYYY, ${(ls.get('chat.24h') === true ? 'HH:mm:ss' : 'hh:mm:ss A')}`)));
                         crel(leftPanel, crel('p', {'style': 'margin-top: 3px; margin-left: 3px; text-align: left;'}, closest.querySelector('.content').textContent));
@@ -4828,9 +4903,7 @@ window.App = (function () {
                             crel(actionsList, actionDeleteMessage);
                             crel(actionsList, actionPurgeUser);
                             crel(actionsList, actionModLookup);
-                            if (user.getRole() === "DEVELOPER") {
-                                crel(actionsList, actionCopyNonce);
-                            }
+                            crel(actionsList, actionChatLookup);
                         }
                         crel(rightPanel, actionsList);
 
@@ -5203,10 +5276,14 @@ window.App = (function () {
                             ));
                             break;
                         }
-                        case 'lookup': {
+                        case 'lookup-mod': {
                             if (user.admin && user.admin.checkUser && user.admin.checkUser.check) {
                                 user.admin.checkUser.check(reportingTarget);
                             }
+                            break;
+                        }
+                        case 'lookup-chat': {
+                            socket.send({type: 'ChatLookup', who: reportingTarget});
                             break;
                         }
                         case 'request-rename': {
@@ -5298,16 +5375,6 @@ window.App = (function () {
                                 crel('h2', {'class': 'modal-title'}, 'Force Rename'),
                                 renameWrapper
                             ));
-                            break;
-                        }
-                        case 'copy-nonce': {
-                            // TODO(netux): use Clipboard API once it becomes Stable
-                            const textArea = document.createElement('textarea');
-                            textArea.value = this.dataset.nonce;
-                            document.body.appendChild(textArea);
-                            textArea.select();
-                            document.execCommand('copy');
-                            document.body.removeChild(textArea);
                             break;
                         }
                     }

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -170,6 +170,7 @@ dd a {
 .halves {
     display: flex;
     flex-wrap: wrap;
+    min-width: 50vw;
 }
 
 .halves .side {

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -1916,7 +1916,7 @@ ul.chat-history, ul.chatban-history {
     z-index: 100;
     width: initial;
     min-width: 10vw;
-    max-width: 97vw;
+    max-width: 96vw;
     max-height: 99vh;
     background-color: #f5f5f5;
     padding: 0;

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -167,6 +167,20 @@ dd a {
     transform: rotateZ(360deg); /* force rainbow rendering onto GPU if available */
 }
 
+.halves {
+    display: flex;
+    flex-wrap: wrap;
+}
+
+.halves .side {
+    flex: 1 0 50%;
+}
+
+.chat-lookup-side {
+    max-height: calc(88vh - 30px);
+    overflow: auto;
+}
+
 /*//////////////////////////*\
 | Overlays
 \*\\\\\\\\\\\\\\\\\\\\\\\\\\*/
@@ -1514,6 +1528,44 @@ ul.chat-body .chat-line[data-nonce].has-ping.-scrolled-to {
     animation: -scrolled-flash 150ms linear 1ms 4 alternate;
 }
 
+.chat-history .chat-line {
+    word-break: break-all;
+}
+
+ul.chat-history, ul.chatban-history {
+    padding: 0;
+    margin: 0;
+    list-style: none;
+}
+
+.chatban-history li {
+    margin: 7px;
+    border-radius: 7px;
+    background-color: rgba(177, 177, 177, 0.3);
+    border: 1px solid #828282;
+}
+
+.chatban-history h4 {
+    margin: 0 0 1em 0;
+    background-color: #82828233;
+    border-radius: 7px 7px 0 0;
+    text-align: center;
+    font-size: 1.25em;
+    line-height: 1.25em;
+    border-bottom: 1px solid #828282;
+}
+
+.chatban-history table {
+    margin: 7px;
+}
+
+.chatban-history th {
+    text-align: right;
+    font-weight: bold;
+    margin-right: .5em;
+}
+
+
 .panel-trigger .ping-counter {
     position: absolute;
     bottom: 0;
@@ -1864,7 +1916,7 @@ ul.chat-body .chat-line[data-nonce].has-ping.-scrolled-to {
     z-index: 100;
     width: initial;
     min-width: 10vw;
-    max-width: 99vw;
+    max-width: 97vw;
     max-height: 99vh;
     background-color: #f5f5f5;
     padding: 0;
@@ -1933,6 +1985,7 @@ ul.chat-body .chat-line[data-nonce].has-ping.-scrolled-to {
 @media (max-width: 768px) {
     .modal {
         min-width: 1vw;
+        max-width: 95vw;
     }
 
     .mobile-only {
@@ -2016,5 +2069,13 @@ ul.chat-body .chat-line[data-nonce].has-ping.-scrolled-to {
         line-height: 2rem;
         font-size: 1.25rem;
         top: -2rem;
+    }
+
+    .halves .side {
+        flex: 1 0 100%;
+    }
+
+    .chat-lookup-side {
+        max-height: initial;
     }
 }

--- a/resources/public/themes/dark.css
+++ b/resources/public/themes/dark.css
@@ -123,6 +123,16 @@ ul.chat-body li.chat-line.server-action {
     color: #9f9f9f;
 }
 
+.chatban-history li {
+    background-color: rgba(37, 37, 37, 0.3);
+    border: 1px solid #828282;
+}
+
+.chatban-history h4 {
+    background-color: #82828233;
+    border-bottom: 1px solid #828282;
+}
+
 .popup {
     background-color: #333;
     color: #ccc;

--- a/resources/public/themes/darker.css
+++ b/resources/public/themes/darker.css
@@ -124,6 +124,16 @@ ul.chat-body li.chat-line.server-action {
     color: #ccc;
 }
 
+.chatban-history li {
+    background-color: #000;
+    border: 1px solid #464646;
+}
+
+.chatban-history h4 {
+    background-color: #46464633;
+    border-bottom: 1px solid #464646;
+}
+
 .popup {
     background-color: #111;
     color: #fff;

--- a/src/main/java/space/pxls/App.java
+++ b/src/main/java/space/pxls/App.java
@@ -1,7 +1,6 @@
 package space.pxls;
 
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import org.apache.logging.log4j.Level;

--- a/src/main/java/space/pxls/App.java
+++ b/src/main/java/space/pxls/App.java
@@ -1,6 +1,7 @@
 package space.pxls;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import org.apache.logging.log4j.Level;

--- a/src/main/java/space/pxls/data/DBChatban.java
+++ b/src/main/java/space/pxls/data/DBChatban.java
@@ -1,0 +1,45 @@
+package space.pxls.data;
+
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class DBChatban {
+    public final int id;
+    public final int target;
+    public final int initiator;
+    public final int when;
+    public final String type;
+    public final int expiry;
+    public final String reason;
+    public final boolean purged;
+
+    public DBChatban(int id, int target, int initiator, int when, String type, int expiry, String reason, boolean purged) {
+        this.id = id;
+        this.target = target;
+        this.initiator = initiator;
+        this.when = when;
+        this.type = type;
+        this.expiry = expiry;
+        this.reason = reason;
+        this.purged = purged;
+    }
+
+    public static class Mapper implements RowMapper<DBChatban> {
+        @Override
+        public DBChatban map(ResultSet r, StatementContext ctx) throws SQLException {
+            return new DBChatban(
+                    r.getInt("id"),
+                    r.getInt("target"),
+                    r.getInt("initiator"),
+                    r.getInt("when"),
+                    r.getString("type"),
+                    r.getInt("expiry"),
+                    r.getString("reason"),
+                    r.getBoolean("purged")
+            );
+        }
+    }
+}

--- a/src/main/java/space/pxls/data/DBExtendedChatban.java
+++ b/src/main/java/space/pxls/data/DBExtendedChatban.java
@@ -1,0 +1,35 @@
+package space.pxls.data;
+
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class DBExtendedChatban extends DBChatban {
+    public final String target_name;
+    public final String initiator_name;
+    public DBExtendedChatban(int id, int target, String target_name, int initiator, String initiator_name, int when, String type, int expiry, String reason, boolean purged) {
+        super(id, target, initiator, when, type, expiry, reason, purged);
+        this.target_name = target_name;
+        this.initiator_name = initiator_name;
+    }
+
+    public static class Mapper implements RowMapper<DBExtendedChatban> {
+        @Override
+        public DBExtendedChatban map(ResultSet r, StatementContext ctx) throws SQLException {
+            return new DBExtendedChatban(
+                r.getInt("id"),
+                r.getInt("target"),
+                r.getString("target_name"),
+                r.getInt("initiator"),
+                r.getString("initiator_name"),
+                r.getInt("when"),
+                r.getString("type"),
+                r.getInt("expiry"),
+                r.getString("reason"),
+                r.getBoolean("purged")
+            );
+        }
+    }
+}

--- a/src/main/java/space/pxls/server/PacketHandler.java
+++ b/src/main/java/space/pxls/server/PacketHandler.java
@@ -18,7 +18,6 @@ import space.pxls.server.packets.socket.*;
 import space.pxls.user.Role;
 import space.pxls.user.User;
 import space.pxls.util.ChatFilter;
-import space.pxls.util.PxlsTimer;
 import space.pxls.util.RateLimitFactory;
 
 import java.util.*;
@@ -117,6 +116,7 @@ public class PacketHandler {
             if (obj instanceof ClientChatbanState) handleChatbanState(channel, user, ((ClientChatbanState) obj));
             if (obj instanceof ClientChatMessage) handleChatMessage(channel, user, ((ClientChatMessage) obj));
             if (obj instanceof ClientUserUpdate) handleClientUserUpdate(channel, user, ((ClientUserUpdate) obj));
+            if (obj instanceof ClientChatLookup) handleChatLookup(channel, user, ((ClientChatLookup) obj));
 
             if (user.getRole().greaterEqual(Role.MODERATOR)) {
                 if (obj instanceof ClientAdminCooldownOverride)
@@ -135,6 +135,15 @@ public class PacketHandler {
             for (WebSocketChannel ch : u.getConnections()) {
                 server.send(ch, msg);
             }
+        }
+    }
+
+    private void handleChatLookup(WebSocketChannel channel, User user, ClientChatLookup obj) {
+        if (user.getRole().greaterEqual(Role.TRIALMOD)) {
+            ServerChatLookup scl = App.getDatabase().runChatLookupForUsername(obj.getWho());
+            server.send(channel, scl == null ? new ServerError("User doesn't exist") : scl);
+        } else {
+            server.send(channel, new ServerError("Missing Permissions"));
         }
     }
 

--- a/src/main/java/space/pxls/server/UndertowServer.java
+++ b/src/main/java/space/pxls/server/UndertowServer.java
@@ -105,7 +105,7 @@ public class UndertowServer {
 
         if (user != null) {
             user.getConnections().add(channel);
-            
+
             // aaaaaaand update the useragent
             List<String> agentAr = exchange.getRequestHeaders().get(Headers.USER_AGENT.toString());
             String agent = "";
@@ -134,20 +134,19 @@ public class UndertowServer {
                 if (type.equals("pixel")) obj = App.getGson().fromJson(jsonObj, ClientPlace.class);
                 if (type.equals("undo")) obj = App.getGson().fromJson(jsonObj, ClientUndo.class);
                 if (type.equals("captcha")) obj = App.getGson().fromJson(jsonObj, ClientCaptcha.class);
-                if (type.equals("admin_cdoverride"))
-                    obj = App.getGson().fromJson(jsonObj, ClientAdminCooldownOverride.class);
-                if (type.equals("admin_message"))
-                    obj = App.getGson().fromJson(jsonObj, ClientAdminMessage.class);
+                if (type.equals("admin_cdoverride")) obj = App.getGson().fromJson(jsonObj, ClientAdminCooldownOverride.class);
+                if (type.equals("admin_message")) obj = App.getGson().fromJson(jsonObj, ClientAdminMessage.class);
                 if (type.equals("shadowbanme")) obj = App.getGson().fromJson(jsonObj, ClientShadowBanMe.class);
                 if (type.equals("banme")) obj = App.getGson().fromJson(jsonObj, ClientBanMe.class);
                 if (type.equalsIgnoreCase("ChatHistory")) obj = App.getGson().fromJson(jsonObj, ClientChatHistory.class);
                 if (type.equalsIgnoreCase("ChatbanState")) obj = App.getGson().fromJson(jsonObj, ClientChatbanState.class);
                 if (type.equalsIgnoreCase("ChatMessage")) obj = App.getGson().fromJson(jsonObj, ClientChatMessage.class);
                 if (type.equalsIgnoreCase("UserUpdate")) obj = App.getGson().fromJson(jsonObj, ClientUserUpdate.class);
+                if (type.equalsIgnoreCase("ChatLookup")) obj = App.getGson().fromJson(jsonObj, ClientChatLookup.class);
 
                 // old thing, will auto-shadowban
                 if (type.equals("place")) obj = App.getGson().fromJson(jsonObj, ClientPlace.class);
-                
+
                 // lol
                 if (type.equals("placepixel")) obj = App.getGson().fromJson(jsonObj, ClientBanMe.class);
 

--- a/src/main/java/space/pxls/server/packets/chat/ClientChatLookup.java
+++ b/src/main/java/space/pxls/server/packets/chat/ClientChatLookup.java
@@ -1,0 +1,13 @@
+package space.pxls.server.packets.chat;
+
+public class ClientChatLookup {
+    public String who;
+
+    public ClientChatLookup(String who) {
+        this.who = who;
+    }
+
+    public String getWho() {
+        return who;
+    }
+}

--- a/src/main/java/space/pxls/server/packets/chat/ServerChatLookup.java
+++ b/src/main/java/space/pxls/server/packets/chat/ServerChatLookup.java
@@ -1,0 +1,37 @@
+package space.pxls.server.packets.chat;
+
+import space.pxls.data.DBChatMessage;
+import space.pxls.data.DBChatban;
+import space.pxls.data.DBExtendedChatban;
+import space.pxls.data.DBUser;
+
+import java.util.List;
+
+public class ServerChatLookup {
+    public DBUser target;
+    public List<DBChatMessage> history;
+    public List<DBExtendedChatban> chatbans;
+    public String type = "chat_lookup";
+
+    public ServerChatLookup(DBUser target, List<DBChatMessage> history, List<DBExtendedChatban> chatbans) {
+        this.target = target;
+        this.history = history;
+        this.chatbans = chatbans;
+    }
+
+    public DBUser getTarget() {
+        return target;
+    }
+
+    public List<DBChatMessage> getHistory() {
+        return history;
+    }
+
+    public List<DBExtendedChatban> getChatbans() {
+        return chatbans;
+    }
+
+    public String getType() {
+        return type;
+    }
+}

--- a/src/main/java/space/pxls/server/packets/socket/ServerError.java
+++ b/src/main/java/space/pxls/server/packets/socket/ServerError.java
@@ -1,0 +1,13 @@
+package space.pxls.server.packets.socket;
+
+public class ServerError {
+    private String message;
+
+    public ServerError(String message) {
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}


### PR DESCRIPTION
A new action has been added to the popup menu for Staff that allows them
to pull a user's last 100 chat messages as well as their chat bans. This
should help cut back on the time spent lookup up things such as 3-star
messages.