### PR TITLE
Make canvas lock stateful, expose setting

### DIFF
--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -235,36 +235,74 @@
             </header>
             <div class="pad-wrapper">
                 <div class="settingToggles">
-                    <label>Theme:
-                        <select id="themeSelect">
-                            <option value="-1" selected>Default</option>
-                        </select>
-                    </label>
-                    <label><input id="audiotoggle" type="checkbox"/>Mute sound</label>
-                    <label><input id="heatmaptoggle" type="checkbox"/>Turn on heatmap (toggle with <kbd>H</kbd>)</label>
-                    <label><input id="virginmaptoggle" type="checkbox"/>Turn on virginmap (toggle with <kbd>X</kbd>)</label>
-                    <button id="hvmapClear">Clear heatmap and virginmap</button> (hotkey: <kbd>O</kbd>)
-                    <label><input id="gridtoggle" type="checkbox"/>Turn on grid (toggle with <kbd>G</kbd>)</label>
-                    <label><input id="native-notification-toggle" type="checkbox"/>Enable pixel available notification</label>
-                    <label><input id="stickyColorToggle" type="checkbox"/>Keep color selected</label>
-                    <label><input id="monospaceToggle" type="checkbox"/>Toggle monospace font for lookups</label>
-                    <label><input id="increasedZoomToggle" type="checkbox"/>Allow zoom values greater than 50x</label>
-                    <label><input id="scrollSwitchToggle" type="checkbox"/>Enable scrolling on the palette to switch colors</label>
-                    <label style="text-indent:1em"><input id="scrollDirectionToggle" type="checkbox"/>Invert scroll direction</label>
-                    <label><input id="showReticuleToggle" type="checkbox"/>Show Reticule</label>
-                    <label><input id="showCursorToggle" type="checkbox"/>Show Cursor</label>
-                    <label><input id="cbEnableMiddleMouseSelect" type="checkbox"> Enable middle mouse button selecting color from board</label>
-                    <label><input id="cbNumberedPalette" type="checkbox"> Add numbers to palette entries</label>
-                    <label>Heatmap Background Opacity: <input type="range" min="0" max="1" step="0.01" id="heatmap-opacity"></label>
-                    <label>Virginmap Background Opacity: <input type="range" min="0" max="1" step="0.01" id="virginmap-opacity"></label>
-                    <label>
-                        Snapshot (hotkey: <kbd>P</kbd>) image format
-                        <select id="snapshotImageFormat">
-                            <option value="image/png" selected>PNG</option>
-                            <option value="image/jpeg">JPEG</option>
-                            <option value="image/webp">WEBP (Chrome only)</option>
-                        </select>
-                    </label>
+                    <div class="lblwrap">
+                        <label>Theme:
+                            <select id="themeSelect">
+                                <option value="-1" selected>Default</option>
+                            </select>
+                        </label>
+                    </div>
+                    <div class="d-block">
+                        <label><input id="audiotoggle" type="checkbox"/>Mute sound</label>
+                    </div>
+                    <div class="d-block">
+                        <label><input id="heatmaptoggle" type="checkbox"/>Turn on heatmap (toggle with <kbd>H</kbd>)</label>
+                    </div>
+                    <div class="d-block">
+                        <label><input id="virginmaptoggle" type="checkbox"/>Turn on virginmap (toggle with <kbd>X</kbd>)</label>
+                    </div>
+                    <div class="d-block">
+                        <button id="hvmapClear">Clear heatmap and virginmap</button> (hotkey: <kbd>O</kbd>)
+                    </div>
+                    <div class="d-block">
+                        <label><input id="gridtoggle" type="checkbox"/>Turn on grid (toggle with <kbd>G</kbd>)</label>
+                    </div>
+                    <div class="d-block">
+                        <label><input id="native-notification-toggle" type="checkbox"/>Enable pixel available notification</label>
+                    </div>
+                    <div class="d-block">
+                        <label><input id="stickyColorToggle" type="checkbox"/>Keep color selected</label>
+                    </div>
+                    <div class="d-block">
+                        <label><input id="monospaceToggle" type="checkbox"/>Toggle monospace font for lookups</label>
+                    </div>
+                    <div class="d-block">
+                        <label><input id="increasedZoomToggle" type="checkbox"/>Allow zoom values greater than 50x</label>
+                    </div>
+                    <div class="d-block">
+                        <label><input id="scrollSwitchToggle" type="checkbox"/>Enable scrolling on the palette to switch colors</label>
+                    </div>
+                    <div class="d-block">
+                        <label style="text-indent:1em"><input id="scrollDirectionToggle" type="checkbox"/>Invert scroll direction</label>
+                    </div>
+                    <div class="d-block">
+                        <label><input id="showReticuleToggle" type="checkbox"/>Show Reticule</label>
+                    </div>
+                    <div class="d-block">
+                        <label><input id="showCursorToggle" type="checkbox"/>Show Cursor</label>
+                    </div>
+                    <div class="d-block">
+                        <label><input id="cbEnableMiddleMouseSelect" type="checkbox"> Enable middle mouse button selecting color from board</label>
+                    </div>
+                    <div class="d-block">
+                        <label><input id="cbNumberedPalette" type="checkbox"> Add numbers to palette entries</label>
+                    </div>
+                    <div class="d-block">
+                        <label>Heatmap Background Opacity: <input type="range" min="0" max="1" step="0.01" id="heatmap-opacity"></label>
+                    </div>
+                    <div class="d-block">
+                        <label>Virginmap Background Opacity: <input type="range" min="0" max="1" step="0.01" id="virginmap-opacity"></label>
+                    </div>
+                    <div class="d-block">
+                        <label>
+                            Snapshot (hotkey: <kbd>P</kbd>) image format
+                            <select id="snapshotImageFormat">
+                                <option value="image/png" selected>PNG</option>
+                                <option value="image/jpeg">JPEG</option>
+                                <option value="image/webp">WEBP (Chrome only)</option>
+                            </select>
+                        </label>
+                    </div>
                     <div>
                         Bubble position
                         <span class="text-orange mobile-only">(not available for mobile/low resolution displays)</span>
