### PR TITLE
Ban info in profile

### DIFF
--- a/resources/public/pebble_templates/profile.html
+++ b/resources/public/pebble_templates/profile.html
@@ -92,6 +92,18 @@
                                         <th class="text-right pr-3">Faction</th>
                                         <td class="text-left">{% if profile_of.displayedFaction | default(0) > 0 %}[{{profile_of.fetchDisplayedFaction.tag}}] {{profile_of.fetchDisplayedFaction.name}} (ID: {{profile_of.fetchDisplayedFaction.id}}){% else %}None{% endif %}</td>
                                     </tr>
+                                    {% if profile_of.isBanned() %}
+                                    <tr>
+                                        <th class="text-right pr-3">Canvas Ban Expiry</th>
+                                        <td class="text-left">{% if profile_of.isPermaBanned() %}Never{% else %}{{profile_of.getBanExpiryTime() | date("LLL d, y, hh:mm:s a (z)")}}{% endif %}</td>
+                                    </tr>
+                                    {% endif %}
+                                    {% if profile_of.isChatbanned() %}
+                                    <tr>
+                                        <th class="text-right pr-3">Chat Ban Expiry</th>
+                                        <td class="text-left">{% if profile_of.isPermaChatbanned() %}Never{% else %}{{profile_of.getChatBanExpiryTime() | date("LLL d, y, hh:mm:s a (z)")}}{% endif %}</td>
+                                    </tr>
+                                    {% endif %}
                                 </tbody>
                             </table>
                             <div class="d-block mt-4">

--- a/src/main/java/space/pxls/user/User.java
+++ b/src/main/java/space/pxls/user/User.java
@@ -280,6 +280,10 @@ public class User {
         return toReturn;
     }
 
+    public boolean isPermaBanned() {
+        return this.role == Role.BANNED;
+    }
+
     public boolean isShadowBanned() {
         return this.role == Role.SHADOWBANNED;
     }


### PR DESCRIPTION
A simple addition that adds the expiry time of a ban to a user's profile page if they are currently banned. This applies both to chat bans and canvas bans. 

If the ban is permanent, the ban is said to expire "Never".