### PR TITLE
Pop a small alert for staff on new received report

### DIFF
--- a/resources/public/SLIDEIN.css
+++ b/resources/public/SLIDEIN.css
@@ -1,0 +1,90 @@
+@keyframes slidein-slide {
+    0% {
+        transform: translateY(-2em);
+    }
+    100% {
+        transform: translateY(0em);
+    }
+}
+
+.slidein {
+    position: fixed;
+    width: 45em;
+    top: 0;
+    left: calc((100% / 2) - (45em / 2));
+    background-color: #333333;
+    display: flex;
+    flex-flow: row;
+    padding: .25em;
+    border-radius: 0 0 5px 5px;
+    height: 2em;
+    overflow: hidden;
+    user-select: none;
+    transform: translateY(-2em);
+    z-index: 30000;
+}
+
+.slidein.showing {
+    animation: slidein-slide 100ms linear;
+}
+
+.slidein.hiding {
+    animation: slidein-slide 100ms linear reverse;
+}
+
+.slidein.shown {
+    transform: translateY(0em);
+}
+
+.slidein .slidein-icon, .slidein-body {
+    display: flex;
+    flex-flow: column;
+    align-content: center;
+    justify-content: center;
+    text-align: center;
+    vertical-align: middle;
+}
+
+.slidein.slidein-success {
+    background: #55e11e linear-gradient(180deg, #67de38, #55e11e) repeat-x;
+}
+.slidein.slidein-danger {
+    background: #e1251c linear-gradient(180deg, #de3e37, #e1251c) repeat-x;
+    color: #ffffff;
+}
+.slidein.slidein-warning {
+    background: #fff339 linear-gradient(180deg, #ded649, #e1d732) repeat-x;
+}
+.slidein.slidein-info {
+    background: #3db7ff linear-gradient(180deg, #50a3de, #3a9ce1) repeat-x;
+    color: #fff;
+}
+
+.slidein .slidein-icon {
+    flex: 0 1 2em;
+}
+
+.slidein .slidein-body {
+    flex: 1 0 27em;
+    margin-left: -2em; /* compensate for .slidein-icon positioning so that the `text-align: center;` is true center */
+}
+
+.slidein .close-button {
+    display: block;
+    position: absolute;
+    right: 1em;
+    cursor: pointer;
+    text-shadow: 0 1px 2px #414141;
+}
+
+.slidein p {
+    margin: 0;
+    padding: 0;
+}
+
+@media (max-width: 768px) {
+    .slidein {
+        width: 97vw;
+        left: 1vw;
+    }
+}