@@ -307,11 +345,11 @@
                     <label><input type="checkbox" id="template-use"> Use template</label>
                 </div>
                 <p>Hold down <kbd>Ctrl</kbd> (or <kbd>Option</kbd> on mac) to drag the template around</p>
-                <div class="longTextInputWrapper">
+                <div class="longTextInputWrapper d-block">
                     <label>Title:</label>
                     <input type="text" id="template-title">
                 </div>
-                <div class="longTextInputWrapper">
+                <div class="longTextInputWrapper d-block">
                     <label>URL:</label>
                     <input type="text" id="template-url">
                     <span id="template-image-error-warning" class="text-red">There was an error getting the image</span>

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -257,7 +257,7 @@
                     <div class="d-block">
                         <label><input id="gridtoggle" type="checkbox"/>Turn on grid (toggle with <kbd>G</kbd>)</label>
                     </div>
-                    <div class="d-block"><label><input type="checkbox" id="lockCanvasToggle"></label>Lock the canvas (disallow canvas drag/zoom with mouse/fingers)</div>
+                    <div class="d-block"><label><input type="checkbox" id="lockCanvasToggle"> Lock the canvas (disallow canvas drag/zoom with mouse/fingers)</label></div>
                     <div class="d-block">
                         <label><input id="native-notification-toggle" type="checkbox"/>Enable pixel available notification</label>
                     </div>

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -257,6 +257,7 @@
                     <div class="d-block">
                         <label><input id="gridtoggle" type="checkbox"/>Turn on grid (toggle with <kbd>G</kbd>)</label>
                     </div>
