### PR TITLE
Chat tweaks

### DIFF
--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -155,7 +155,7 @@
 <aside id="chat" data-panel="chat" class="panel right">
     <header class="panel-header">
         <div class="left"><i class="fas fa-times text-red panel-closer"></i></div>
-        <h2><i class="fas fa-comment-alt fa-is-left fa-1_5x"></i>Chat</h2>
+        <h2><i class="fas fa-comment-alt fa-is-left fa-1_5x"></i>Chat <span class="mobile-only" id="txtMobileChatCooldown"></span></h2>
         <div class="right">
             <i class="fas fa-at" id="btnPings" title="Pings"></i>
             <i class="fas fa-cogs" id="btnChatSettings" title="Settings"></i>

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -2847,9 +2847,9 @@ window.App = (function () {
                 loadingStates: {},
                 banner: {
                     HTMLs: [
-                        crel('span', crel('i', {'class': 'fab fa-discord fa-is-left'}), ' We have a discord! Join here: ', crel('a', {'href': 'https://pxls.space/discord', 'target': '_blank'}, 'Discord Invite')).outerHTML,
-                        crel('span', {'style': 'font-size: .75rem'}, crel('i', {'class': 'fas fa-gavel fa-is-left'}), 'Chat is moderated, ensure you read the rules in the info panel.').outerHTML,
-                        crel('span', {'style': 'font-size: .8rem'}, crel('i', {'class': 'fas fa-question-circle fa-is-left'}), 'If you haven\'t already, make sure you read the FAQ top left!').outerHTML
+                        crel('span', crel('i', {'class': 'fab fa-discord fa-is-left'}), ' Official Discord: ', crel('a', {'href': 'https://pxls.space/discord', 'target': '_blank'}, 'Invite Link')).outerHTML,
+                        crel('span', {'style': ''}, crel('i', {'class': 'fas fa-gavel fa-is-left'}), 'Read the chat rules in the info panel.').outerHTML,
+                        crel('span', {'style': ''}, crel('i', {'class': 'fas fa-question-circle fa-is-left'}), 'Ensure you read the FAQ top left!').outerHTML
                     ],
                     curElem: 0,
                     intervalID: 0,

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -169,13 +169,16 @@ window.App = (function () {
          * @param dbType {string} The type of the database, acts internally as a map key.
          * @param [keepTrigger=false] {boolean} Whether or not this trigger type should keep it's matching trigger chars on search results.
          * @param [hasPair=false] {boolean} Whether or not this trigger has a matching pair at the end, e.g. ':word:' vs '@word'
+         * @param [minLength=0] {number} The minimum length of the match before this trigger is considered valid.
+         *                                Length is calculated without `this.char`, so a trigger of ":" and a match of ":one" will be a length of 3.
          * @constructor
          */
-        function Trigger(char, dbType, keepTrigger = false, hasPair = false) {
+        function Trigger(char, dbType, keepTrigger = false, hasPair = false, minLength = 0) {
             this.char = char;
             this.dbType = dbType;
             this.keepTrigger = keepTrigger;
             this.hasPair = hasPair;
+            this.minLength = minLength;
         }
 
         /**
@@ -280,7 +283,7 @@ window.App = (function () {
                     match.word = searchString.substring(match.start+1, fixedEnd);
                 }
 
-                return matched ? match : false;
+                return matched ? (match.word.length >= match.trigger.minLength ? match : false) : false;
             };
 
             /**
@@ -4157,7 +4160,7 @@ window.App = (function () {
                     }
 
                     // init triggers
-                    let triggerEmoji = new TH.Trigger(':', 'emoji', false, true);
+                    let triggerEmoji = new TH.Trigger(':', 'emoji', false, true, 2);
                     let triggerUsers = new TH.Trigger('@', 'users', true, false);
 
                     // init typeahead

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -5459,7 +5459,8 @@ window.App = (function () {
                 elements: {
                     palette: $("#palette"),
                     timer_overlay: $("#cd-timer-overlay"),
-                    timer_bubble: $("#cooldown-timer")
+                    timer_bubble: $("#cooldown-timer"),
+                    timer_chat: $('#txtMobileChatCooldown'),
                 },
                 isOverlay: false,
                 hasFiredNotification: true,
@@ -5511,7 +5512,8 @@ window.App = (function () {
                             secsStr = secs < 10 ? "0" + secs : secs,
                             minutes = Math.floor(delta / 60),
                             minuteStr = minutes < 10 ? "0" + minutes : minutes;
-                        self.elements.timer.text(minuteStr + ":" + secsStr);
+                        self.elements.timer.text(`${minuteStr}:${secsStr}`);
+                        self.elements.timer_chat.text(`(${minuteStr}:${secsStr})`);
 
                         document.title = uiHelper.getTitle(`[${minuteStr}:${secsStr}]`);
 
@@ -5533,6 +5535,7 @@ window.App = (function () {
                         self.elements.timer.css("left", "0");
                     }
                     self.elements.timer.hide();
+                    self.elements.timer_chat.text('');
 
                     if (alertDelay > 0) {
                         setTimeout(() => {
@@ -5567,6 +5570,7 @@ window.App = (function () {
                         ? self.elements.timer_overlay
                         : self.elements.timer_bubble;
                     self.elements.timer.hide();
+                    self.elements.timer_chat.text('');
 
                     setTimeout(function () {
                         if (self.cooledDown() && uiHelper.getAvailable() === 0) {

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -2019,16 +2019,16 @@ ul.chat-history, ul.chatban-history {
         width: initial;
         transition: none;
     }
+
+    .mobile-only {
+        display: initial;
+    }
 }
 
 @media (max-width: 768px) {
     .modal {
         min-width: 1vw;
         max-width: 95vw;
-    }
-
-    .mobile-only {
-        display: initial;
     }
 
     .palette {

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -1251,7 +1251,7 @@ body.panel-left.panel-right.panel-right-halfwidth #ui {
 
 ul.chat-body li.chat-line {
     /*border:1px solid #000;*/
-    line-height: 1.5rem;
+    line-height: 1.5em;
     border-bottom: 1px solid #bfbfbf;
     overflow: hidden;
 }
@@ -1278,10 +1278,10 @@ li.chat-line i[title] {
 }
 
 li.chat-line .text-badge, header .text-badge {
-    line-height: 1rem;
+    line-height: 1em;
     background-color: #ccc;
-    padding: .15rem .5rem;
-    border-radius: 1rem;
+    padding: .15em .5em;
+    border-radius: 1em;
     color: #770;
     cursor: default;
     -webkit-user-select: none;
@@ -1358,12 +1358,14 @@ li.chat-line .actions [data-action]:not(:last-of-type):not(:only-child) {
 }
 
 .chat-wrapper .bottom-banner {
-    height: 1.25rem;
-    line-height: 1.25rem;
-    font-size: 1rem;
+    height: 1.25em;
+    line-height: 1.25em;
+    font-size: 1em;
     text-align: right;
     font-style: italic;
     opacity: 100%;
+    overflow-y: hidden;
+    text-align: center;
 }
 
 .chat-wrapper .bottom-banner.transparent {
@@ -1395,7 +1397,7 @@ li.chat-line .actions [data-action]:not(:last-of-type):not(:only-child) {
     width: 100%;
     height: 100%;
     margin: 0;
-    padding: 5px;
+    padding: 5px 1.75rem 5px 5px;
     resize: none;
     font-family: Arial, Helvetica, sans-serif;
 }
@@ -1491,11 +1493,11 @@ li.chat-line .actions [data-action]:not(:last-of-type):not(:only-child) {
 }
 
 #typeahead ul li {
-    font-size: 1rem;
-    line-height: 1.5rem;
+    font-size: 1em;
+    line-height: 1.5em;
     cursor: pointer;
     user-select: none;
-    text-indent: .75rem;
+    text-indent: .75em;
     background-color: #a3a3a3;
     border-radius: 4px;
     padding: 3px;
@@ -1983,6 +1985,42 @@ ul.chat-history, ul.chatban-history {
     }
 }
 
+@media (max-width: 1152px) {
+    .panel, .panel.half-width {
+        max-width: 50% !important;
+        width: 50% !important;
+    }
+
+    .panel.left {
+        left: -55%;
+    }
+
+    .panel.right {
+        right: -55%;
+    }
+}
+
+@media (max-width: 960px) {
+    .panel, .panel.half-width {
+        max-width: 100% !important;
+        width: 100% !important;
+    }
+
+    .panel.left {
+        left: -105%;
+    }
+
+    .panel.right {
+        right: -105%;
+    }
+
+    body.panel-open #ui {
+        right: initial;
+        width: initial;
+        transition: none;
+    }
+}
+
 @media (max-width: 768px) {
     .modal {
         min-width: 1vw;
@@ -2026,25 +2064,6 @@ ul.chat-history, ul.chatban-history {
         max-height: 100%;
         overflow: auto;
         width: 95%;
-    }
-
-    .panel, .panel.half-width {
-        max-width: 100% !important;
-        width: 100% !important;
-    }
-
-    .panel.left {
-        left: -105%;
-    }
-
-    .panel.right {
-        right: -105%;
-    }
-
-    body.panel-open #ui {
-        right: initial;
-        width: initial;
-        transition: none;
     }
 
     #ui #main-bubble {


### PR DESCRIPTION
This PR brings the following:
* Add a minLength to typeahead trigger matches. This stops `:p` from triggering.
* Allow typeahead matches to be unanchored. This allows someone to do `:shrug` and find `:woman_shrugging`
* Scale chat-lines correctly by using em instead of rem
* Add a pixel timer to the chat box header on mobile
* Update breakpoints for panel shrinking, add an inbetween from mobile to desktop to stop it from shrinking too much