### PR TITLE
Chat Lookup Tweaks

### DIFF
--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -3706,7 +3706,7 @@ window.App = (function () {
                                                         chatban.type !== 'UNBAN' ? ([
                                                             crel('tr',
                                                                 crel('th', 'Length:'),
-                                                                crel('td', (chatban.type.toUpperCase().trim() === 'PERMA') ? 'Permanent' : `${chatban.expiry-chatban.when}s`)
+                                                                crel('td', (chatban.type.toUpperCase().trim() === 'PERMA') ? 'Permanent' : `${chatban.expiry-chatban.when}s${(chatban.expiry-chatban.when) >= 60 ? ` (${moment.duration(chatban.expiry-chatban.when, 'seconds').humanize()})` : ''}`)
                                                             ),
                                                             (chatban.type.toUpperCase().trim() === 'PERMA') ? null : crel('tr',
                                                                 crel('th', 'Expiry:'),

--- a/resources/reference.conf
+++ b/resources/reference.conf
@@ -200,6 +200,7 @@ chat {
     defaultColorIndex: 5
     characterLimit: 256
     canvasBanRespected: false
+    chatLookupScrollbackAmount: 500
 }
 
 userIdleTimeout: 30m

--- a/src/main/java/space/pxls/data/Database.java
+++ b/src/main/java/space/pxls/data/Database.java
@@ -1292,9 +1292,10 @@ public class Database {
      * Returns the requested user's last 100 messages and chatbans.
      *
      * @param username The {@link User}'s name to look up.
+     * @param history_limit The maximum number of chat message history to fetch.
      * @return The requested user's last 100 messages and chatbans.
      */
-    public ServerChatLookup runChatLookupForUsername(String username) {
+    public ServerChatLookup runChatLookupForUsername(String username, int history_limit) {
         // we want to run all these queries with their own handle so we don't hit the pool x times.
         return jdbi.withHandle(handle -> {
             Optional<DBUser> dbu = handle.createQuery(SQL_USER_BY_NAME)
@@ -1309,8 +1310,9 @@ public class Database {
                     .map(new DBExtendedChatban.Mapper())
                     .list();
 
-            List<DBChatMessage> messages = handle.createQuery("SELECT * FROM chat_messages WHERE author = :uid ORDER BY sent DESC LIMIT 100")
+            List<DBChatMessage> messages = handle.createQuery("SELECT * FROM chat_messages WHERE author = :uid ORDER BY sent DESC LIMIT :lim")
                     .bind("uid", dbUser.id)
+                    .bind("lim", history_limit)
                     .map(new DBChatMessage.Mapper())
                     .list();
 

--- a/src/main/java/space/pxls/server/PacketHandler.java
+++ b/src/main/java/space/pxls/server/PacketHandler.java
@@ -141,7 +141,7 @@ public class PacketHandler {
 
     private void handleChatLookup(WebSocketChannel channel, User user, ClientChatLookup obj) {
         if (user.getRole().greaterEqual(Role.TRIALMOD)) {
-            ServerChatLookup scl = App.getDatabase().runChatLookupForUsername(obj.getWho());
+            ServerChatLookup scl = App.getDatabase().runChatLookupForUsername(obj.getWho(), App.getConfig().getInt("chat.chatLookupScrollbackAmount"));
             server.send(channel, scl == null ? new ServerError("User doesn't exist") : scl);
         } else {
             server.send(channel, new ServerError("Missing Permissions"));


### PR DESCRIPTION
Make the amount of chat lookup scrollback lines configurable and
increase the default amount to 500.

Add a humanized time diff (e.g. 600s -> "10 minutes") for chatban
lengths that are >= 1 minute.