--- a/resources/public/SLIDEIN.js
+++ b/resources/public/SLIDEIN.js
@@ -1,0 +1,119 @@
+window.SLIDEIN = window.SLIDEIN || (() => {
+  const SLIDEIN_TYPES = Object.freeze({
+    SUCCESS: 'success',
+    DANGER: 'danger',
+    WARNING: 'warning',
+    INFO: 'info',
+  });
+
+  { // ensure our fa-times is loaded into dom at least once so that the font is fetched and loaded by the browser. Fixes the close button not displaying on network drop.
+    const icon = crel('div', {'style': 'transform: translateX(-99999em);'}, crel('i', {'class': 'fas fa-times'}));
+    crel(document.body, icon);
+    setTimeout(() => icon.remove(), 5);
+  }
+
+  /**
+   * A slidein instance.
+   *
+   * @param content {string|HTMLElement} The slidein text.
+   * @param [icon=''] {string} The slidein's icon. Appended to `i.fas.fa-`, so an icon of "`check`" becomes `i.fas.fa-check`
+   * @param [type='dark'] {string} The type of slidein. Used for contextual styles, e.g. background color.
+   * @param [closeable=true]
+   * @constructor
+   */
+  function Slidein(content, icon = '', type = SLIDEIN_TYPES.INFO, closeable = true) {
+    if (!content || !((typeof content === 'string' && content.trim().length > 0) || content instanceof HTMLElement)) throw new Error("Invalid argument: text");
+    this.content = content;
+    this.closeable = closeable === true;
+    this.icon = icon || false;
+    this.type = type || SLIDEIN_TYPES.DARK;
+    this._dom = _buildSlideinDom(this);
+    this._delayClose = 0;
+    this.show = () => {
+      if (!this._dom) this._dom = _buildSlideinDom(this);
+      this._dom.removeEventListener('animationend', showingHandler);
+      this._dom.remove();
+      this._dom.classList.remove('shown', 'showing');
+      this._dom.removeEventListener('animationend', showingHandler);
+      this._dom.removeEventListener('animationend', hidingHandler);
+      requestAnimationFrame(() => {
+        this._dom.addEventListener('animationend', showingHandler);
+        document.body.appendChild(this._dom);
+        this._dom.classList.add('showing');
+      });
+      return this;
+    };
+    this.hide = () => {
+      this._dom.removeEventListener('animationend', showingHandler);
+      this._dom.removeEventListener('animationend', hidingHandler);
+      this._dom.classList.remove('showing');
+      requestAnimationFrame(() => {
+        this._dom.addEventListener('animationend', hidingHandler);
+        this._dom.classList.add('hiding');
+      });
+      return this;
+    };
+    this.closeAfter = (ms) => {
+      if (this._delayClose !== 0) clearTimeout(this._delayClose);
+      this._delayClose = setTimeout(() => this.hide(), ms);
+      return this;
+    };
+  }
+
+  function showingHandler() {
+    this.removeEventListener('animationend', showingHandler);
+    this.classList.add('shown');
+    this.classList.remove('showing');
+  }
+
+  function hidingHandler() {
+    if (this._delayClose !== 0) {
+      clearTimeout(this._delayClose);
+      this._delayClose = 0;
+    }
+    this.removeEventListener('animationend', hidingHandler);
+    this.classList.remove('shown', 'showing', 'hiding');
+    this.remove();
+  }
+
+  function _buildSlideinDom(slidein) {
+    const _class = (() => {
+      switch (slidein.type.toLowerCase().trim()) {
+        case SLIDEIN_TYPES.SUCCESS: {
+          return `slidein-${SLIDEIN_TYPES.SUCCESS}`;
+        }
+        case SLIDEIN_TYPES.DANGER: {
+          return `slidein-${SLIDEIN_TYPES.DANGER}`;
+        }
+        case SLIDEIN_TYPES.WARNING: {
+          return `slidein-${SLIDEIN_TYPES.WARNING}`;
+        }
+        case SLIDEIN_TYPES.INFO:
+        default: {
+          return `slidein-${SLIDEIN_TYPES.INFO}`;
+        }
+      }
+    })();
+    const _close = crel('i', {'class': 'fas fa-times close-button'});
+    const _dom = crel('div', {'class': `slidein ${_class}`, 'data-icon': slidein.icon, 'data-type': slidein.type, 'data-closeable': slidein.closeable},
+      crel('div', {'class': 'slidein-icon'}, !slidein.icon ? null : crel('i', {'class': `fas fa-${slidein.icon}`})),
+      crel('div', {'class': 'slidein-body'},
+        slidein.content instanceof HTMLElement ? slidein.content : crel('p', slidein.content),
+        slidein.closeable ? _close : null
+      )
+    );
+
+    _close.addEventListener('click', function() {
+      if (this && this.closest && this.closest('.slidein')) {
+        slidein.hide();
+      }
+    });
+
+    return _dom;
+  }
+
+  return {
+    Slidein,
+    SLIDEIN_TYPES,
+  };
+})();

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -19,6 +19,7 @@
     <link rel="stylesheet" href="jquery.modal.min.css">
     <link rel="stylesheet" href="fontawesome-all.min.css">
     <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="SLIDEIN.css">
     <link rel="icon" href="/favicon.ico" type="image/x-icon">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/interact.js/1.2.8/interact.min.js"></script>

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -29,6 +29,7 @@
     <script src="twemoji.min.js"></script>
     <script src="emojiDB.min.js"></script>
     <script src="jquery.modal.min.js"></script>
