### PR TITLE
Round of fixes and QoL improvements to chat

### DIFF
--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -4767,10 +4767,10 @@ window.App = (function () {
                             switch(badge.type) {
                                 case 'text':
                                     let _countBadgeShow = ls.get('chat.text-icons-enabled') === true ? 'initial' : 'none';
-                                    crel(flairs, crel('span', {'class': 'text-badge', 'style': `display: ${_countBadgeShow}`, 'title': badge.tooltip || ''}, badge.displayName || ''));
+                                    crel(flairs, crel('span', {'class': 'flair text-badge', 'style': `display: ${_countBadgeShow}`, 'title': badge.tooltip || ''}, badge.displayName || ''));
                                     break;
                                 case 'icon':
-                                    crel(flairs, crel('span', crel('i', {'class': (badge.cssIcon || '') + ' icon-badge', 'title': badge.tooltip || ''}, document.createTextNode(' '))));
+                                    crel(flairs, crel('span', {'class': 'flair icon-badge'}, crel('i', {'class': badge.cssIcon || '', 'title': badge.tooltip || ''}, document.createTextNode(' '))));
                                     break;
                             }
                         });
@@ -4780,7 +4780,7 @@ window.App = (function () {
                     let _facColor = packet.strippedFaction ? self.intToHex(packet.strippedFaction.color) : 0;
                     let _facTagShow = packet.strippedFaction && ls.get('chat.faction-tags-enabled') === true ? 'initial' : 'none';
                     let _facTitle = packet.strippedFaction ? `${packet.strippedFaction.name} (ID: ${packet.strippedFaction.id})` : '';
-                    crel(flairs, crel('span', {'class': 'faction-tag', 'data-tag': _facTag, 'style': `color: ${_facColor}; display: ${_facTagShow}`, 'title': _facTitle}, `[${_facTag}]`))
+                    crel(flairs, crel('span', {'class': 'flair faction-tag', 'data-tag': _facTag, 'style': `color: ${_facColor}; display: ${_facTagShow}`, 'title': _facTitle}, `[${_facTag}]`))
 
                     let contentSpan = self.processMessage('span', 'content', packet.message_raw);
                     twemoji.parse(contentSpan);
@@ -5025,7 +5025,6 @@ window.App = (function () {
                         try {
                             badgesArray = JSON.parse(closest.dataset.badges);
                         } catch (ignored) {}
-                        // TODO(netux): display faction tag
                         let badges = crel('span', {'class': 'badges'});
                         badgesArray.forEach(badge => {
                             switch(badge.type) {

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -3805,6 +3805,7 @@ window.App = (function () {
                                         self.elements.rate_limit_overlay.hide();
                                         self.elements.rate_limit_counter.text('');
                                         self.elements.emoji_button.show();
+                                        self._handleChatbanVisualState(true);
                                     }
                                 }, 150);
                             } else if (e.permanent) {

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -4748,16 +4748,16 @@ window.App = (function () {
                         .split(' ')
                         .some((s) => s.search(new RegExp(`@${user.getUsername().toLowerCase()}(?![a-zA-Z0-9_\-])`)) == 0);
                     let when = moment.unix(packet.date);
-                    let badges = crel('span', {'class': 'badges'});
+                    let flairs = crel('span', {'class': 'flairs'});
                     if (Array.isArray(packet.badges)) {
                         packet.badges.forEach(badge => {
                             switch(badge.type) {
                                 case 'text':
                                     if (ls.get('chat.text-icons-enabled') !== true) return;
-                                    crel(badges, crel('span', {'class': 'text-badge', 'title': badge.tooltip || ''}, badge.displayName || ''), document.createTextNode(' '));
+                                    crel(flairs, crel('span', {'class': 'text-badge', 'title': badge.tooltip || ''}, badge.displayName || ''), document.createTextNode(' '));
                                     break;
                                 case 'icon':
-                                    crel(badges, crel('i', {'class': (badge.cssIcon || '') + ' icon-badge', 'title': badge.tooltip || ''}, document.createTextNode(' ')), document.createTextNode(' '));
+                                    crel(flairs, crel('i', {'class': (badge.cssIcon || '') + ' icon-badge', 'title': badge.tooltip || ''}, document.createTextNode(' ')), document.createTextNode(' '));
                                     break;
                             }
                         });
@@ -4767,7 +4767,7 @@ window.App = (function () {
                     if (packet.strippedFaction && ls.get('chat.faction-tags-enabled') === true) {
                         let _facTitle = `${packet.strippedFaction.name} (ID: ${packet.strippedFaction.id})`;
                         let _facColor = self.intToHex(packet.strippedFaction.color);
-                        crel(badges, crel('span', {'class': 'faction-tag', 'data-tag': _facTag, 'style': `color: ${_facColor}`, 'title': _facTitle}, `[${_facTag}]`), document.createTextNode(' '))
+                        crel(flairs, crel('span', {'class': 'faction-tag', 'data-tag': _facTag, 'style': `color: ${_facColor}`, 'title': _facTitle}, `[${_facTag}]`), document.createTextNode(' '))
                     }
 
                     let contentSpan = self.processMessage('span', 'content', packet.message_raw);
@@ -4780,7 +4780,7 @@ window.App = (function () {
                         crel('li', {'data-id': packet.id, 'data-tag': _facTag, 'data-faction': (packet.strippedFaction && packet.strippedFaction.id) || '', 'data-author': packet.author, 'data-date': packet.date, 'data-badges': JSON.stringify(packet.badges || []), 'class': `chat-line${hasPing ? ' has-ping' : ''} ${packet.author.toLowerCase().trim() === user.getUsername().toLowerCase().trim() ? 'is-from-us' : ''}`},
                             crel('span', {'title': when.format('MMM Do YYYY, hh:mm:ss A')}, when.format(ls.get('chat.24h') === true ? 'HH:mm' : 'hh:mm A')),
                             document.createTextNode(' '),
-                            badges,
+                            flairs,
                             crel('span', {'class': nameClasses, style: `color: ${place.getPaletteColor(packet.authorNameColor)}`, onclick: self._popUserPanel, onmousemiddledown: self._addAuthorMentionToChatbox}, packet.author),
                             document.createTextNode(': '),
                             contentSpan,

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -3685,7 +3685,9 @@ window.App = (function () {
                     });
                     socket.on('message_cooldown', e => {
                         self.timeout.ends = (new Date >> 0) + ((e.diff >> 0) * 1e3) + 1e3; //add 1 second so that we're 1-based instead of 0-based
-                        self.elements.input.val(e.message);
+                        if (uiHelper.tabHasFocus()) {
+                            self.elements.input.val(e.message);
+                        }
                         if ((new Date >> 0) > self.timeout.ends) {
                             self.elements.rate_limit_overlay.fadeOut();
                         } else {

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -1321,12 +1321,8 @@ li.chat-line.server-action {
     cursor: default;
 }
 
-li.chat-line .icon-badge, li.chat-line .text-badge {
+li.chat-line .flairs > * {
     margin-right: .25rem;
-}
-
-li.chat-line .flairs .faction-tag::after {
-    content: " ";
 }
 
 li.chat-line .user {

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -1325,10 +1325,6 @@ li.chat-line .text-badge:not(:last-child):not(:only-of-type) {
     margin-right: .25rem;
 }
 
-li.chat-line .badges {
-    margin-right: .25rem;
-}
-
 li.chat-line .user {
     font-weight: bold;
     cursor: pointer;

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -1321,8 +1321,12 @@ li.chat-line.server-action {
     cursor: default;
 }
 
-li.chat-line .text-badge:not(:last-child):not(:only-of-type) {
+li.chat-line .icon-badge, li.chat-line .text-badge {
     margin-right: .25rem;
+}
+
+li.chat-line .flairs .faction-tag::after {
+    content: " ";
 }
 
 li.chat-line .user {

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -1321,7 +1321,7 @@ li.chat-line.server-action {
     cursor: default;
 }
 
-li.chat-line .flairs > * {
+li.chat-line .flairs .flair {
     margin-right: .25rem;
 }
 


### PR DESCRIPTION
1. Fix chat cooldown setting the message back on all open tabs
2. Fix chat input being disabled after chat ban expires
3. Add option to hide faction tags
4. Re-add "default internal link action" and "template title" settings