### PR TITLE
Allow the UI bubble to be repositioned on mobile

### DIFF
--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -306,7 +306,6 @@
                     </div>
                     <div>
                         Bubble position
-                        <span class="text-orange mobile-only">(not available for mobile/low resolution displays)</span>
                         <div id="bubble-position">
                             <label>
                                 <input type="radio" name="bubble-position" value="top left" />

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -2070,10 +2070,6 @@ ul.chat-history, ul.chatban-history {
         width: 95%;
     }
 
-    #bubble-position {
-        opacity: .5;
-    }
-
     #chat-hint {
         font-size: .7rem;
     }

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -2070,13 +2070,6 @@ ul.chat-history, ul.chatban-history {
         width: 95%;
     }
 
-    #ui #main-bubble {
-        top: 4rem;
-        bottom: initial;
-        left: 1rem;
-        right: initial;
-    }
-
     #bubble-position {
         opacity: .5;
     }


### PR DESCRIPTION
This PR brings the following:
* Unlocked the UI position on mobile screens. This allows mobile users to stick the bubble in whichever corner they prefer. Useful for #293