+                    <div class="d-block"><label><input type="checkbox" id="lockCanvasToggle"></label>Lock the canvas (disallow canvas drag/zoom with mouse/fingers)</div>
                     <div class="d-block">
                         <label><input id="native-notification-toggle" type="checkbox"/>Enable pixel available notification</label>
                     </div>

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -861,9 +861,8 @@ window.App = (function () {
                             case 76:            // L
                             case "l":
                             case "L":
-                                self.allowDrag = !self.allowDrag;
-                                if (self.allowDrag) coords.lockIcon.fadeOut(200);
-                                else coords.lockIcon.fadeIn(200);
+                                board.setAllowDrag(!self.allowDrag);
+                                $('#lockCanvasToggle').prop('checked', !self.allowDrag);
                                 break;
                             case "KeyR":
                             case 82:            // R
@@ -1450,6 +1449,14 @@ window.App = (function () {
                 refresh: self.refresh,
                 updateViewport: self.updateViewport,
                 allowDrag: self.allowDrag,
+                setAllowDrag: (allowDrag) => {
+                    self.allowDrag = allowDrag === true;
+                    if (self.allowDrag)
+                        coords.lockIcon.fadeOut(200);
+                    else
+                        coords.lockIcon.fadeIn(200);
+                    ls.set('canvas.unlocked', self.allowDrag);
+                },
                 validateCoordinates: self.validateCoordinates
             };
         })(),
@@ -2966,6 +2973,11 @@ window.App = (function () {
                             place.setNumberedPaletteEnabled(this.checked === true);
                         });
 
+                    board.setAllowDrag(ls.get('canvas.unlocked') !== false); // false check for new connections
+                    $('#lockCanvasToggle').prop('checked', board.allowDrag)
+                        .change(function() {
+                            board.setAllowDrag(this.checked === false); // updates localStorage for us
+                        });
 
                     const numOrDefault = (n, def) => isNaN(n) ? def : n;
                     const colorBrightnessLevel = numOrDefault(parseFloat(ls.get("colorBrightness")), 1);

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -760,10 +760,10 @@ window.App = (function () {
                     if (!isNaN(data.scale)) self.scale = parseFloat(data.scale);
                     self.centerOn(data.x, data.y);
                 },
-                centerOn: function (x, y) {
+                centerOn: function (x, y, ignoreLock=false) {
                     if (x != null) self.pan.x = (self.width / 2 - x);
                     if (y != null) self.pan.y = (self.height / 2 - y);
-                    self.update();
+                    self.update(null, ignoreLock);
                 },
                 replayBuffer: function () {
                     $.map(self.pixelBuffer, function (p) {
@@ -1134,7 +1134,7 @@ window.App = (function () {
                         var cx = query.get("x") || self.width / 2,
                             cy = query.get("y") || self.height / 2;
                         self.scale = query.get("scale") || self.scale;
-                        self.centerOn(cx, cy);
+                        self.centerOn(cx, cy, true);
                         socket.init();
                         binary_ajax("/boarddata" + "?_" + (new Date()).getTime(), self.draw, socket.reconnect);
 
@@ -1186,7 +1186,7 @@ window.App = (function () {
                         socket.reconnect();
                     });
                 },
-                update: function (optional) {
+                update: function (optional, ignoreCanvasLock=false) {
                     self.pan.x = Math.min(self.width / 2, Math.max(-self.width / 2, self.pan.x));
                     self.pan.y = Math.min(self.height / 2, Math.max(-self.height / 2, self.pan.y));
                     query.set({
@@ -1261,7 +1261,7 @@ window.App = (function () {
                     } else {
                         self.elements.board.addClass("pixelate");
                     }
-                    if (self.allowDrag || (!self.allowDrag && self.pannedWithKeys)) {
+                    if (ignoreCanvasLock || self.allowDrag || (!self.allowDrag && self.pannedWithKeys)) {
                         self.elements.mover.css({
                             width: self.width,
                             height: self.height,

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -4506,18 +4506,17 @@ window.App = (function () {
 
                     crel(body,
                         crel('h3', {'class': 'chat-settings-title'}, 'Chat Settings'),
-                        crel('div', {'class': 'd-block'}, lbl24hTimestamps),
-                        crel('div', {'class': 'd-block'}, lblPixelPlaceBadges),
-                        crel('div', {'class': 'd-block'}, lblPings),
-                        crel('div', {'class': 'd-block'}, lblPingAudio),
-                        crel('div', {'class': 'd-block'}, lblPingAudioVol),
-                        crel('div', {'class': 'd-block'}, lblBanner),
-                        crel('div', {'class': 'd-block'}, lblTemplateTitles),
-                        crel('div', {'class': 'd-block'}, lblFontSize),
-                        crel('div', {'class': 'd-block'}, lblInternalAction),
-                        crel('div', {'class': 'd-block'}, lblUsernameColor),
-                        crel('div', {'class': 'd-block'}, lblIgnores),
-                        crel('div', {'class': 'd-block'}, lblIgnoresFeedback)
+                        [
+                            lbl24hTimestamps,
+                            lblPixelPlaceBadges,
+                            lblPings,
+                            lblPingAudio,
+                            lblPingAudioVol,
+                            lblBanner,
+                            lblFontSize,
+                            lblUsernameColor,
+                            lblIgnoresFeedback
+                        ].map(x => crel('div', {'class': 'd-block'}, x))
                     )
                     modal.show(modal.buildDom(
                         crel('h2', {'class': 'modal-title'}, 'Chat Settings'),

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -4345,54 +4345,54 @@ window.App = (function () {
                     let body = crel('div', {'class': 'chat-settings-wrapper'});
 
                     let _cb24hTimestamps = crel('input', {'type': 'checkbox'});
-                    let lbl24hTimestamps = crel('label', {'style': 'display: block;'}, _cb24hTimestamps, '24 Hour Timestamps');
+                    let lbl24hTimestamps = crel('label', _cb24hTimestamps, '24 Hour Timestamps');
 
                     let _cbPixelPlaceBadges = crel('input', {'type': 'checkbox'});
-                    let lblPixelPlaceBadges = crel('label', {'style': 'display: block;'}, _cbPixelPlaceBadges, 'Show pixel-placed badges');
+                    let lblPixelPlaceBadges = crel('label', _cbPixelPlaceBadges, 'Show pixel-placed badges');
 
                     let _cbPings = crel('input', {'type': 'checkbox'});
-                    let lblPings = crel('label', {'style': 'display: block;'}, _cbPings, 'Enable pings');
+                    let lblPings = crel('label', _cbPings, 'Enable pings');
 
                     let _cbPingAudio = crel('select', {},
                         crel('option', {'value': 'off'}, 'Off'),
                         crel('option', {'value': 'discrete'}, 'Only when necessary'),
                         crel('option', {'value': 'always'}, 'Always')
                     );
-                    let lblPingAudio = crel('div', {'style': 'display: block;'},
-                        'Play sound on ping',
+                    let lblPingAudio = crel('label',
+                        'Play sound on ping: ',
                         _cbPingAudio
                     );
 
                     let _rgPingAudioVol = crel('input', {'type': 'range', min: 0, max: 100});
                     let _txtPingAudioVol = crel('span');
-                    let lblPingAudioVol = crel('label', {'style': 'display: block;'},
-                        'Ping sound volume',
+                    let lblPingAudioVol = crel('label',
+                        'Ping sound volume: ',
                         _rgPingAudioVol,
                         _txtPingAudioVol
                     );
 
                     let _cbBanner = crel('input', {'type': 'checkbox'});
-                    let lblBanner = crel('label', {'style': 'display: block;'}, _cbBanner, 'Enable the rotating banner under chat');
+                    let lblBanner = crel('label', _cbBanner, 'Enable the rotating banner under chat');
 
                     let _cbTemplateTitles = crel('input', {'type': 'checkbox'});
-                    let lblTemplateTitles = crel('label', {'style': 'display: block;'}, _cbTemplateTitles, 'Replace template titles with URLs in chat where applicable');
+                    let lblTemplateTitles = crel('label', _cbTemplateTitles, 'Replace template titles with URLs in chat where applicable');
 
                     let _txtFontSize = crel('input', {'type': 'number', 'min': '1', 'max': '72'});
                     let _btnFontSizeConfirm = crel('button', {'class': 'buton'}, crel('i', {'class': 'fas fa-check'}));
-                    let lblFontSize = crel('label', {'style': 'display: block;'}, 'Font Size: ', _txtFontSize, _btnFontSizeConfirm);
+                    let lblFontSize = crel('label', 'Font Size: ', _txtFontSize, _btnFontSizeConfirm);
 
                     let _selInternalClick = crel('select',
                         Object.values(self.TEMPLATE_ACTIONS).map(action =>
                             crel('option', {'value': action.id}, action.pretty)
                         )
                     );
-                    let lblInternalAction = crel('label', {'style': 'display: block;'}, 'Default internal link action click: ', _selInternalClick);
+                    let lblInternalAction = crel('label', 'Default internal link action click: ', _selInternalClick);
 
                     let _selUsernameColor = crel('select', {'class': 'username-color-picker'},
                         user.isStaff() ? crel('option', {value: -1, 'class': 'rainbow'}, 'rainbow') : null,
                         place.getPalette().map((x, i) => crel('option', {value: i, 'data-idx': i, style: `background-color: ${x}`}, x))
                     );
-                    let lblUsernameColor = crel('label', {'style': 'display: block;'}, 'Username Color: ', _selUsernameColor);
+                    let lblUsernameColor = crel('label', 'Username Color: ', _selUsernameColor);
 
                     let _selIgnores = crel('select', {'class': 'user-ignores', 'style': 'font-family: monospace; padding: 5px; border-radius: 5px;'},
                         self.getIgnores().sort((a, b) => a.toLocaleLowerCase().localeCompare(b.toLocaleLowerCase())).map(x =>
@@ -4494,18 +4494,18 @@ window.App = (function () {
 
                     crel(body,
                         crel('h3', {'class': 'chat-settings-title'}, 'Chat Settings'),
-                        lbl24hTimestamps,
-                        lblPixelPlaceBadges,
-                        lblPings,
-                        lblPingAudio,
-                        lblPingAudioVol,
-                        lblBanner,
-                        lblTemplateTitles,
-                        lblFontSize,
-                        lblInternalAction,
-                        lblUsernameColor,
-                        lblIgnores,
-                        lblIgnoresFeedback
+                        crel('div', {'class': 'd-block'}, lbl24hTimestamps),
+                        crel('div', {'class': 'd-block'}, lblPixelPlaceBadges),
+                        crel('div', {'class': 'd-block'}, lblPings),
+                        crel('div', {'class': 'd-block'}, lblPingAudio),
+                        crel('div', {'class': 'd-block'}, lblPingAudioVol),
+                        crel('div', {'class': 'd-block'}, lblBanner),
+                        crel('div', {'class': 'd-block'}, lblTemplateTitles),
+                        crel('div', {'class': 'd-block'}, lblFontSize),
+                        crel('div', {'class': 'd-block'}, lblInternalAction),
+                        crel('div', {'class': 'd-block'}, lblUsernameColor),
+                        crel('div', {'class': 'd-block'}, lblIgnores),
+                        crel('div', {'class': 'd-block'}, lblIgnoresFeedback)
                     )
                     modal.show(modal.buildDom(
                         crel('h2', {'class': 'modal-title'}, 'Chat Settings'),

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -1846,7 +1846,7 @@ ul.chat-history, ul.chatban-history {
 
 /* Chat settings tweaks */
 .chat-settings-wrapper label {
-    display: block;
+    display: inline-block;
     cursor: pointer;
     user-select: none;
     margin: 6px 0;
@@ -1854,6 +1854,10 @@ ul.chat-history, ul.chatban-history {
 
 .chat-settings-wrapper input:not([type=checkbox]) {
     border: 1px solid #888;
+}
+
+.d-block {
+    display: block !important;
 }
 
 /* Notifications */


### PR DESCRIPTION
This PR brings the following:
* Canvas lock state is now stateful (serialized to localStorage, default unlocked). A new UI element has been added to the settings panel to toggle this on/off on mobile.
* Wrap settings label in a div instead of making the labels themselves blocks to reduce on accidental clicks.