+    <script src="SLIDEIN.js"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0"/>
     <meta name="theme-color">
 

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -2903,7 +2903,7 @@ window.App = (function () {
                         ), {closeExisting: false});
                     });
                     socket.on('received_report', (data) => {
-                        new slidein.Slidein(`A new ${data.report_type.toLowerCase()} report has been received.`, 'info-circle').show().closeAfter(3000);
+                        new SLIDEIN.Slidein(`A new ${data.report_type.toLowerCase()} report has been received.`, 'info-circle').show().closeAfter(3000);
                     });
 
                     var useMono = ls.get("monospace_lookup");
@@ -6236,127 +6236,7 @@ window.App = (function () {
                         elem[0].remove();
                 }
             };
-        })(),
-        slidein = (() => {
-            let self = {};
-
-            const SLIDEIN_TYPES = Object.freeze({
-                SUCCESS: 'success',
-                DANGER: 'danger',
-                WARNING: 'warning',
-                INFO: 'info',
-            });
-
-            { // ensure our fa-times is loaded into dom at least once so that the font is fetched and loaded by the browser. Fixes the close button not displaying on network drop.
-                const icon = crel('div', {'style': 'transform: translateX(-99999em);'}, crel('i', {'class': 'fas fa-times'}));
-                crel(document.body, icon);
-                setTimeout(() => icon.remove(), 5);
-            }
-
-            /**
-             * A slidein instance.
-             *
-             * @param content {string|HTMLElement} The slidein text.
-             * @param [icon=''] {string} The slidein's icon. Appended to `i.fas.fa-`, so an icon of "`check`" becomes `i.fas.fa-check`
-             * @param [type='dark'] {string} The type of slidein. Used for contextual styles, e.g. background color.
-             * @param [closeable=true]
-             * @constructor
-             */
-            function Slidein(content, icon = '', type = SLIDEIN_TYPES.INFO, closeable = true) {
-                if (!content || !((typeof content === 'string' && content.trim().length > 0) || content instanceof HTMLElement)) throw new Error("Invalid argument: text");
-                this.content = content;
-                this.closeable = closeable === true;
-                this.icon = icon || false;
-                this.type = type || SLIDEIN_TYPES.DARK;
-                this._dom = _buildSlideinDom(this);
-                this._delayClose = 0;
-                this.show = () => {
-                    if (!this._dom) this._dom = _buildSlideinDom(this);
-                    this._dom.removeEventListener('animationend', showingHandler);
-                    this._dom.remove();
-                    this._dom.classList.remove('shown', 'showing');
-                    this._dom.removeEventListener('animationend', showingHandler);
-                    this._dom.removeEventListener('animationend', hidingHandler);
-                    requestAnimationFrame(() => {
-                        this._dom.addEventListener('animationend', showingHandler);
-                        document.body.appendChild(this._dom);
-                        this._dom.classList.add('showing');
-                    });
-                    return this;
-                };
-                this.hide = () => {
-                    this._dom.removeEventListener('animationend', showingHandler);
-                    this._dom.removeEventListener('animationend', hidingHandler);
-                    this._dom.classList.remove('showing');
-                    requestAnimationFrame(() => {
-                        this._dom.addEventListener('animationend', hidingHandler);
-                        this._dom.classList.add('hiding');
-                    });
-                    return this;
-                };
-                this.closeAfter = (ms) => {
-                    if (this._delayClose !== 0) clearTimeout(this._delayClose);
-                    this._delayClose = setTimeout(() => this.hide(), ms);
-                    return this;
-                };
-            }
-
-            function showingHandler() {
-                this.removeEventListener('animationend', showingHandler);
-                this.classList.add('shown');
-                this.classList.remove('showing');
-            }
-
-            function hidingHandler() {
-                if (this._delayClose !== 0) {
-                    clearTimeout(this._delayClose);
-                    this._delayClose = 0;
-                }
-                this.removeEventListener('animationend', hidingHandler);
-                this.classList.remove('shown', 'showing', 'hiding');
-                this.remove();
-            }
-
-            function _buildSlideinDom(slidein) {
-                const _class = (() => {
-                    switch(slidein.type.toLowerCase().trim()) {
-                        case SLIDEIN_TYPES.SUCCESS: {
-                            return `slidein-${SLIDEIN_TYPES.SUCCESS}`;
-                        }
-                        case SLIDEIN_TYPES.DANGER: {
-                            return `slidein-${SLIDEIN_TYPES.DANGER}`;
-                        }
-                        case SLIDEIN_TYPES.WARNING: {
-                            return `slidein-${SLIDEIN_TYPES.WARNING}`;
-                        }
-                        case SLIDEIN_TYPES.INFO:
-                        default: {
-                            return `slidein-${SLIDEIN_TYPES.INFO}`;
-                        }
-                    }
-                })();
-                const _close = crel('i', {'class': 'fas fa-times close-button'});
-                const _dom = crel('div', {'class': `slidein ${_class}`, 'data-icon': slidein.icon, 'data-type': slidein.type, 'data-closeable': slidein.closeable},
-                    crel('div', {'class': 'slidein-icon'}, !slidein.icon ? null : crel('i', {'class': `fas fa-${slidein.icon}`})),
-                    crel('div', {'class': 'slidein-body'},
-                        slidein.content instanceof HTMLElement ? slidein.content : crel('p', slidein.content),
-                        slidein.closeable ? _close : null
-                    )
-                );
-
-                _close.addEventListener('click', function() {
-                    if (this && this.closest && this.closest('.slidein')) {
-                        slidein.hide();
-                    }
-                });
-
-                return _dom;
-            }
-            return {
-                Slidein,
-                SLIDEIN_TYPES,
-            };
-        })();
+        })()
     // init progress
     query.init();
     board.init();
