### PR TITLE
Tweak modal close button styles

### DIFF
--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -6201,6 +6201,7 @@ window.App = (function () {
                         escapeClose: true,
                         clickClose: true,
                         showClose: true,
+                        closeText: '<i class="fas fa-times"></i>',
                     }, {removeOnClose: true}, opts);
                     if (!document.body.contains(modal)) {
                         document.body.appendChild(modal);

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -1926,6 +1926,23 @@ ul.chat-history, ul.chatban-history {
     outline: 0;
 }
 
+.modal a.close-modal {
+    position: absolute;
+    font-size: 1.25em;
+    top: 0;
+    right: 0;
+    background: #660000;
+    width: 1.5em;
+    height: 1.5em;
+    line-height: 1.5em;
+    text-align: center;
+    color: #eee;
+    text-decoration: none;
+    text-indent: 0;
+    border-radius: 0 6px 0 12px;
+    box-shadow: 1px 1px 5px #660000aa;
+}
+
 .modal .modal-footer {
     text-align: right;
 }


### PR DESCRIPTION
The modal close button was escaping its parent's boundaries and causing
issues for mobile users. The new close button now squishes into the top
right corner so that it is always accessible and doesn't overflow.