### PR TITLE
Add moderator endpoints to edit and delete factions

### DIFF
--- a/src/main/java/space/pxls/server/UndertowServer.java
+++ b/src/main/java/space/pxls/server/UndertowServer.java
@@ -80,6 +80,8 @@ public class UndertowServer {
                 .addPrefixPath("/execNameChange", new RoleGate(Role.USER, webHandler::execNameChange))
                 .addPrefixPath("/admin/flagNameChange", new RoleGate(Role.MODERATOR, webHandler::flagNameChange))
                 .addPrefixPath("/admin/forceNameChange", new RoleGate(Role.DEVELOPER, webHandler::forceNameChange))
+                .addPrefixPath("/admin/faction/edit", new RoleGate(Role.TRIALMOD, new JsonReader(webHandler::adminEditFaction)))
+                .addPrefixPath("/admin/faction/delete", new RoleGate(Role.TRIALMOD, new JsonReader(webHandler::adminDeleteFaction)))
                 .addPrefixPath("/admin", new RoleGate(Role.TRIALMOD, Handlers.resource(new ClassPathResourceManager(App.class.getClassLoader(), "public/admin/"))
                         .setCacheTime(10)))
                 .addPrefixPath("/whoami", webHandler::whoami)


### PR DESCRIPTION
- Delete with `/admin/faction/delete?fid={faction id}`
- Edit with `/admin/faction/edit?fid={faction id}`, which requires of an edit query object with `name`, `tag`, `owner` and/or `color`.

For future use on the admin panel