@@ -6383,7 +6263,6 @@ window.App = (function () {
 
 
     window.TH = window.TH || TH;
-    window.Slidein = window.Slidein || slidein;
 
 
     return {
@@ -6438,6 +6317,5 @@ window.App = (function () {
         },
         chat,
         typeahead: chat.typeahead,
-        slidein,
     };
 })();

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -6239,10 +6239,6 @@ window.App = (function () {
         })(),
         slidein = (() => {
             let self = {};
-            /**
-             * @returns {string}
-             */
-            const r = () => `${Math.random() * 1e7 >> 0}-${Math.random() * 1e7 >> 0}-${Math.random() * 1e7 >> 0}-${Math.random() * 1e7 >> 0}`;
 
             const SLIDEIN_TYPES = Object.freeze({
                 SUCCESS: 'success',
@@ -6272,7 +6268,6 @@ window.App = (function () {
                 this.closeable = closeable === true;
                 this.icon = icon || false;
                 this.type = type || SLIDEIN_TYPES.DARK;
-                this.r = r();
                 this._dom = _buildSlideinDom(this);
                 this._delayClose = 0;
                 this.show = () => {

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -2902,6 +2902,9 @@ window.App = (function () {
                             crel('span', {'style': 'font-style: italic'}, `Sent from ${data.sender || '$Unknown'}`)
                         ), {closeExisting: false});
                     });
+                    socket.on('received_report', (data) => {
+                        new slidein.Slidein(`A new ${data.report_type.toLowerCase()} report has been received.`, 'info-circle').show().closeAfter(3000);
+                    });
 
                     var useMono = ls.get("monospace_lookup");
                     if (typeof useMono === 'undefined') {
@@ -6233,6 +6236,131 @@ window.App = (function () {
                         elem[0].remove();
                 }
             };
+        })(),
+        slidein = (() => {
+            let self = {};
+            /**
+             * @returns {string}
+             */
+            const r = () => `${Math.random() * 1e7 >> 0}-${Math.random() * 1e7 >> 0}-${Math.random() * 1e7 >> 0}-${Math.random() * 1e7 >> 0}`;
+
+            const SLIDEIN_TYPES = Object.freeze({
+                SUCCESS: 'success',
+                DANGER: 'danger',
+                WARNING: 'warning',
+                INFO: 'info',
+            });
+
+            { // ensure our fa-times is loaded into dom at least once so that the font is fetched and loaded by the browser. Fixes the close button not displaying on network drop.
+                const icon = crel('div', {'style': 'transform: translateX(-99999em);'}, crel('i', {'class': 'fas fa-times'}));
+                crel(document.body, icon);
+                setTimeout(() => icon.remove(), 5);
+            }
+
+            /**
+             * A slidein instance.
+             *
+             * @param content {string|HTMLElement} The slidein text.
+             * @param [icon=''] {string} The slidein's icon. Appended to `i.fas.fa-`, so an icon of "`check`" becomes `i.fas.fa-check`
+             * @param [type='dark'] {string} The type of slidein. Used for contextual styles, e.g. background color.
+             * @param [closeable=true]
+             * @constructor
+             */
+            function Slidein(content, icon = '', type = SLIDEIN_TYPES.INFO, closeable = true) {
+                if (!content || !((typeof content === 'string' && content.trim().length > 0) || content instanceof HTMLElement)) throw new Error("Invalid argument: text");
+                this.content = content;
+                this.closeable = closeable === true;
+                this.icon = icon || false;
+                this.type = type || SLIDEIN_TYPES.DARK;
+                this.r = r();
+                this._dom = _buildSlideinDom(this);
+                this._delayClose = 0;
+                this.show = () => {
+                    if (!this._dom) this._dom = _buildSlideinDom(this);
+                    this._dom.removeEventListener('animationend', showingHandler);
+                    this._dom.remove();
+                    this._dom.classList.remove('shown', 'showing');
+                    this._dom.removeEventListener('animationend', showingHandler);
+                    this._dom.removeEventListener('animationend', hidingHandler);
+                    requestAnimationFrame(() => {
+                        this._dom.addEventListener('animationend', showingHandler);
+                        document.body.appendChild(this._dom);
+                        this._dom.classList.add('showing');
+                    });
+                    return this;
+                };
+                this.hide = () => {
+                    this._dom.removeEventListener('animationend', showingHandler);
+                    this._dom.removeEventListener('animationend', hidingHandler);
+                    this._dom.classList.remove('showing');
+                    requestAnimationFrame(() => {
+                        this._dom.addEventListener('animationend', hidingHandler);
+                        this._dom.classList.add('hiding');
+                    });
+                    return this;
+                };
+                this.closeAfter = (ms) => {
+                    if (this._delayClose !== 0) clearTimeout(this._delayClose);
+                    this._delayClose = setTimeout(() => this.hide(), ms);
+                    return this;
+                };
+            }
+
+            function showingHandler() {
+                this.removeEventListener('animationend', showingHandler);
+                this.classList.add('shown');
+                this.classList.remove('showing');
+            }
+
+            function hidingHandler() {
+                if (this._delayClose !== 0) {
+                    clearTimeout(this._delayClose);
+                    this._delayClose = 0;
+                }
+                this.removeEventListener('animationend', hidingHandler);
+                this.classList.remove('shown', 'showing', 'hiding');
+                this.remove();
+            }
+
+            function _buildSlideinDom(slidein) {
+                const _class = (() => {
+                    switch(slidein.type.toLowerCase().trim()) {
+                        case SLIDEIN_TYPES.SUCCESS: {
+                            return `slidein-${SLIDEIN_TYPES.SUCCESS}`;
+                        }
+                        case SLIDEIN_TYPES.DANGER: {
+                            return `slidein-${SLIDEIN_TYPES.DANGER}`;
+                        }
+                        case SLIDEIN_TYPES.WARNING: {
+                            return `slidein-${SLIDEIN_TYPES.WARNING}`;
+                        }
+                        case SLIDEIN_TYPES.INFO:
+                        default: {
+                            return `slidein-${SLIDEIN_TYPES.INFO}`;
+                        }
+                    }
+                })();
+                const _close = crel('i', {'class': 'fas fa-times close-button'});
+                const _dom = crel('div', {'class': `slidein ${_class}`, 'data-icon': slidein.icon, 'data-type': slidein.type, 'data-closeable': slidein.closeable},
+                    crel('div', {'class': 'slidein-icon'}, !slidein.icon ? null : crel('i', {'class': `fas fa-${slidein.icon}`})),
+                    crel('div', {'class': 'slidein-body'},
+                        slidein.content instanceof HTMLElement ? slidein.content : crel('p', slidein.content),
+                        slidein.closeable ? _close : null
+                    )
+                );
+
+                _close.addEventListener('click', function() {
+                    if (this && this.closest && this.closest('.slidein')) {
+                        slidein.hide();
+                    }
+                });
+
+                return _dom;
+            }
+            return {
+                Slidein,
+                SLIDEIN_TYPES,
+            };
         })();
     // init progress
     query.init();
@@ -6257,6 +6385,10 @@ window.App = (function () {
     chromeOffsetWorkaround.init();
     // and here we finally go...
     board.start();
+
+
+    window.TH = window.TH || TH;
+    window.Slidein = window.Slidein || slidein;
 
 
     return {
@@ -6310,6 +6442,7 @@ window.App = (function () {
             ban.me(4);
         },
         chat,
-        typeahead: chat.typeahead
+        typeahead: chat.typeahead,
+        slidein,
     };
 })();

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -1972,94 +1972,6 @@ ul.chat-history, ul.chatban-history {
 }
 
 /*//////////////////////////*\
-| Slidein
-\*\\\\\\\\\\\\\\\\\\\\\\\\\\*/
-@keyframes slidein-slide {
-    0% {
-        transform: translateY(-2em);
-    }
-    100% {
-        transform: translateY(0em);
-    }
-}
-
-.slidein {
-    position: fixed;
-    width: 45em;
-    top: 0;
-    left: calc((100% / 2) - (45em / 2));
-    background-color: #333333;
-    display: flex;
-    flex-flow: row;
-    padding: .25em;
-    border-radius: 0 0 5px 5px;
-    height: 2em;
-    overflow: hidden;
-    user-select: none;
-    transform: translateY(-2em);
-    z-index: 30000;
-}
-
-.slidein.showing {
-    animation: slidein-slide 100ms linear;
-}
-
-.slidein.hiding {
-    animation: slidein-slide 100ms linear reverse;
-}
-
-.slidein.shown {
-    transform: translateY(0em);
-}
-
-.slidein .slidein-icon, .slidein-body {
-    display: flex;
-    flex-flow: column;
-    align-content: center;
-    justify-content: center;
-    text-align: center;
-    vertical-align: middle;
-}
-
-.slidein.slidein-success {
-    /*background: #87d212 linear-gradient(180deg, #92d12e, #87d212) repeat-x;*/
-    background: #55e11e linear-gradient(180deg, #67de38, #55e11e) repeat-x;
-}
-.slidein.slidein-danger {
-    background: #e1251c linear-gradient(180deg, #de3e37, #e1251c) repeat-x;
-    color: #ffffff;
-}
-.slidein.slidein-warning {
-    background: #fff339 linear-gradient(180deg, #ded649, #e1d732) repeat-x;
-}
-.slidein.slidein-info {
-    background: #3db7ff linear-gradient(180deg, #50a3de, #3a9ce1) repeat-x;
-    color: #fff;
-}
-
-.slidein .slidein-icon {
-    flex: 0 1 2em;
-}
-
-.slidein .slidein-body {
-    flex: 1 0 27em;
-    margin-left: -2em; /* compensate for .slidein-icon positioning so that the `text-align: center;` is true center */
-}
-
-.slidein .close-button {
-    display: block;
-    position: absolute;
-    right: 1em;
-    cursor: pointer;
-    text-shadow: 0 1px 2px #414141;
-}
-
-.slidein p {
-    margin: 0;
-    padding: 0;
-}
-
-/*//////////////////////////*\
 | Mobile Styles
 \*\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
@@ -2074,11 +1986,6 @@ ul.chat-history, ul.chatban-history {
 }
 
 @media (max-width: 768px) {
-    .slidein {
-        width: 97vw;
-        left: 1vw;
-    }
-
     .panel, .panel.half-width {
         max-width: 100% !important;
         width: 100% !important;

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -1972,6 +1972,94 @@ ul.chat-history, ul.chatban-history {
 }
 
 /*//////////////////////////*\
+| Slidein
+\*\\\\\\\\\\\\\\\\\\\\\\\\\\*/
+@keyframes slidein-slide {
+    0% {
+        transform: translateY(-2em);
+    }
+    100% {
+        transform: translateY(0em);
+    }
+}
+
+.slidein {
+    position: fixed;
+    width: 45em;
+    top: 0;
+    left: calc((100% / 2) - (45em / 2));
+    background-color: #333333;
+    display: flex;
+    flex-flow: row;
+    padding: .25em;
+    border-radius: 0 0 5px 5px;
+    height: 2em;
+    overflow: hidden;
+    user-select: none;
+    transform: translateY(-2em);
+    z-index: 30000;
+}
+
+.slidein.showing {
+    animation: slidein-slide 100ms linear;
+}
+
+.slidein.hiding {
+    animation: slidein-slide 100ms linear reverse;
+}
+
+.slidein.shown {
+    transform: translateY(0em);
+}
+
+.slidein .slidein-icon, .slidein-body {
+    display: flex;
+    flex-flow: column;
+    align-content: center;
+    justify-content: center;
+    text-align: center;
+    vertical-align: middle;
+}
+
+.slidein.slidein-success {
+    /*background: #87d212 linear-gradient(180deg, #92d12e, #87d212) repeat-x;*/
+    background: #55e11e linear-gradient(180deg, #67de38, #55e11e) repeat-x;
+}
+.slidein.slidein-danger {
+    background: #e1251c linear-gradient(180deg, #de3e37, #e1251c) repeat-x;
+    color: #ffffff;
+}
+.slidein.slidein-warning {
+    background: #fff339 linear-gradient(180deg, #ded649, #e1d732) repeat-x;
+}
+.slidein.slidein-info {
+    background: #3db7ff linear-gradient(180deg, #50a3de, #3a9ce1) repeat-x;
+    color: #fff;
+}
+
+.slidein .slidein-icon {
+    flex: 0 1 2em;
+}
+
+.slidein .slidein-body {
+    flex: 1 0 27em;
+    margin-left: -2em; /* compensate for .slidein-icon positioning so that the `text-align: center;` is true center */
+}
+
+.slidein .close-button {
+    display: block;
+    position: absolute;
+    right: 1em;
+    cursor: pointer;
+    text-shadow: 0 1px 2px #414141;
+}
+
+.slidein p {
+    margin: 0;
+    padding: 0;
+}
+
+/*//////////////////////////*\
 | Mobile Styles
 \*\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
@@ -1986,6 +2074,11 @@ ul.chat-history, ul.chatban-history {
 }
 
 @media (max-width: 768px) {
+    .slidein {
+        width: 97vw;
+        left: 1vw;
+    }
+
     .panel, .panel.half-width {
         max-width: 100% !important;
         width: 100% !important;

--- a/src/main/java/space/pxls/data/Database.java
+++ b/src/main/java/space/pxls/data/Database.java
@@ -934,7 +934,9 @@ public class Database {
                 .bind("x", x)
                 .bind("y", y)
                 .bind("message", message)
-                .execute());
+                .executeAndReturnGeneratedKeys("id")
+                .mapTo(Integer.TYPE)
+                .first());
     }
 
     /**
@@ -942,11 +944,13 @@ public class Database {
      * @param reported The banned {@link User}'s ID.
      * @param message The report message.
      */
-    public void insertServerReport(int reported, String message) {
-        jdbi.useHandle(handle -> handle.createUpdate("INSERT INTO reports (who, pixel_id, x, y, message, reported, time) VALUES (0, 0, 0, 0, :message, :reported, (SELECT EXTRACT(EPOCH FROM NOW())))")
+    public Integer insertServerReport(int reported, String message) {
+        return jdbi.withHandle(handle -> handle.createUpdate("INSERT INTO reports (who, pixel_id, x, y, message, reported, time) VALUES (0, 0, 0, 0, :message, :reported, (SELECT EXTRACT(EPOCH FROM NOW())))")
                 .bind("message", message)
                 .bind("reported", reported)
-                .execute());
+                .executeAndReturnGeneratedKeys("id")
+                .mapTo(Integer.TYPE)
+                .first());
     }
 
     /**
@@ -1206,7 +1210,9 @@ public class Database {
                 .bind("target", targetID)
                 .bind("initiator", initiatorID)
                 .bind("report_message", reportMessage)
-                .execute());
+                .executeAndReturnGeneratedKeys("id")
+                .mapTo(Integer.TYPE)
+                .first());
     }
 
     /**

--- a/src/main/java/space/pxls/server/WebHandler.java
+++ b/src/main/java/space/pxls/server/WebHandler.java
@@ -269,7 +269,9 @@ public class WebHandler {
 
         String _reportMessage = reportMessage.getValue().trim();
         if (_reportMessage.length() > 2048) _reportMessage = _reportMessage.substring(0, 2048);
-        App.getDatabase().insertChatReport(chatMessage.nonce, chatMessage.author_uid, user.getId(), _reportMessage);
+        Integer rid = App.getDatabase().insertChatReport(chatMessage.nonce, chatMessage.author_uid, user.getId(), _reportMessage);
+        if (rid != null)
+            App.getServer().broadcastToStaff(new ServerReceivedReport(rid, ServerReceivedReport.REPORT_TYPE_CHAT));
 
         exchange.setStatusCode(200);
         exchange.getResponseSender().send("{}");
@@ -1203,7 +1205,9 @@ public class WebHandler {
             exchange.endExchange();
             return;
         }
-        App.getDatabase().insertReport(user.getId(), pxl.userId, id, x, y, msgq.getValue());
+        Integer rid = App.getDatabase().insertReport(user.getId(), pxl.userId, id, x, y, msgq.getValue());
+        if (rid != null)
+            App.getServer().broadcastToStaff(new ServerReceivedReport(rid, ServerReceivedReport.REPORT_TYPE_CANVAS));
         exchange.setStatusCode(200);
     }
 

--- a/src/main/java/space/pxls/server/packets/socket/ServerReceivedReport.java
+++ b/src/main/java/space/pxls/server/packets/socket/ServerReceivedReport.java
@@ -1,0 +1,15 @@
+package space.pxls.server.packets.socket;
+
+public class ServerReceivedReport {
+    public static final String REPORT_TYPE_CHAT = "CHAT";
+    public static final String REPORT_TYPE_CANVAS = "CANVAS";
+
+    private Integer report_id;
+    private String type = "received_report";
+    private String report_type;
+
+    public ServerReceivedReport(Integer report_id, String report_type) {
+        this.report_id = report_id;
+        this.report_type = report_type;
+    }
+}

--- a/src/main/java/space/pxls/tasks/UserAuthedTask.java
+++ b/src/main/java/space/pxls/tasks/UserAuthedTask.java
@@ -2,6 +2,7 @@ package space.pxls.tasks;
 
 import io.undertow.websockets.core.WebSocketChannel;
 import space.pxls.App;
+import space.pxls.server.packets.socket.ServerReceivedReport;
 import space.pxls.user.User;
 
 import java.util.List;
@@ -39,7 +40,9 @@ public class UserAuthedTask implements Runnable {
                         System.err.printf("    ID from database (%d) resulted in a null user lookup (triggered by UserDupeIP task for %s (ID: %d))%n", uids.get(i), user.getName(), user.getId());
                     }
                 }
-                App.getDatabase().insertServerReport(user.getId(), toReport.toString());
+                Integer rid = App.getDatabase().insertServerReport(user.getId(), toReport.toString());
+                if (rid != null)
+                    App.getServer().broadcastToStaff(new ServerReceivedReport(rid, ServerReceivedReport.REPORT_TYPE_CANVAS));
                 App.getDatabase().setLastIPAlertFlag(user.getId(), true);
             }
         }


### PR DESCRIPTION
This PR introduces a set of UI elements and functions which give us the ability to pop sliding banners with optional auto-hide timeouts. They are currently only hooked up to show an alert when a canvas and/or chat report is received by the server to staff, however they will be used in the future to replace most "job done" modals. That is outside the scope of this PR though, and this PR is considered a blocking dependency for those.