### PR TITLE
Fix for the double link bug.

### DIFF
--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -4782,7 +4782,9 @@ window.App = (function () {
                                 if (anchorTarget) elem.target = anchorTarget;
                             }
 
-                            str = str.replace(x.raw, elem.outerHTML);
+                            if (!str.includes(elem.outerHTML)) {
+                                str = str.split(x.raw).join(elem.outerHTML);
+                            }
                         }
 
                         //any other text manipulation after anchor insertion


### PR DESCRIPTION
Having 2 of the same link in a single message the `<a>` tag to embed on the first link twice because str.replace only targets the first link and gets fired twice, breaking the message. 
This pull request fixes this by replacing all of the links in a message on the first call, and rejects any future calls with an if statement.

```javascript
if (!str.includes(elem.outerHTML)) {
  str = str.split(x.raw).join(elem.outerHTML);
}