### PR TITLE
CSS cleanup

### DIFF
--- a/resources/public/admin/admin.css
+++ b/resources/public/admin/admin.css
@@ -38,25 +38,9 @@
     left: 172px;
 }
 
-.admin-check {
-    position: fixed;
-
-    z-index: 22;
-    top: 45vh;
-    left: 50%;
-    transform: translateX(-50%) translateY(-50%);
-    max-height: 100vh;
-    overflow-y: auto;
-}
-
 .admin input[type=text] {
     width: 80%;
     margin-top: 4px;
-}
-
-.admin-lookup-msg {
-    width: 100%;
-    margin-top: 6px;
 }
 
 .admin-bannumber {

--- a/resources/public/admin/admin.css
+++ b/resources/public/admin/admin.css
@@ -9,12 +9,8 @@
     left: -180px;
     width: 210px;
     min-height: 62px;
-    background: #333;
-    background: var(--admin-background);
-    color: #fff;
-    color: var(--admin-text-color);
-    padding: 10px;
-    border-radius: 0 5px 5px 0;
+    border-top-left-radius: 0px !important;
+    border-bottom-left-radius: 0px !important;
     transition: left 0.2s ease-out;
     transform: translateY(-50%);
 }
@@ -43,14 +39,6 @@
 }
 
 .admin-check {
-    border-radius: 5px;
-    border: 1px solid #ccc;
-    border: 1px solid var(--admin-check-border-color);
-    background-color: #eee;
-    background-color: var(--admin-check-background-color);
-    color: inherit;
-    color: var(--admin-check-text-color);
-    padding: 10px 10px 5px;
     position: fixed;
 
     z-index: 22;
@@ -59,11 +47,6 @@
     transform: translateX(-50%) translateY(-50%);
     max-height: 100vh;
     overflow-y: auto;
-}
-
-.admin-check .buttons {
-    margin-top: 1rem;
-    text-align: right;
 }
 
 .admin input[type=text] {

--- a/resources/public/admin/admin.js
+++ b/resources/public/admin/admin.js
@@ -157,7 +157,7 @@
   const checkUser = (function () {
     const self = {
       elements: {
-        check: $('<div>').addClass('admin-check floating-panel')
+        check: $('<div>').addClass('message floating-panel')
       },
       callback: function (data) {
         const delta = (data.banExpiry - (new Date()).getTime()) / 1000;

--- a/resources/public/admin/admin.js
+++ b/resources/public/admin/admin.js
@@ -7,7 +7,7 @@
       right: 'auto',
       left: 'auto',
       bottom: 'auto'
-    }).text(s);
+    }).addClass('text-button').text(s);
   };
   const sendAlert = function(username) {
     if (admin.user.getRole() === 'TRIALMOD') return '';
@@ -244,18 +244,21 @@
             ),
             crel('div',
               crel('button', {
+                class: 'text-button',
                 'data-action': 'chatban',
                 'data-target': data.username,
                 style: 'position: initial; right: auto; left: auto; bottom: auto;',
                 onclick: admin.chat._handleActionClick
               }, 'Chat (un)ban'),
               crel('button', {
+                class: 'text-button',
                 'data-action': 'purge',
                 'data-target': data.username,
                 style: 'position: initial; right: auto; left: auto; bottom: auto;',
                 onclick: admin.chat._handleActionClick
               }, 'Chat purge'),
               crel('button', {
+                class: 'text-button',
                 'data-action': 'lookup-chat',
                 'data-target': data.username,
                 style: 'position: initial; right: auto; left: auto; bottom: auto;',
@@ -265,12 +268,14 @@
             (admin.user.getRole() !== 'TRIALMOD'
               ? crel('div',
                 crel('button', {
+                  class: 'text-button',
                   'data-action': 'request-rename',
                   'data-target': data.username,
                   style: 'position: initial; right: auto; left: auto; bottom: auto;',
                   onclick: admin.chat._handleActionClick
                 }, 'Request Rename'),
                 (admin.user.getRole() === 'ADMIN' || admin.user.getRole() === 'DEVELOPER' ? crel('button', {
+                  class: 'text-button',
                   'data-action': 'force-rename',
                   'data-target': data.username,
                   style: 'position: initial; right: auto; left: auto; bottom: auto;',
@@ -309,7 +314,7 @@
         });
       },
       popUnban: username => {
-        const btnSubmit = crel('button', { type: 'submit' }, 'Unban');
+        const btnSubmit = crel('button', { class: 'text-button', type: 'submit' }, 'Unban');
         const txtUnbanReason = crel('input', { type: 'text', required: 'true' });
         const lblUnbanReason = crel('label', 'Unban Reason: ', txtUnbanReason);
 
@@ -320,6 +325,7 @@
           lblUnbanReason,
           crel('div', { class: 'buttons' },
             crel('button', {
+              class: 'text-button',
               type: 'button',
               onclick: () => { admin.modal.closeAll(); }
             }, 'Cancel'),

--- a/resources/public/admin/admin.js
+++ b/resources/public/admin/admin.js
@@ -2,12 +2,12 @@
 (function () {
   let admin = null;
   const genButton = function(s) {
-    return $('<div>').css({
+    return $('<button>').css({
       position: 'initial',
       right: 'auto',
       left: 'auto',
       bottom: 'auto'
-    }).addClass('button').text(s);
+    }).text(s);
   };
   const sendAlert = function(username) {
     if (admin.user.getRole() === 'TRIALMOD') return '';
@@ -245,21 +245,18 @@
             crel('button', {
               'data-action': 'chatban',
               'data-target': data.username,
-              class: 'button',
               style: 'position: initial; right: auto; left: auto; bottom: auto;',
               onclick: admin.chat._handleActionClick
             }, 'Chat (un)ban'),
             crel('button', {
               'data-action': 'purge',
               'data-target': data.username,
-              class: 'button',
               style: 'position: initial; right: auto; left: auto; bottom: auto;',
               onclick: admin.chat._handleActionClick
             }, 'Chat purge'),
             crel('button', {
               'data-action': 'lookup-chat',
               'data-target': data.username,
-              class: 'button',
               style: 'position: initial; right: auto; left: auto; bottom: auto;',
               onclick: admin.chat._handleActionClick
             }, 'Chat lookup')
@@ -269,14 +266,12 @@
               crel('button', {
                 'data-action': 'request-rename',
                 'data-target': data.username,
-                class: 'button',
                 style: 'position: initial; right: auto; left: auto; bottom: auto;',
                 onclick: admin.chat._handleActionClick
               }, 'Request Rename'),
               (admin.user.getRole() === 'ADMIN' || admin.user.getRole() === 'DEVELOPER' ? crel('button', {
                 'data-action': 'force-rename',
                 'data-target': data.username,
-                class: 'button',
                 style: 'position: initial; right: auto; left: auto; bottom: auto;',
                 onclick: admin.chat._handleActionClick
               }, 'Force Rename') : '')
@@ -314,7 +309,7 @@
         });
       },
       popUnban: username => {
-        const btnSubmit = crel('button', { type: 'submit', class: 'button' }, 'Unban');
+        const btnSubmit = crel('button', { type: 'submit' }, 'Unban');
         const txtUnbanReason = crel('input', { type: 'text', required: 'true' });
         const lblUnbanReason = crel('label', 'Unban Reason: ', txtUnbanReason);
 
@@ -325,7 +320,6 @@
           lblUnbanReason,
           crel('div', { class: 'buttons' },
             crel('button', {
-              class: 'button',
               type: 'button',
               onclick: () => { admin.modal.closeAll(); }
             }, 'Cancel'),

--- a/resources/public/admin/admin.js
+++ b/resources/public/admin/admin.js
@@ -157,7 +157,7 @@
   const checkUser = (function () {
     const self = {
       elements: {
-        check: $('<div>').addClass('admin-check')
+        check: $('<div>').addClass('admin-check floating-panel')
       },
       callback: function (data) {
         const delta = (data.banExpiry - (new Date()).getTime()) / 1000;
@@ -212,87 +212,87 @@
           }
         }
         self.elements.check.empty().append(
-          $.map(items, function (o) {
-            return $('<div>').append(
-              $('<b>').text(o[0] + ': '),
-              typeof o[1] === 'string' ? $('<span>').text(o[1]) : o[1]
-            );
-          }),
-          $('<div>').append(sendAlert(data.username)),
-          $('<div>').append(
-            genButton('Ban (24h)').click(function () {
-              ban.ban_24h(data.username, function () {
-                self.elements.check.fadeOut(200);
-              });
+          $('<div>').addClass('content').append(
+            $.map(items, function (o) {
+              return $('<div>').append(
+                $('<b>').text(o[0] + ': '),
+                typeof o[1] === 'string' ? $('<span>').text(o[1]) : o[1]
+              );
             }),
-            (admin.user.getRole() !== 'TRIALMOD' ? genButton('Permaban').click(function () {
-              ban.perma(data.username, function () {
-                self.elements.check.fadeOut(200);
-              });
-            }) : '')
-          ),
-          $('<div>').append(
-            genButton('Unban').click(() => self.popUnban(data.username)),
-            (admin.user.getRole() === 'ADMIN'
-              ? genButton('Shadowban').click(function () {
-                ban.shadow(data.username, function () {
+            $('<div>').append(sendAlert(data.username)),
+            $('<div>').append(
+              genButton('Ban (24h)').click(function () {
+                ban.ban_24h(data.username, function () {
+                  self.elements.check.fadeOut(200);
+                });
+              }),
+              (admin.user.getRole() !== 'TRIALMOD' ? genButton('Permaban').click(function () {
+                ban.perma(data.username, function () {
+                  self.elements.check.fadeOut(200);
+                });
+              }) : '')
+            ),
+            $('<div>').append(
+              genButton('Unban').click(() => self.popUnban(data.username)),
+              (admin.user.getRole() === 'ADMIN'
+                ? genButton('Shadowban').click(function () {
+                  ban.shadow(data.username, function () {
+                    self.elements.check.fadeOut(200);
+                  });
+                })
+                : '')
+            ),
+            crel('div',
+              crel('button', {
+                'data-action': 'chatban',
+                'data-target': data.username,
+                style: 'position: initial; right: auto; left: auto; bottom: auto;',
+                onclick: admin.chat._handleActionClick
+              }, 'Chat (un)ban'),
+              crel('button', {
+                'data-action': 'purge',
+                'data-target': data.username,
+                style: 'position: initial; right: auto; left: auto; bottom: auto;',
+                onclick: admin.chat._handleActionClick
+              }, 'Chat purge'),
+              crel('button', {
+                'data-action': 'lookup-chat',
+                'data-target': data.username,
+                style: 'position: initial; right: auto; left: auto; bottom: auto;',
+                onclick: admin.chat._handleActionClick
+              }, 'Chat lookup')
+            ),
+            (admin.user.getRole() !== 'TRIALMOD'
+              ? crel('div',
+                crel('button', {
+                  'data-action': 'request-rename',
+                  'data-target': data.username,
+                  style: 'position: initial; right: auto; left: auto; bottom: auto;',
+                  onclick: admin.chat._handleActionClick
+                }, 'Request Rename'),
+                (admin.user.getRole() === 'ADMIN' || admin.user.getRole() === 'DEVELOPER' ? crel('button', {
+                  'data-action': 'force-rename',
+                  'data-target': data.username,
+                  style: 'position: initial; right: auto; left: auto; bottom: auto;',
+                  onclick: admin.chat._handleActionClick
+                }, 'Force Rename') : '')
+              )
+              : ''
+            ),
+            $('<div>').append(
+              $('<b>').text('Custom ban length: '), '<br>',
+              $('<input>').attr('type', 'number').attr('step', 'any').addClass('admin-bannumber').val(24),
+              ' hours ',
+              genButton('Ban').click(function () {
+                ban.ban(data.username, parseFloat($(this).parent().find('input').val()) * 3600, function () {
                   self.elements.check.fadeOut(200);
                 });
               })
-              : '')
-          ),
-          crel('div',
-            crel('button', {
-              'data-action': 'chatban',
-              'data-target': data.username,
-              style: 'position: initial; right: auto; left: auto; bottom: auto;',
-              onclick: admin.chat._handleActionClick
-            }, 'Chat (un)ban'),
-            crel('button', {
-              'data-action': 'purge',
-              'data-target': data.username,
-              style: 'position: initial; right: auto; left: auto; bottom: auto;',
-              onclick: admin.chat._handleActionClick
-            }, 'Chat purge'),
-            crel('button', {
-              'data-action': 'lookup-chat',
-              'data-target': data.username,
-              style: 'position: initial; right: auto; left: auto; bottom: auto;',
-              onclick: admin.chat._handleActionClick
-            }, 'Chat lookup')
-          ),
-          (admin.user.getRole() !== 'TRIALMOD'
-            ? crel('div',
-              crel('button', {
-                'data-action': 'request-rename',
-                'data-target': data.username,
-                style: 'position: initial; right: auto; left: auto; bottom: auto;',
-                onclick: admin.chat._handleActionClick
-              }, 'Request Rename'),
-              (admin.user.getRole() === 'ADMIN' || admin.user.getRole() === 'DEVELOPER' ? crel('button', {
-                'data-action': 'force-rename',
-                'data-target': data.username,
-                style: 'position: initial; right: auto; left: auto; bottom: auto;',
-                onclick: admin.chat._handleActionClick
-              }, 'Force Rename') : '')
             )
-            : ''
           ),
-          $('<div>').append(
-            $('<b>').text('Custom ban length: '), '<br>',
-            $('<input>').attr('type', 'number').attr('step', 'any').addClass('admin-bannumber').val(24),
-            ' hours ',
-            genButton('Ban').click(function () {
-              ban.ban(data.username, parseFloat($(this).parent().find('input').val()) * 3600, function () {
-                self.elements.check.fadeOut(200);
-              });
-            })
-          ),
-          $('<div>').addClass('buttons').append(
-            genButton('Close').click(function () {
-              self.elements.check.fadeOut(200);
-            })
-          )
+          genButton('Close').addClass('float-right').click(function () {
+            self.elements.check.fadeOut(200);
+          })
         ).fadeIn(200);
       },
       init: function () {
@@ -353,7 +353,7 @@
         panel: $('<div>')
       },
       init: function () {
-        self.elements.panel.hide().addClass('admin').append(
+        self.elements.panel.hide().addClass('admin bubble').append(
           $('<h1>').text('MOD'),
           $('<div>').append(
             // first do the checkboxes

--- a/resources/public/admin/admin.js
+++ b/resources/public/admin/admin.js
@@ -60,7 +60,7 @@
             genButton('Cancel').click(function () {
               self.elements.prompt.fadeOut(200);
             }),
-            genButton('OK').click(function () {
+            genButton('Ban').addClass('dangerous-button').click(function () {
               const selectedRule = self.elements.prompt.find('select').val();
               const textarea = self.elements.prompt.find('textarea').val().trim();
               let msg = selectedRule;

--- a/resources/public/faq.html
+++ b/resources/public/faq.html
@@ -1,5 +1,5 @@
 <article>
-    <header class="slim darker">
+    <header>
         <h2>FAQ</h2>
     </header>
     <div class="pad-wrapper">

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -121,16 +121,16 @@
     <div id="cursor-text"><i class="fas fa-spinner fa-spin captcha-loading-icon"></i> <span id="placeableCount-cursor">N/A</span></div>
 </div>
 <div id="reticule"></div>
-<div id="prompt" class="message"></div>
-<div id="signup" class="message">
-    <h1>Sign up</h1>
-    <h4>Pick a username</h4>
+<div id="prompt" class="message floating-panel"></div>
+<div id="signup" class="message floating-panel">
+    <div class="content">
+      <h1>Sign up</h1>
+      <h4>Pick a username</h4>
 
-    <label>Username: <input type="text" maxlength="32"></label>
-    <div class="error" id="error"></div>
-    <div class="buttons">
-        <button id="signup-button">Sign up</button>
+      <label>Username: <input type="text" maxlength="32"></label>
+      <div class="error" id="error"></div>
     </div>
+    <button id="signup-button" class="float-right">Sign up</button>
 </div>
 
 

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -181,7 +181,7 @@
                     <p class="text-muted" data-dismiss="typeahead" style="cursor: pointer; padding-top: .25rem; padding-bottom: .25rem; margin: 0 0 .5rem 0rem; text-align: center; font-style: italic;">Tap here or press ESC to cancel</p>
                     <ul></ul>
                 </div>
-                <i class="far fa-grin" id="emojiPanelTrigger"></i>
+                <button type="button" title="Emoji" id="emojiPanelTrigger"><i class="far fa-grin"></i></button>
                 <label><textarea name="txtChatContent" id="txtChatContent" placeholder="Press ENTER to send..."></textarea></label>
                 <div class="bottom-banner" id="bottom-banner"></div>
             </div>

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -115,7 +115,7 @@
 </div>
 
 
-<div id="lookup"></div>
+<div id="lookup" class="floating-panel"></div>
 <div id="loading"><span>Loading...</span></div>
 <div id="cursor">
     <div id="cursor-text"><i class="fas fa-spinner fa-spin captcha-loading-icon"></i> <span id="placeableCount-cursor">N/A</span></div>

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -172,11 +172,11 @@
             </div>
             <div class="chat-controls">
                 <div class="chat-ratelimit-overlay"><span id="chat-ratelimit">3s</span></div>
-                <div id="jump-to-bottom" style="display: none;">
+                <button type="button" class="fullwidth" id="jump-to-bottom" style="display: none;">
                     <i class="fas fa-arrow-down fa-is-right" style="float: left; margin-top: 4px;"></i>
                     <span>Jump To Bottom</span>
                     <i class="fas fa-arrow-down fa-is-left" style="float: right; margin-top: 4px;"></i>
-                </div>
+                </button>
                 <div id="typeahead" style="display: none;">
                     <button data-dismiss="typeahead" class="text-muted" style="width: 100%; font-size: inherit; display:block; padding-top: .25rem; padding-bottom: .25rem; margin: 0 0 .5rem 0rem; text-align: center; font-style: italic;">Tap here or press ESC to cancel</button>
                     <ul></ul>

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -142,7 +142,7 @@
     <header class="panel-header">
         <div class="left"></div>
         <div class="mid">
-            <h2><i class="fas fa-info-circle fa-is-left fa-1_5x"></i>Info</h2>
+            <h2><i class="fas fa-info-circle fa-is-left"></i>Info</h2>
         </div>
         <div class="right">
             <button type="button" class="panel-closer"><i class="fas fa-times"></i></button>
@@ -158,7 +158,7 @@
         <div class="left">
             <button type="button" class="panel-closer" title="Close Panel"><i class="fas fa-times"></i></button>
         </div>
-        <h2><i class="fas fa-comment-alt fa-is-left fa-1_5x"></i>Chat <span class="mobile-only" id="txtMobileChatCooldown"></span></h2>
+        <h2><i class="fas fa-comment-alt fa-is-left"></i>Chat <span class="mobile-only" id="txtMobileChatCooldown"></span></h2>
         <div class="right">
             <button type="button" title="Pings"><i class="fas fa-at" id="btnPings"></i></i></button>
             <button type="button" title="Settings"><i class="fas fa-cogs" id="btnChatSettings"></i></button>
@@ -196,13 +196,13 @@
             <button type="button" class="panel-closer" title="Close Panel"><i class="fas fa-times"></i></button>
         </div>
         <div class="mid">
-            <h2><i class="fas fa-cogs fa-is-left fa-1_5x"></i>Settings</h2>
+            <h2><i class="fas fa-cogs fa-is-left"></i>Settings</h2>
         </div>
         <div class="right"></div>
     </header>
     <div class="panel-body">
         <article class="no-p-margin">
-            <header class="slim">
+            <header>
                 <h2>Keybinds</h2>
             </header>
             <div class="pad-wrapper">
@@ -235,7 +235,7 @@
             </div>
         </article>
         <article>
-            <header class="slim">
+            <header>
                 <h2>General Settings</h2>
             </header>
             <div class="pad-wrapper">
@@ -247,64 +247,64 @@
                             </select>
                         </label>
                     </div>
-                    <div class="d-block">
+                    <div>
                         <label><input id="audiotoggle" type="checkbox"/>Mute sound</label>
                     </div>
-                    <div class="d-block">
+                    <div>
                         <label><input id="heatmaptoggle" type="checkbox"/>Turn on heatmap (toggle with <kbd>H</kbd>)</label>
                     </div>
-                    <div class="d-block">
+                    <div>
                         <label><input id="virginmaptoggle" type="checkbox"/>Turn on virginmap (toggle with <kbd>X</kbd>)</label>
                     </div>
-                    <div class="d-block">
+                    <div>
                         <button class="text-button" id="hvmapClear">Clear heatmap and virginmap</button> (hotkey: <kbd>O</kbd>)
                     </div>
-                    <div class="d-block">
+                    <div>
                         <label><input id="gridtoggle" type="checkbox"/>Turn on grid (toggle with <kbd>G</kbd>)</label>
                     </div>
-                    <div class="d-block">
+                    <div>
                         <label><input type="checkbox" id="lockCanvasToggle">Lock the canvas (disallow canvas drag/zoom with mouse/fingers)</label>
                     </div>
-                    <div class="d-block">
+                    <div>
                         <label><input id="native-notification-toggle" type="checkbox"/>Enable pixel available notification</label>
                     </div>
-                    <div class="d-block">
+                    <div>
                         <label><input id="stickyColorToggle" type="checkbox"/>Keep color selected</label>
                     </div>
-                    <div class="d-block">
+                    <div>
                         <label><input id="monospaceToggle" type="checkbox"/>Toggle monospace font for lookups</label>
                     </div>
-                    <div class="d-block">
+                    <div>
                         <label><input id="increasedZoomToggle" type="checkbox"/>Allow zoom values greater than 50x</label>
                     </div>
-                    <div class="d-block">
+                    <div>
                         <label><input id="scrollSwitchToggle" type="checkbox"/>Enable scrolling on the palette to switch colors</label>
                     </div>
-                    <div class="d-block">
+                    <div>
                         <label style="text-indent:1em"><input id="scrollDirectionToggle" type="checkbox"/>Invert scroll direction</label>
                     </div>
-                    <div class="d-block">
+                    <div>
                         <label><input id="showReticuleToggle" type="checkbox"/>Show Reticule</label>
                     </div>
-                    <div class="d-block">
+                    <div>
                         <label><input id="showCursorToggle" type="checkbox"/>Show Cursor</label>
                     </div>
-                    <div class="d-block">
+                    <div>
                         <label><input id="templateBeneathHeatmapToggle" type="checkbox"/>Layer Template Underneath Heatmap</label>
                     </div>
-                    <div class="d-block">
+                    <div>
                         <label><input id="cbEnableMiddleMouseSelect" type="checkbox"> Enable middle mouse button selecting color from board</label>
                     </div>
-                    <div class="d-block">
+                    <div>
                         <label><input id="cbNumberedPalette" type="checkbox"> Add numbers to palette entries</label>
                     </div>
-                    <div class="d-block">
+                    <div>
                         <label>Heatmap Background Opacity: <input type="range" min="0" max="1" step="0.01" id="heatmap-opacity"></label>
                     </div>
-                    <div class="d-block">
+                    <div>
                         <label>Virginmap Background Opacity: <input type="range" min="0" max="1" step="0.01" id="virginmap-opacity"></label>
                     </div>
-                    <div class="d-block">
+                    <div>
                         <label>
                             Snapshot (hotkey: <kbd>P</kbd>) image format
                             <select id="snapshotImageFormat">
@@ -347,7 +347,7 @@
             </div>
         </article>
         <article>
-            <header class="slim">
+            <header>
                 <h2>Template</h2>
             </header>
             <div class="pad-wrapper">
@@ -355,15 +355,15 @@
                     <label><input type="checkbox" id="template-use"> Use template</label>
                 </div>
                 <p>Hold down <kbd>Ctrl</kbd> (or <kbd>Option</kbd> on mac) to drag the template around</p>
-                <div class="longTextInputWrapper d-block">
+                <p>
                     <label>Title:</label>
-                    <input type="text" id="template-title">
-                </div>
-                <div class="longTextInputWrapper d-block">
+                    <input class="fullwidth" type="text" id="template-title">
+                </p>
+                <p>
                     <label>URL:</label>
-                    <input type="text" id="template-url">
+                    <input class="fullwidth" type="text" id="template-url">
                     <span id="template-image-error-warning" class="text-red">There was an error getting the image</span>
-                </div>
+                </p>
                 <div>
                     <label>Position: <input type="number" min="0" class="template-coords small-input" id="template-coords-x">, <input type="number" min="0" class="template-coords small-input" id="template-coords-y"></label>
                 </div>
@@ -378,12 +378,12 @@
             </div>
         </article>
         <article>
-            <header class="slim">
+            <header>
                 <h2>Pixel Ready Alert Settings</h2>
             </header>
             <div class="pad-wrapper">
-                <p class="longTextInputWrapper"><label for="txtAlertLocation">Alert URL:</label><input type="text" placeholder="notify.wav" id="txtAlertLocation"></p>
-                <div class="ButtonBar">
+                <p><label for="txtAlertLocation">Alert URL:</label><input class="fullwidth" type="text" placeholder="notify.wav" id="txtAlertLocation"></p>
+                <div class="button-bar">
                     <button class="text-button" id="btnForceAudioUpdate">Update</button>
                     <button class="text-button" id="btnAlertAudioTest">Test</button>
                     <button class="text-button" id="btnAlertReset">Reset</button>
@@ -397,12 +397,12 @@
             </div>
         </article>
         <article>
-            <header class="slim">
+            <header>
                 <h2>Account Settings</h2>
             </header>
             <div class="pad-wrapper">
-                <p class="longTextInputWrapper"><label for="txtDiscordName">Public Discord Name:</label><input type="text" placeholder="pxlslover#1337" id="txtDiscordName"></p>
-                <div class="ButtonBar">
+                <p><label for="txtDiscordName">Public Discord Name:</label><input class="fullwidth" type="text" placeholder="pxlslover#1337" id="txtDiscordName"></p>
+                <div class="button-bar">
                     <button class="text-button" id="btnDiscordNameSet">Set</button>
                     <button class="text-button" id="btnDiscordNameRemove">Remove</button>
                 </div>
@@ -411,10 +411,10 @@
     </div>
 </aside>
 
-<aside id="faq" data-panel="faq" class="panel half-width left">
+<aside id="faq" data-panel="faq" class="panel left">
     <header class="panel-header">
         <div class="left"></div>
-        <h2><i class="fas fa-question-circle fa-is-left fa-1_5x"></i>Help</h2>
+        <h2><i class="fas fa-question-circle fa-is-left"></i>Help</h2>
         <div class="right">
             <button type="button" class="panel-closer" title="Close Panel"><i class="fas fa-times"></i></button>
         </div>
@@ -427,7 +427,7 @@
 <aside id="notifications" data-panel="notifications" class="panel left">
     <header class="panel-header">
         <div class="left"></div>
-        <h2><i class="fas fa-bell fa-is-left fa-1_5x"></i>Notifications</h2>
+        <h2><i class="fas fa-bell fa-is-left"></i>Notifications</h2>
         <div class="right">
             <button type="button" class="panel-closer" title="Close Panel"><i class="fas fa-times"></i></button>
         </div>

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -6,16 +6,6 @@
     <meta name="keywords" content="pxls, pixels, place, art">
     <meta name="description" content="Place pixels with people to create art">
     <meta name="google-play-app" content="app-id=space.pxls.android">
-    <style type="text/css">
-        /** These MUST be here because the YUI compressor breaks calc() and is abandoned */
-        body.panel-open.panel-right #ui .right {
-            right: calc(30vw + 10px);
-        }
-
-        body.panel-open.panel-left #ui .left {
-            left: calc(30vw + 10px);
-        }
-    </style>
     <link rel="stylesheet" href="jquery.modal.min.css">
     <link rel="stylesheet" href="fontawesome-all.min.css">
     <link rel="stylesheet" href="style.css">

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -401,7 +401,7 @@
     </div>
 </aside>
 
-<aside id="faq" data-panel="faq" class="panel left">
+<aside id="faq" data-panel="faq" class="panel left half-width">
     <header class="panel-header">
         <div class="left"></div>
         <h2><i class="fas fa-question-circle fa-is-left"></i>Help</h2>

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -139,7 +139,7 @@
      data-size="invisible"></div>
 
 <aside class="panel left" data-panel="info">
-    <header class="panel-header darker">
+    <header class="panel-header">
         <div class="left"></div>
         <div class="mid">
             <h2><i class="fas fa-info-circle fa-is-left fa-1_5x"></i>Info</h2>
@@ -198,7 +198,7 @@
     </header>
     <div class="panel-body">
         <article class="no-p-margin">
-            <header class="slim darker">
+            <header class="slim">
                 <h2>Keybinds</h2>
             </header>
             <div class="pad-wrapper">
@@ -231,7 +231,7 @@
             </div>
         </article>
         <article>
-            <header class="slim darker">
+            <header class="slim">
                 <h2>General Settings</h2>
             </header>
             <div class="pad-wrapper">
@@ -343,7 +343,7 @@
             </div>
         </article>
         <article>
-            <header class="slim darker">
+            <header class="slim">
                 <h2>Template</h2>
             </header>
             <div class="pad-wrapper">
@@ -374,7 +374,7 @@
             </div>
         </article>
         <article>
-            <header class="slim darker">
+            <header class="slim">
                 <h2>Pixel Ready Alert Settings</h2>
             </header>
             <div class="pad-wrapper">
@@ -393,7 +393,7 @@
             </div>
         </article>
         <article>
-            <header class="slim darker">
+            <header class="slim">
                 <h2>Account Settings</h2>
             </header>
             <div class="pad-wrapper">

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -178,7 +178,7 @@
                     <i class="fas fa-arrow-down fa-is-left" style="float: right; margin-top: 4px;"></i>
                 </div>
                 <div id="typeahead" style="display: none;">
-                    <p class="text-muted" data-dismiss="typeahead" style="cursor: pointer; padding-top: .25rem; padding-bottom: .25rem; margin: 0 0 .5rem 0rem; text-align: center; font-style: italic;">Tap here or press ESC to cancel</p>
+                    <button data-dismiss="typeahead" class="text-muted" style="width: 100%; font-size: inherit; display:block; padding-top: .25rem; padding-bottom: .25rem; margin: 0 0 .5rem 0rem; text-align: center; font-style: italic;">Tap here or press ESC to cancel</button>
                     <ul></ul>
                 </div>
                 <button type="button" title="Emoji" id="emojiPanelTrigger"><i class="far fa-grin"></i></button>

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -129,7 +129,7 @@
     <label>Username: <input type="text" maxlength="32"></label>
     <div class="error" id="error"></div>
     <div class="buttons">
-        <span class="button" id="signup-button">Sign up</span>
+        <button id="signup-button">Sign up</button>
     </div>
 </div>
 
@@ -380,9 +380,9 @@
             <div class="pad-wrapper">
                 <p class="longTextInputWrapper"><label for="txtAlertLocation">Alert URL:</label><input type="text" placeholder="notify.wav" id="txtAlertLocation"></p>
                 <div class="ButtonBar">
-                    <button id="btnForceAudioUpdate" class="button">Update</button>
-                    <button id="btnAlertAudioTest" class="button">Test</button>
-                    <button id="btnAlertReset" class="button">Reset</button>
+                    <button id="btnForceAudioUpdate">Update</button>
+                    <button id="btnAlertAudioTest">Test</button>
+                    <button id="btnAlertReset">Reset</button>
                 </div>
                 <div>
                     <label for="rangeAlertVolume">Volume:</label>
@@ -399,8 +399,8 @@
             <div class="pad-wrapper">
                 <p class="longTextInputWrapper"><label for="txtDiscordName">Public Discord Name:</label><input type="text" placeholder="pxlslover#1337" id="txtDiscordName"></p>
                 <div class="ButtonBar">
-                    <button id="btnDiscordNameSet" class="button">Set</button>
-                    <button id="btnDiscordNameRemove" class="button">Remove</button>
+                    <button id="btnDiscordNameSet">Set</button>
+                    <button id="btnDiscordNameRemove">Remove</button>
                 </div>
             </div>
         </article>

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -39,26 +39,26 @@
 <body class="show-placeable-bubble">
 <header class="transparent controls">
     <div class="left">
-        <div class="panel-trigger" data-panel="info">
+        <button type="button" class="panel-trigger" data-panel="info">
             <i class="fas fa-info-circle"></i>
-        </div>
-        <div class="panel-trigger" data-panel="faq">
+        </button>
+        <button type="button" class="panel-trigger" data-panel="faq">
             <i class="fas fa-question-circle"></i>
-        </div>
-        <div class="panel-trigger" data-panel="notifications">
+        </button>
+        <button type="button" class="panel-trigger" data-panel="notifications">
             <i class="fas fa-bell" id="notifications-icon"></i>
             <i class="fas fa-circle ping-counter" id="notifications-ping-counter"></i>
-        </div>
+        </button>
     </div>
     <div class="mid"></div>
     <div class="right">
-        <div class="panel-trigger" data-panel="settings">
+        <button type="button" class="panel-trigger" data-panel="settings">
             <i class="fas fa-cog"></i>
-        </div>
-        <div class="panel-trigger" data-panel="chat">
+        </button>
+        <button type="button" class="panel-trigger" data-panel="chat">
             <i class="fas fa-comment-alt" id="message-icon"></i>
             <i class="fas fa-circle ping-counter" id="ping-counter"></i>
-        </div>
+        </button>
     </div>
 </header>
 
@@ -103,7 +103,7 @@
     </div>
 
     <div id="ui-bottom">
-        <div id="undo"><span>Undo</span></div>
+        <button type="button" id="undo"><span>Undo</span></button>
         <div id="login-overlay" class="palette-overlay">
             You are not signed in.&nbsp;<a href="#">Sign in with...</a>
         </div>
@@ -130,7 +130,7 @@
       <label>Username: <input type="text" maxlength="32"></label>
       <div class="error" id="error"></div>
     </div>
-    <button id="signup-button" class="float-right">Sign up</button>
+    <button id="signup-button" class="float-right text-button">Sign up</button>
 </div>
 
 
@@ -145,7 +145,7 @@
             <h2><i class="fas fa-info-circle fa-is-left fa-1_5x"></i>Info</h2>
         </div>
         <div class="right">
-            <i class="fas fa-times panel-closer text-red"></i>
+            <button type="button" class="panel-closer"><i class="fas fa-times"></i></button>
         </div>
     </header>
     <div class="panel-body">
@@ -155,11 +155,13 @@
 
 <aside id="chat" data-panel="chat" class="panel right">
     <header class="panel-header">
-        <div class="left"><i class="fas fa-times text-red panel-closer"></i></div>
+        <div class="left">
+            <button type="button" class="panel-closer" title="Close Panel"><i class="fas fa-times"></i></button>
+        </div>
         <h2><i class="fas fa-comment-alt fa-is-left fa-1_5x"></i>Chat <span class="mobile-only" id="txtMobileChatCooldown"></span></h2>
         <div class="right">
-            <i class="fas fa-at" id="btnPings" title="Pings"></i>
-            <i class="fas fa-cogs" id="btnChatSettings" title="Settings"></i>
+            <button type="button" title="Pings"><i class="fas fa-at" id="btnPings"></i></i></button>
+            <button type="button" title="Settings"><i class="fas fa-cogs" id="btnChatSettings"></i></button>
         </div>
     </header>
     <div class="panel-body">
@@ -190,7 +192,9 @@
 
 <aside id="settings" data-panel="settings" class="panel right">
     <header class="panel-header">
-        <div class="left"><i class="fas fa-times panel-closer text-red"></i></div>
+        <div class="left">
+            <button type="button" class="panel-closer" title="Close Panel"><i class="fas fa-times"></i></button>
+        </div>
         <div class="mid">
             <h2><i class="fas fa-cogs fa-is-left fa-1_5x"></i>Settings</h2>
         </div>
@@ -253,7 +257,7 @@
                         <label><input id="virginmaptoggle" type="checkbox"/>Turn on virginmap (toggle with <kbd>X</kbd>)</label>
                     </div>
                     <div class="d-block">
-                        <button id="hvmapClear">Clear heatmap and virginmap</button> (hotkey: <kbd>O</kbd>)
+                        <button class="text-button" id="hvmapClear">Clear heatmap and virginmap</button> (hotkey: <kbd>O</kbd>)
                     </div>
                     <div class="d-block">
                         <label><input id="gridtoggle" type="checkbox"/>Turn on grid (toggle with <kbd>G</kbd>)</label>
@@ -369,7 +373,7 @@
                 </div>
                 <div>
                     <label>Width: <input type="number" id="template-width" class="small-input" min="0"></label>
-                    <button id="template-width-reset">Reset</button>
+                    <button class="text-button" id="template-width-reset">Reset</button>
                 </div>
             </div>
         </article>
@@ -380,9 +384,9 @@
             <div class="pad-wrapper">
                 <p class="longTextInputWrapper"><label for="txtAlertLocation">Alert URL:</label><input type="text" placeholder="notify.wav" id="txtAlertLocation"></p>
                 <div class="ButtonBar">
-                    <button id="btnForceAudioUpdate">Update</button>
-                    <button id="btnAlertAudioTest">Test</button>
-                    <button id="btnAlertReset">Reset</button>
+                    <button class="text-button" id="btnForceAudioUpdate">Update</button>
+                    <button class="text-button" id="btnAlertAudioTest">Test</button>
+                    <button class="text-button" id="btnAlertReset">Reset</button>
                 </div>
                 <div>
                     <label for="rangeAlertVolume">Volume:</label>
@@ -399,8 +403,8 @@
             <div class="pad-wrapper">
                 <p class="longTextInputWrapper"><label for="txtDiscordName">Public Discord Name:</label><input type="text" placeholder="pxlslover#1337" id="txtDiscordName"></p>
                 <div class="ButtonBar">
-                    <button id="btnDiscordNameSet">Set</button>
-                    <button id="btnDiscordNameRemove">Remove</button>
+                    <button class="text-button" id="btnDiscordNameSet">Set</button>
+                    <button class="text-button" id="btnDiscordNameRemove">Remove</button>
                 </div>
             </div>
         </article>
@@ -411,7 +415,9 @@
     <header class="panel-header">
         <div class="left"></div>
         <h2><i class="fas fa-question-circle fa-is-left fa-1_5x"></i>Help</h2>
-        <div class="right"><i class="fas fa-times text-red panel-closer"></i></div>
+        <div class="right">
+            <button type="button" class="panel-closer" title="Close Panel"><i class="fas fa-times"></i></button>
+        </div>
     </header>
     <div class="panel-body">
         {{faq}}
@@ -422,7 +428,9 @@
     <header class="panel-header">
         <div class="left"></div>
         <h2><i class="fas fa-bell fa-is-left fa-1_5x"></i>Notifications</h2>
-        <div class="right"><i class="fas fa-times text-red panel-closer"></i></div>
+        <div class="right">
+            <button type="button" class="panel-closer" title="Close Panel"><i class="fas fa-times"></i></button>
+        </div>
     </header>
     <div class="panel-body"></div>
 </aside>

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -37,7 +37,7 @@
     {{head}}
 </head>
 <body class="show-placeable-bubble">
-<header class="transparent" style="margin-top: 5px;">
+<header class="transparent controls">
     <div class="left">
         <div class="panel-trigger" data-panel="info">
             <i class="fas fa-info-circle"></i>

--- a/resources/public/info.html
+++ b/resources/public/info.html
@@ -1,5 +1,5 @@
 <article>
-	<header class="slim darker">
+	<header>
 		<h2>Welcome!</h2>
 	</header>
 	<div class="pad-wrapper">
@@ -9,7 +9,7 @@
 	</div>
 </article>
 <article id="canvas-rules">
-	<header class="slim darker">
+	<header>
 		<h2 class="text-red">Canvas Rules</h2>
 	</header>
 	<div class="pad-wrapper" id="rules-content">
@@ -39,7 +39,7 @@
 	</div>
 </article>
 <article id="chat-rules">
-	<header class="slim darker">
+	<header>
 		<h2 class="text-red">Chat Rules</h2>
 	</header>
 	<div class="pad-wrapper">
@@ -67,7 +67,7 @@
 	</div>
 </article>
 <article>
-	<header class="slim darker">
+	<header>
 		<h2>Links</h2>
 	</header>
 	<div class="pad-wrapper">
@@ -87,7 +87,7 @@
 	</div>
 </article>
 <article>
-	<header class="slim darker">
+	<header>
 		<h2>Donate</h2>
 	</header>
 	<div class="pad-wrapper">

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -3714,32 +3714,38 @@ window.App = (function() {
                 crel('hr'),
                 crel('ul', { class: 'chatban-history' },
                   e.chatbans.map(chatban => {
-                    return crel('li', { class: 'chatban' },
-                      crel('h4', `${chatban.initiator_name} ${chatban.type === 'UNBAN' ? 'un' : ''}banned ${e.target.username}${chatban.type !== 'PERMA' ? '' : ''}`),
-                      crel('table',
-                        crel('tbody',
-                          crel('tr',
-                            crel('th', 'Reason:'),
-                            crel('td', chatban.reason || '$No reason provided$')
-                          ),
-                          crel('tr',
-                            crel('th', 'When:'),
-                            crel('td', moment(chatban.when * 1e3).format(longFormat))
-                          ),
-                          chatban.type !== 'UNBAN' ? ([
-                            crel('tr',
-                              crel('th', 'Length:'),
-                              crel('td', (chatban.type.toUpperCase().trim() === 'PERMA') ? 'Permanent' : `${chatban.expiry - chatban.when}s${(chatban.expiry - chatban.when) >= 60 ? ` (${moment.duration(chatban.expiry - chatban.when, 'seconds').humanize()})` : ''}`)
-                            ),
-                            (chatban.type.toUpperCase().trim() === 'PERMA') ? null : crel('tr',
-                              crel('th', 'Expiry:'),
-                              crel('td', moment(chatban.expiry * 1e3).format(longFormat))
-                            ),
-                            crel('tr',
-                              crel('th', 'Purged:'),
-                              crel('td', String(chatban.purged))
+                    return crel('li',
+                      crel('article', { class: 'chatban' },
+                        crel('header',
+                          crel('h4', `${chatban.initiator_name} ${chatban.type === 'UNBAN' ? 'un' : ''}banned ${e.target.username}${chatban.type !== 'PERMA' ? '' : ''}`)
+                        ),
+                        crel('div',
+                          crel('table',
+                            crel('tbody',
+                              crel('tr',
+                                crel('th', 'Reason:'),
+                                crel('td', chatban.reason || '$No reason provided$')
+                              ),
+                              crel('tr',
+                                crel('th', 'When:'),
+                                crel('td', moment(chatban.when * 1e3).format(longFormat))
+                              ),
+                              chatban.type !== 'UNBAN' ? ([
+                                crel('tr',
+                                  crel('th', 'Length:'),
+                                  crel('td', (chatban.type.toUpperCase().trim() === 'PERMA') ? 'Permanent' : `${chatban.expiry - chatban.when}s${(chatban.expiry - chatban.when) >= 60 ? ` (${moment.duration(chatban.expiry - chatban.when, 'seconds').humanize()})` : ''}`)
+                                ),
+                                (chatban.type.toUpperCase().trim() === 'PERMA') ? null : crel('tr',
+                                  crel('th', 'Expiry:'),
+                                  crel('td', moment(chatban.expiry * 1e3).format(longFormat))
+                                ),
+                                crel('tr',
+                                  crel('th', 'Purged:'),
+                                  crel('td', String(chatban.purged))
+                                )
+                              ]) : null
                             )
-                          ]) : null
+                          )
                         )
                       )
                     );
@@ -6572,7 +6578,7 @@ window.App = (function() {
               crel('div', { class: 'left' }),
               crel('div', { class: 'mid' }, headerContent),
               crel('div', { class: 'right' }, this.buildCloser())),
-            bodyContent == null ? null : crel('div', { class: 'modal-body' }, bodyContent),
+            bodyContent == null ? null : crel('div', { class: 'modal-body panel-body' }, bodyContent),
             footerContent == null ? null : crel('footer', { class: 'modal-footer panel-footer' }, footerContent)
           )
         );

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -2308,7 +2308,8 @@ window.App = (function() {
         self.palette = palette;
         self.elements.palette.find('.palette-color').remove().end().append(
           $.map(self.palette, function(p, idx) {
-            return $('<div>')
+            return $('<button>')
+              .attr('type', 'button')
               .attr('data-idx', idx)
               .addClass('palette-color')
               .addClass('ontouchstart' in window ? 'touch' : 'no-touch')
@@ -2324,7 +2325,8 @@ window.App = (function() {
           })
         );
         self.elements.palette.prepend(
-          $('<div>')
+          $('<button>')
+            .attr('type', 'button')
             .attr('data-idx', -1)
             .addClass('palette-color no-border deselect-button')
             .addClass('ontouchstart' in window ? 'touch' : 'no-touch').css('background-color', 'transparent')
@@ -2505,7 +2507,7 @@ window.App = (function() {
       },
       handle: null,
       report: function(id, x, y) {
-        const reportButton = crel('button', {}, 'Report');
+        const reportButton = crel('button', { class: 'text-button' }, 'Report');
         reportButton.addEventListener('click', function() {
           this.disabled = true;
           this.textContent = 'Sending...';
@@ -2552,7 +2554,7 @@ window.App = (function() {
             })
           ),
           [ // crel will inject the array as fragments
-            crel('button', { onclick: () => modal.closeAll() }, 'Cancel'),
+            crel('button', { class: 'text-button', onclick: () => modal.closeAll() }, 'Cancel'),
             reportButton
           ]
         ));
@@ -2672,14 +2674,14 @@ window.App = (function() {
         return self.elements.lookup.empty().append(
           $('<div>').addClass('content'),
           (!data.bg && user.isLoggedIn()
-            ? $('<button>').css('float', 'left').addClass('report-button').text('Report').click(function() {
+            ? $('<button>').css('float', 'left').addClass('report-button text-button').text('Report').click(function() {
               self.report(data.id, data.x, data.y);
             })
             : ''),
-          $('<button>').css('float', 'right').text('Close').click(function() {
+          $('<button>').css('float', 'right').addClass('text-button').text('Close').click(function() {
             self.elements.lookup.fadeOut(200);
           }),
-          (template.getOptions().use ? $('<button>').addClass('button').css('float', 'right').text('Move Template Here').click(function() {
+          (template.getOptions().use ? $('<button>').css('float', 'right').addClass('text-button').text('Move Template Here').click(function() {
             template.queueUpdate({
               ox: data.x,
               oy: data.y
@@ -4113,9 +4115,9 @@ window.App = (function() {
           };
 
           const popupWrapper = crel('div', { class: 'popup panels' });
-          const panelHeader = crel('header', { style: 'text-align: center' },
-            crel('div', { class: 'left' }, crel('i', {
-              class: 'fas fa-times text-red',
+          const panelHeader = crel('header', { class: 'panel-header' },
+            crel('button', { class: 'left panel-closer' }, crel('i', {
+              class: 'fas fa-times',
               onclick: closeHandler
             })),
             crel('h2', 'Pings'),
@@ -4421,7 +4423,7 @@ window.App = (function() {
         const lblTemplateTitles = crel('label', _cbTemplateTitles, 'Replace template titles with URLs in chat where applicable');
 
         const _txtFontSize = crel('input', { type: 'number', min: '1', max: '72' });
-        const _btnFontSizeConfirm = crel('button', {}, crel('i', { class: 'fas fa-check' }));
+        const _btnFontSizeConfirm = crel('button', { class: 'text-button' }, crel('i', { class: 'fas fa-check' }));
         const lblFontSize = crel('label', 'Font Size: ', _txtFontSize, _btnFontSizeConfirm);
 
         const _cbHorizontal = crel('input', { type: 'checkbox' });
@@ -4452,7 +4454,7 @@ window.App = (function() {
           crel('option', { value: x }, x)
         )
         );
-        const _btnUnignore = crel('button', { style: 'margin-left: .5rem' }, 'Unignore');
+        const _btnUnignore = crel('button', { class: 'text-button', style: 'margin-left: .5rem' }, 'Unignore');
         const lblIgnores = crel('label', 'Ignores: ', _selIgnores, _btnUnignore);
         const lblIgnoresFeedback = crel('label', { style: 'display: none; margin-left: 1rem;' }, '');
 
@@ -5024,6 +5026,7 @@ window.App = (function() {
               ['OK', () => resolve(bodyWrapper.querySelector('input[type=radio]:checked').dataset.actionId >> 0)]
             ].map(x =>
               crel('button', {
+                class: 'text-button',
                 style: 'margin-left: 3px; position: initial !important; bottom: initial !important; right: initial !important;',
                 onclick: x[1]
               }, x[0])
@@ -5088,9 +5091,9 @@ window.App = (function() {
 
           const popupWrapper = crel('div', { class: 'popup panels', 'data-popup-for': id });
           const panelHeader = crel('header',
-            { style: 'text-align: center;' },
-            crel('div', { class: 'left' }, crel('i', {
-              class: 'fas fa-times text-red',
+            { class: 'panel-header' },
+            crel('button', { class: 'left panel-closer' }, crel('i', {
+              class: 'fas fa-times',
               onclick: closeHandler
             })),
             crel('span', (closest.dataset.tag ? `[${closest.dataset.tag}] ` : null), closest.dataset.author, badges),
@@ -5234,6 +5237,7 @@ window.App = (function() {
                   textArea,
                   crel('div', { style: 'text-align: right' },
                     crel('button', {
+                      class: 'text-button',
                       style: 'position: initial; margin-right: .25rem',
                       type: 'button',
                       onclick: () => {
@@ -5356,13 +5360,14 @@ window.App = (function() {
             const _reasonWrap = crel('div', { style: 'display: block;' });
 
             const _btnCancel = crel('button', {
+              class: 'text-button',
               type: 'button',
               onclick: () => {
                 chatbanContainer.remove();
                 modal.closeAll();
               }
             }, 'Cancel');
-            const _btnOK = crel('button', { type: 'submit' }, 'Ban');
+            const _btnOK = crel('button', { class: 'text-button', type: 'submit' }, 'Ban');
 
             const chatbanContainer = crel('form', {
               class: 'chatmod-container',
@@ -5483,7 +5488,7 @@ window.App = (function() {
             if (e.shiftKey === true) {
               return dodelete();
             }
-            const btndelete = crel('button', {}, 'Delete');
+            const btndelete = crel('button', { class: 'text-button' }, 'Delete');
             btndelete.onclick = () => dodelete();
             const deleteWrapper = crel('div', { class: 'chatmod-container' },
               crel('table',
@@ -5506,6 +5511,7 @@ window.App = (function() {
               ),
               crel('div', { class: 'buttons' },
                 crel('button', {
+                  class: 'text-button',
                   type: 'button',
                   onclick: () => {
                     deleteWrapper.remove();
@@ -5527,7 +5533,7 @@ window.App = (function() {
             const txtPurgeReason = crel('input', { type: 'text', onkeydown: e => e.stopPropagation() });
             const lblPurgeReasonError = crel('label', { class: 'hidden error-label' });
 
-            const btnPurge = crel('button', { type: 'submit' }, 'Purge');
+            const btnPurge = crel('button', { class: 'text-button', type: 'submit' }, 'Purge');
 
             const messageTable = mode
               ? crel('table',
@@ -5558,6 +5564,7 @@ window.App = (function() {
               ),
               crel('div', { class: 'buttons' },
                 crel('button', {
+                  class: 'text-button',
                   type: 'button',
                   onclick: () => {
                     purgeWrapper.remove();
@@ -5609,7 +5616,7 @@ window.App = (function() {
             const stateOn = crel('label', { style: 'display: inline-block' }, rbStateOn, ' On');
             const stateOff = crel('label', { style: 'display: inline-block' }, rbStateOff, ' Off');
 
-            const btnSetState = crel('button', { type: 'submit' }, 'Set');
+            const btnSetState = crel('button', { class: 'text-button', type: 'submit' }, 'Set');
 
             const renameError = crel('p', {
               style: 'display: none; color: #f00; font-weight: bold; font-size: .9rem',
@@ -5625,6 +5632,7 @@ window.App = (function() {
               renameError,
               crel('div', { class: 'buttons' },
                 crel('button', {
+                  class: 'text-button',
                   type: 'button',
                   onclick: () => {
                     renameWrapper.remove();
@@ -5672,7 +5680,7 @@ window.App = (function() {
             });
             const newNameWrapper = crel('label', 'New Name: ', newNameInput);
 
-            const btnSetState = crel('button', { type: 'submit' }, 'Set');
+            const btnSetState = crel('button', { class: 'text-button', type: 'submit' }, 'Set');
 
             const renameError = crel('p', {
               style: 'display: none; color: #f00; font-weight: bold; font-size: .9rem',
@@ -5685,6 +5693,7 @@ window.App = (function() {
               renameError,
               crel('div', { class: 'buttons' },
                 crel('button', {
+                  class: 'text-button',
                   type: 'button',
                   onclick: () => {
                     modal.closeAll();
@@ -6041,7 +6050,7 @@ window.App = (function() {
         self.elements.loginOverlay.find('a').click(function(evt) {
           evt.preventDefault();
 
-          const cancelButton = crel('button', { class: 'float-right' }, 'Cancel');
+          const cancelButton = crel('button', { class: 'float-right text-button' }, 'Cancel');
           cancelButton.addEventListener('click', function() {
             self.elements.prompt.fadeOut(200);
           });
@@ -6272,8 +6281,8 @@ window.App = (function() {
             class: 'rename-error'
           }, ''),
           crel('div', { style: 'text-align: right' },
-            crel('button', { onclick: () => modal.closeAll() }, 'Not now'),
-            crel('button', { class: 'rename-submit', type: 'submit' }, 'Change')
+            crel('button', { class: 'text-button', onclick: () => modal.closeAll() }, 'Not now'),
+            crel('button', { class: 'rename-submit text-button', type: 'submit' }, 'Change')
           )
         );
         modal.show(modal.buildDom(
@@ -6551,13 +6560,18 @@ window.App = (function() {
           });
         }
       },
+      buildCloser: function() {
+        const button = crel('button', { class: 'panel-closer' }, crel('i', { class: 'fas fa-times' }));
+        button.addEventListener('click', () => modal.closeTop());
+        return button;
+      },
       buildDom: function(headerContent, bodyContent, footerContent) {
         return crel('div', { class: 'modal panel', tabindex: '-1', role: 'dialog' },
           crel('div', { class: 'modal-wrapper', role: 'document' },
             headerContent == null ? null : crel('header', { class: 'modal-header panel-header' },
               crel('div', { class: 'left' }),
               crel('div', { class: 'mid' }, headerContent),
-              crel('div', { class: 'right' }, crel('a', { class: 'fas fa-times text-red', rel: 'modal:close' }))),
+              crel('div', { class: 'right' }, this.buildCloser())),
             bodyContent == null ? null : crel('div', { class: 'modal-body' }, bodyContent),
             footerContent == null ? null : crel('footer', { class: 'modal-footer panel-footer' }, footerContent)
           )

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -2551,12 +2551,12 @@ window.App = (function() {
               placeholder: 'Additional information (if applicable)',
               style: 'width: 100%; height: 5em',
               onkeydown: e => e.stopPropagation()
-            })
-          ),
-          [ // crel will inject the array as fragments
-            crel('button', { class: 'text-button', onclick: () => modal.closeAll() }, 'Cancel'),
-            reportButton
-          ]
+            }),
+            crel('div', { class: 'buttons' },
+              crel('button', { class: 'text-button', onclick: () => modal.closeAll() }, 'Cancel'),
+              reportButton
+            )
+          )
         ));
       },
       /**

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -2505,7 +2505,7 @@ window.App = (function() {
       },
       handle: null,
       report: function(id, x, y) {
-        const reportButton = crel('button', { class: 'button' }, 'Report');
+        const reportButton = crel('button', {}, 'Report');
         reportButton.addEventListener('click', function() {
           this.disabled = true;
           this.textContent = 'Sending...';
@@ -2552,7 +2552,7 @@ window.App = (function() {
             })
           ),
           [ // crel will inject the array as fragments
-            crel('button', { class: 'button', onclick: () => modal.closeAll() }, 'Cancel'),
+            crel('button', { onclick: () => modal.closeAll() }, 'Cancel'),
             reportButton
           ]
         ));
@@ -2672,14 +2672,14 @@ window.App = (function() {
         return self.elements.lookup.empty().append(
           $('<div>').addClass('content'),
           (!data.bg && user.isLoggedIn()
-            ? $('<div>').addClass('button').css('float', 'left').addClass('report-button').text('Report').click(function() {
+            ? $('<button>').css('float', 'left').addClass('report-button').text('Report').click(function() {
               self.report(data.id, data.x, data.y);
             })
             : ''),
-          $('<div>').addClass('button').css('float', 'right').text('Close').click(function() {
+          $('<button>').css('float', 'right').text('Close').click(function() {
             self.elements.lookup.fadeOut(200);
           }),
-          (template.getOptions().use ? $('<div>').addClass('button').css('float', 'right').text('Move Template Here').click(function() {
+          (template.getOptions().use ? $('<button>').addClass('button').css('float', 'right').text('Move Template Here').click(function() {
             template.queueUpdate({
               ox: data.x,
               oy: data.y
@@ -4452,7 +4452,7 @@ window.App = (function() {
           crel('option', { value: x }, x)
         )
         );
-        const _btnUnignore = crel('button', { class: 'button', style: 'margin-left: .5rem' }, 'Unignore');
+        const _btnUnignore = crel('button', { style: 'margin-left: .5rem' }, 'Unignore');
         const lblIgnores = crel('label', 'Ignores: ', _selIgnores, _btnUnignore);
         const lblIgnoresFeedback = crel('label', { style: 'display: none; margin-left: 1rem;' }, '');
 
@@ -5024,7 +5024,6 @@ window.App = (function() {
               ['OK', () => resolve(bodyWrapper.querySelector('input[type=radio]:checked').dataset.actionId >> 0)]
             ].map(x =>
               crel('button', {
-                class: 'button',
                 style: 'margin-left: 3px; position: initial !important; bottom: initial !important; right: initial !important;',
                 onclick: x[1]
               }, x[0])
@@ -5215,7 +5214,6 @@ window.App = (function() {
         switch (this.dataset.action.toLowerCase().trim()) {
           case 'report': {
             const reportButton = crel('button', {
-              class: 'button',
               style: 'position: initial;',
               type: 'submit'
             }, 'Report');
@@ -5236,7 +5234,6 @@ window.App = (function() {
                   textArea,
                   crel('div', { style: 'text-align: right' },
                     crel('button', {
-                      class: 'button',
                       style: 'position: initial; margin-right: .25rem',
                       type: 'button',
                       onclick: () => {
@@ -5359,14 +5356,13 @@ window.App = (function() {
             const _reasonWrap = crel('div', { style: 'display: block;' });
 
             const _btnCancel = crel('button', {
-              class: 'button',
               type: 'button',
               onclick: () => {
                 chatbanContainer.remove();
                 modal.closeAll();
               }
             }, 'Cancel');
-            const _btnOK = crel('button', { class: 'button', type: 'submit' }, 'Ban');
+            const _btnOK = crel('button', { type: 'submit' }, 'Ban');
 
             const chatbanContainer = crel('form', {
               class: 'chatmod-container',
@@ -5487,7 +5483,7 @@ window.App = (function() {
             if (e.shiftKey === true) {
               return dodelete();
             }
-            const btndelete = crel('button', { class: 'button' }, 'Delete');
+            const btndelete = crel('button', {}, 'Delete');
             btndelete.onclick = () => dodelete();
             const deleteWrapper = crel('div', { class: 'chatmod-container' },
               crel('table',
@@ -5510,7 +5506,6 @@ window.App = (function() {
               ),
               crel('div', { class: 'buttons' },
                 crel('button', {
-                  class: 'button',
                   type: 'button',
                   onclick: () => {
                     deleteWrapper.remove();
@@ -5532,7 +5527,7 @@ window.App = (function() {
             const txtPurgeReason = crel('input', { type: 'text', onkeydown: e => e.stopPropagation() });
             const lblPurgeReasonError = crel('label', { class: 'hidden error-label' });
 
-            const btnPurge = crel('button', { class: 'button', type: 'submit' }, 'Purge');
+            const btnPurge = crel('button', { type: 'submit' }, 'Purge');
 
             const messageTable = mode
               ? crel('table',
@@ -5563,7 +5558,6 @@ window.App = (function() {
               ),
               crel('div', { class: 'buttons' },
                 crel('button', {
-                  class: 'button',
                   type: 'button',
                   onclick: () => {
                     purgeWrapper.remove();
@@ -5615,7 +5609,7 @@ window.App = (function() {
             const stateOn = crel('label', { style: 'display: inline-block' }, rbStateOn, ' On');
             const stateOff = crel('label', { style: 'display: inline-block' }, rbStateOff, ' Off');
 
-            const btnSetState = crel('button', { class: 'button', type: 'submit' }, 'Set');
+            const btnSetState = crel('button', { type: 'submit' }, 'Set');
 
             const renameError = crel('p', {
               style: 'display: none; color: #f00; font-weight: bold; font-size: .9rem',
@@ -5631,7 +5625,6 @@ window.App = (function() {
               renameError,
               crel('div', { class: 'buttons' },
                 crel('button', {
-                  class: 'button',
                   type: 'button',
                   onclick: () => {
                     renameWrapper.remove();
@@ -5679,7 +5672,7 @@ window.App = (function() {
             });
             const newNameWrapper = crel('label', 'New Name: ', newNameInput);
 
-            const btnSetState = crel('button', { class: 'button', type: 'submit' }, 'Set');
+            const btnSetState = crel('button', { type: 'submit' }, 'Set');
 
             const renameError = crel('p', {
               style: 'display: none; color: #f00; font-weight: bold; font-size: .9rem',
@@ -5692,7 +5685,6 @@ window.App = (function() {
               renameError,
               crel('div', { class: 'buttons' },
                 crel('button', {
-                  class: 'button',
                   type: 'button',
                   onclick: () => {
                     modal.closeAll();
@@ -6049,7 +6041,7 @@ window.App = (function() {
         self.elements.loginOverlay.find('a').click(function(evt) {
           evt.preventDefault();
 
-          const cancelButton = crel('button', { class: 'button' }, 'Cancel');
+          const cancelButton = crel('button', {}, 'Cancel');
           cancelButton.addEventListener('click', function() {
             self.elements.prompt.fadeOut(200);
           });
@@ -6280,8 +6272,8 @@ window.App = (function() {
             class: 'rename-error'
           }, ''),
           crel('div', { style: 'text-align: right' },
-            crel('button', { class: 'button', onclick: () => modal.closeAll() }, 'Not now'),
-            crel('button', { class: 'button rename-submit', type: 'submit' }, 'Change')
+            crel('button', { onclick: () => modal.closeAll() }, 'Not now'),
+            crel('button', { class: 'rename-submit', type: 'submit' }, 'Change')
           )
         );
         modal.show(modal.buildDom(

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -3485,19 +3485,15 @@ window.App = (function() {
             $(window).trigger('pxls:panel:opened', panelDescriptor);
             document.body.classList.toggle('panel-open', true);
             document.body.classList.toggle(`panel-${panelPosition}`, true);
-            if (panel.classList.contains('half-width')) {
-              document.body.classList.toggle(`panel-${panelPosition}-halfwidth`, true);
-            } else if (panel.classList.contains('horizontal')) {
-              document.body.classList.toggle('panel-horizontal', true);
-            }
           } else {
             $(window).trigger('pxls:panel:closed', panelDescriptor);
             document.body.classList.toggle('panel-open', document.querySelectorAll('.panel.open').length - 1 > 0);
             document.body.classList.toggle(`panel-${panelPosition}`, false);
-            document.body.classList.toggle(`panel-${panelPosition}-halfwidth`, false);
-            document.body.classList.toggle('panel-horizontal', false);
           }
           panel.classList.toggle('open', state);
+
+          document.body.classList.toggle(`panel-${panelPosition}-halfwidth`, $(`.panel[data-panel].${panelPosition}.open.half-width`).length > 0);
+          document.body.classList.toggle(`panel-${panelPosition}-horizontal`, $(`.panel[data-panel].${panelPosition}.open.horizontal`).length > 0);
         }
       }
     };
@@ -4546,7 +4542,7 @@ window.App = (function() {
           if (_chatPanel) {
             _chatPanel.classList.toggle('horizontal', this.checked === true);
             if (_chatPanel.classList.contains('open')) {
-              document.body.classList.toggle('panel-horizontal', this.checked === true);
+              document.body.classList.toggle(`panel-${_chatPanel.classList.contains('right') ? 'right' : 'left'}-horizontal`, this.checked === true);
             }
           }
         });

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -4421,7 +4421,7 @@ window.App = (function() {
         const lblTemplateTitles = crel('label', _cbTemplateTitles, 'Replace template titles with URLs in chat where applicable');
 
         const _txtFontSize = crel('input', { type: 'number', min: '1', max: '72' });
-        const _btnFontSizeConfirm = crel('button', { class: 'buton' }, crel('i', { class: 'fas fa-check' }));
+        const _btnFontSizeConfirm = crel('button', {}, crel('i', { class: 'fas fa-check' }));
         const lblFontSize = crel('label', 'Font Size: ', _txtFontSize, _btnFontSizeConfirm);
 
         const _cbHorizontal = crel('input', { type: 'checkbox' });

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -6554,12 +6554,12 @@ window.App = (function() {
       buildDom: function(headerContent, bodyContent, footerContent) {
         return crel('div', { class: 'modal panel', tabindex: '-1', role: 'dialog' },
           crel('div', { class: 'modal-wrapper', role: 'document' },
-            headerContent == null ? null : crel('header', { class: 'modal-header' },
+            headerContent == null ? null : crel('header', { class: 'modal-header panel-header' },
               crel('div', { class: 'left' }),
               crel('div', { class: 'mid' }, headerContent),
               crel('div', { class: 'right' }, crel('a', { class: 'fas fa-times text-red', rel: 'modal:close' }))),
             bodyContent == null ? null : crel('div', { class: 'modal-body' }, bodyContent),
-            footerContent == null ? null : crel('footer', { class: 'modal-footer' }, footerContent)
+            footerContent == null ? null : crel('footer', { class: 'modal-footer panel-footer' }, footerContent)
           )
         );
       },

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -2507,7 +2507,7 @@ window.App = (function() {
       },
       handle: null,
       report: function(id, x, y) {
-        const reportButton = crel('button', { class: 'text-button' }, 'Report');
+        const reportButton = crel('button', { class: 'text-button dangerous-button' }, 'Report');
         reportButton.addEventListener('click', function() {
           this.disabled = true;
           this.textContent = 'Sending...';
@@ -5186,7 +5186,7 @@ window.App = (function() {
         switch (this.dataset.action.toLowerCase().trim()) {
           case 'report': {
             const reportButton = crel('button', {
-              style: 'position: initial;',
+              class: 'text-button dangerous-button',
               type: 'submit'
             }, 'Report');
             const textArea = crel('textarea', {
@@ -5336,7 +5336,7 @@ window.App = (function() {
                 modal.closeAll();
               }
             }, 'Cancel');
-            const _btnOK = crel('button', { class: 'text-button', type: 'submit' }, 'Ban');
+            const _btnOK = crel('button', { class: 'text-button dangerous-button', type: 'submit' }, 'Ban');
 
             const chatbanContainer = crel('form', {
               class: 'chatmod-container',
@@ -5457,7 +5457,7 @@ window.App = (function() {
             if (e.shiftKey === true) {
               return dodelete();
             }
-            const btndelete = crel('button', { class: 'text-button' }, 'Delete');
+            const btndelete = crel('button', { class: 'text-button dangerous-button' }, 'Delete');
             btndelete.onclick = () => dodelete();
             const deleteWrapper = crel('div', { class: 'chatmod-container' },
               crel('table',
@@ -5499,7 +5499,7 @@ window.App = (function() {
           case 'purge': {
             const txtPurgeReason = crel('input', { type: 'text', onkeydown: e => e.stopPropagation() });
 
-            const btnPurge = crel('button', { class: 'text-button', type: 'submit' }, 'Purge');
+            const btnPurge = crel('button', { class: 'text-button dangerous-button', type: 'submit' }, 'Purge');
 
             const messageTable = mode
               ? crel('table',

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -3047,7 +3047,7 @@ window.App = (function() {
           switch (evt.key || evt.which) {
             case 'Escape':
             case 27: {
-              const selector = $('#lookup, #prompt, #alert, .popup.panels');
+              const selector = $('#lookup, #prompt, #alert, .popup');
               const openPanels = $('.panel.open');
               if (selector.is(':visible')) {
                 selector.fadeOut(200);
@@ -4083,7 +4083,7 @@ window.App = (function() {
         });
 
         $(window).on('resize', e => {
-          const popup = document.querySelector('.popup.panels[data-popup-for]');
+          const popup = document.querySelector('.popup[data-popup-for]');
           if (!popup) return;
           const cog = document.querySelector(`.chat-line[data-id="${popup.dataset.popupFor}"] [data-action="actions-panel"]`);
           if (!cog) return console.warn('no cog');
@@ -4096,7 +4096,7 @@ window.App = (function() {
         });
 
         self.elements.body[0].addEventListener('wheel', e => {
-          const popup = document.querySelector('.popup.panels');
+          const popup = document.querySelector('.popup');
           if (popup) popup.remove();
         });
 
@@ -4115,12 +4115,12 @@ window.App = (function() {
         self.elements.pings_button[0].addEventListener('click', function() {
           const closeHandler = function() {
             if (this && this.closest) {
-              const toClose = this.closest('.popup.panels');
+              const toClose = this.closest('.popup');
               if (toClose) toClose.remove();
             }
           };
 
-          const popupWrapper = crel('div', { class: 'popup panels' });
+          const popupWrapper = crel('div', { class: 'popup panel' });
           const panelHeader = crel('header', { class: 'panel-header' },
             crel('button', { class: 'left panel-closer' }, crel('i', {
               class: 'fas fa-times',
@@ -4588,7 +4588,7 @@ window.App = (function() {
             lblUsernameColor,
             lblIgnores,
             lblIgnoresFeedback
-          ].map(x => crel('div', { class: 'd-block' }, x))
+          ].map(x => crel('div', x))
         );
         modal.show(modal.buildDom(
           crel('h2', { class: 'modal-title' }, 'Chat Settings'),
@@ -5090,12 +5090,12 @@ window.App = (function() {
 
           const closeHandler = function() {
             if (this && this.closest) {
-              const toClose = this.closest('.popup.panels');
+              const toClose = this.closest('.popup');
               if (toClose) toClose.remove();
             }
           };
 
-          const popupWrapper = crel('div', { class: 'popup panels panel', 'data-popup-for': id });
+          const popupWrapper = crel('div', { class: 'popup panel', 'data-popup-for': id });
           const panelHeader = crel('header',
             { class: 'panel-header' },
             crel('button', { class: 'left panel-closer' }, crel('i', {
@@ -5497,10 +5497,7 @@ window.App = (function() {
             break;
           }
           case 'purge': {
-            // const lblPurgeAmountError = crel('label', { class: 'hidden error-label' });
-
             const txtPurgeReason = crel('input', { type: 'text', onkeydown: e => e.stopPropagation() });
-            const lblPurgeReasonError = crel('label', { class: 'hidden error-label' });
 
             const btnPurge = crel('button', { class: 'text-button', type: 'submit' }, 'Purge');
 
@@ -5527,9 +5524,7 @@ window.App = (function() {
               messageTable,
               crel('div',
                 crel('h5', 'Purge Reason'),
-                txtPurgeReason,
-                crel('br'),
-                lblPurgeReasonError
+                txtPurgeReason
               ),
               crel('div', { class: 'buttons' },
                 crel('button', {

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -2674,7 +2674,7 @@ window.App = (function() {
         return self.elements.lookup.empty().append(
           $('<div>').addClass('content'),
           (!data.bg && user.isLoggedIn()
-            ? $('<button>').css('float', 'left').addClass('report-button text-button').text('Report').click(function() {
+            ? $('<button>').css('float', 'left').addClass('dangerous-button text-button').text('Report').click(function() {
               self.report(data.id, data.x, data.y);
             })
             : ''),
@@ -5110,7 +5110,7 @@ window.App = (function() {
           const actionsList = crel('ul', { class: 'actions-list' });
 
           const actions = [
-            { label: 'Report', action: 'report', class: 'report-button' },
+            { label: 'Report', action: 'report', class: 'dangerous-button' },
             { label: 'Mention', action: 'mention' },
             { label: 'Ignore', action: 'ignore' },
             { label: 'Profile', action: 'profile' },

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -4330,12 +4330,12 @@ window.App = (function() {
             } else {
               self.elements.typeahead_list[0].innerHTML = '';
               const LIs = got.slice(0, 10).map(x =>
-                crel('li', {
+                crel('li', crel('button', {
                   'data-insert': `${x} `,
                   'data-start': scanRes.start,
                   'data-end': scanRes.end,
                   onclick: self._handleTypeaheadInsert
-                }, x)
+                }, x))
               );
               LIs[0].classList.add('active');
               crel(self.elements.typeahead_list[0], LIs);

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -5095,7 +5095,7 @@ window.App = (function() {
             }
           };
 
-          const popupWrapper = crel('div', { class: 'popup panels', 'data-popup-for': id });
+          const popupWrapper = crel('div', { class: 'popup panels panel', 'data-popup-for': id });
           const panelHeader = crel('header',
             { class: 'panel-header' },
             crel('button', { class: 'left panel-closer' }, crel('i', {
@@ -5121,7 +5121,7 @@ window.App = (function() {
             { label: 'Chat Lookup', action: 'lookup-chat', staffaction: true }
           ];
 
-          crel(leftPanel, crel('p', { class: 'popup-timestamp-header' }, moment.unix(closest.dataset.date >> 0).format(`MMM Do YYYY, ${(ls.get('chat.24h') === true ? 'HH:mm:ss' : 'hh:mm:ss A')}`)));
+          crel(leftPanel, crel('p', { class: 'popup-timestamp-header text-muted' }, moment.unix(closest.dataset.date >> 0).format(`MMM Do YYYY, ${(ls.get('chat.24h') === true ? 'HH:mm:ss' : 'hh:mm:ss A')}`)));
           crel(leftPanel, crel('p', { class: 'content', style: 'margin-top: 3px; margin-left: 3px; text-align: left;' }, closest.querySelector('.content').textContent));
 
           crel(actionsList, actions

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -5105,7 +5105,7 @@ window.App = (function() {
             crel('span', (closest.dataset.tag ? `[${closest.dataset.tag}] ` : null), closest.dataset.author, badges),
             crel('div', { class: 'right' })
           );
-          const leftPanel = crel('div', { class: 'pane details-wrapper' });
+          const leftPanel = crel('div', { class: 'pane details-wrapper chat-line' });
           const rightPanel = crel('div', { class: 'pane actions-wrapper' });
           const actionsList = crel('ul', { class: 'actions-list' });
 
@@ -5157,7 +5157,7 @@ window.App = (function() {
           }, 'Chat Lookup');
 
           crel(leftPanel, crel('p', { class: 'popup-timestamp-header' }, moment.unix(closest.dataset.date >> 0).format(`MMM Do YYYY, ${(ls.get('chat.24h') === true ? 'HH:mm:ss' : 'hh:mm:ss A')}`)));
-          crel(leftPanel, crel('p', { style: 'margin-top: 3px; margin-left: 3px; text-align: left;' }, closest.querySelector('.content').textContent));
+          crel(leftPanel, crel('p', { class: 'content', style: 'margin-top: 3px; margin-left: 3px; text-align: left;' }, closest.querySelector('.content').textContent));
 
           crel(actionsList, actionReport);
           crel(actionsList, actionMention);

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -6041,34 +6041,34 @@ window.App = (function() {
         self.elements.loginOverlay.find('a').click(function(evt) {
           evt.preventDefault();
 
-          const cancelButton = crel('button', {}, 'Cancel');
+          const cancelButton = crel('button', { class: 'float-right' }, 'Cancel');
           cancelButton.addEventListener('click', function() {
             self.elements.prompt.fadeOut(200);
           });
 
           self.elements.prompt[0].innerHTML = '';
           crel(self.elements.prompt[0],
-            crel('h1', 'Sign in with...'),
-            crel('ul',
-              Object.values(data.authServices).map(service => {
-                const anchor = crel('a', { href: `/signin/${service.id}?redirect=1` }, service.name);
-                anchor.addEventListener('click', function(e) {
-                  if (window.open(this.href, '_blank')) {
-                    e.preventDefault();
-                    return;
+            crel('div', { class: 'content' },
+              crel('h1', 'Sign in with...'),
+              crel('ul',
+                Object.values(data.authServices).map(service => {
+                  const anchor = crel('a', { href: `/signin/${service.id}?redirect=1` }, service.name);
+                  anchor.addEventListener('click', function(e) {
+                    if (window.open(this.href, '_blank')) {
+                      e.preventDefault();
+                      return;
+                    }
+                    ls.set('auth_same_window', true);
+                  });
+                  const toRet = crel('li', anchor);
+                  if (!service.registrationEnabled) {
+                    crel(toRet, crel('span', { style: 'font-style: italic; font-size: .75em; font-weight: bold; color: red; margin-left: .5em' }, 'New Accounts Disabled'));
                   }
-                  ls.set('auth_same_window', true);
-                });
-                const toRet = crel('li', anchor);
-                if (!service.registrationEnabled) {
-                  crel(toRet, crel('span', { style: 'font-style: italic; font-size: .75em; font-weight: bold; color: red; margin-left: .5em' }, 'New Accounts Disabled'));
-                }
-                return toRet;
-              })
+                  return toRet;
+                })
+              )
             ),
-            crel('div', { class: 'buttons' },
-              cancelButton
-            )
+            cancelButton
           );
           self.elements.prompt.fadeIn(200);
         });

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -6538,7 +6538,7 @@ window.App = (function() {
           closeExisting: true,
           escapeClose: true,
           clickClose: true,
-          showClose: true,
+          showClose: false,
           closeText: '<i class="fas fa-times"></i>'
         }, { removeOnClose: true }, opts);
         if (!document.body.contains(modal)) {
@@ -6552,11 +6552,14 @@ window.App = (function() {
         }
       },
       buildDom: function(headerContent, bodyContent, footerContent) {
-        return crel('div', { class: 'modal', tabindex: '-1', role: 'dialog' },
+        return crel('div', { class: 'modal panel', tabindex: '-1', role: 'dialog' },
           crel('div', { class: 'modal-wrapper', role: 'document' },
-            headerContent == null ? null : crel('div', { class: 'modal-header' }, headerContent),
+            headerContent == null ? null : crel('header', { class: 'modal-header' },
+              crel('div', { class: 'left' }),
+              crel('div', { class: 'mid' }, headerContent),
+              crel('div', { class: 'right' }, crel('a', { class: 'fas fa-times text-red', rel: 'modal:close' }))),
             bodyContent == null ? null : crel('div', { class: 'modal-body' }, bodyContent),
-            footerContent == null ? null : crel('div', { class: 'modal-footer' }, footerContent)
+            footerContent == null ? null : crel('footer', { class: 'modal-footer' }, footerContent)
           )
         );
       },

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -5109,67 +5109,30 @@ window.App = (function() {
           const rightPanel = crel('div', { class: 'pane actions-wrapper' });
           const actionsList = crel('ul', { class: 'actions-list' });
 
-          const actionReport = crel('li', {
-            class: 'text-red',
-            'data-action': 'report',
-            'data-id': id,
-            onclick: self._handleActionClick
-          }, 'Report');
-          const actionMention = crel('li', {
-            'data-action': 'mention',
-            'data-id': id,
-            onclick: self._handleActionClick
-          }, 'Mention');
-          const actionIgnore = crel('li', {
-            'data-action': 'ignore',
-            'data-id': id,
-            onclick: self._handleActionClick
-          }, 'Ignore');
-          const actionProfile = crel('li', {
-            'data-action': 'profile',
-            'data-id': id,
-            onclick: self._handleActionClick
-          }, 'Profile');
-          const actionChatban = crel('li', {
-            'data-action': 'chatban',
-            'data-id': id,
-            onclick: self._handleActionClick
-          }, 'Chat (un)ban');
-          const actionPurgeUser = crel('li', {
-            'data-action': 'purge',
-            'data-id': id,
-            onclick: self._handleActionClick
-          }, 'Purge User');
-          const actiondeleteMessage = crel('li', {
-            'data-action': 'delete',
-            'data-id': id,
-            onclick: self._handleActionClick
-          }, 'Delete');
-          const actionModLookup = crel('li', {
-            'data-action': 'lookup-mod',
-            'data-id': id,
-            onclick: self._handleActionClick
-          }, 'Mod Lookup');
-          const actionChatLookup = crel('li', {
-            'data-action': 'lookup-chat',
-            'data-id': id,
-            onclick: self._handleActionClick
-          }, 'Chat Lookup');
+          const actions = [
+            { label: 'Report', action: 'report', class: 'report-button' },
+            { label: 'Mention', action: 'mention' },
+            { label: 'Ignore', action: 'ignore' },
+            { label: 'Profile', action: 'profile' },
+            { label: 'Chat (un)ban', action: 'chatban', staffaction: true },
+            { label: 'Purge User', action: 'purge', staffaction: true },
+            { label: 'Delete', action: 'delete', staffaction: true },
+            { label: 'Mod Lookup', action: 'lookup-mod', staffaction: true },
+            { label: 'Chat Lookup', action: 'lookup-chat', staffaction: true }
+          ];
 
           crel(leftPanel, crel('p', { class: 'popup-timestamp-header' }, moment.unix(closest.dataset.date >> 0).format(`MMM Do YYYY, ${(ls.get('chat.24h') === true ? 'HH:mm:ss' : 'hh:mm:ss A')}`)));
           crel(leftPanel, crel('p', { class: 'content', style: 'margin-top: 3px; margin-left: 3px; text-align: left;' }, closest.querySelector('.content').textContent));
 
-          crel(actionsList, actionReport);
-          crel(actionsList, actionMention);
-          crel(actionsList, actionProfile);
-          crel(actionsList, actionIgnore);
-          if (user.isStaff()) {
-            crel(actionsList, actionChatban);
-            crel(actionsList, actiondeleteMessage);
-            crel(actionsList, actionPurgeUser);
-            crel(actionsList, actionModLookup);
-            crel(actionsList, actionChatLookup);
-          }
+          crel(actionsList, actions
+            .filter((action) => user.isStaff() || !action.staffaction)
+            .map((action) => crel('li', crel('button', {
+              type: 'button',
+              class: 'text-button fullwidth ' + (action.class || ''),
+              'data-action': action.action,
+              'data-id': id,
+              onclick: self._handleActionClick
+            }, action.label))));
           crel(rightPanel, actionsList);
 
           const popup = crel(popupWrapper, panelHeader, leftPanel, rightPanel);

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -2896,7 +2896,7 @@ window.App = (function() {
           modal.show(modal.buildDom(
             crel('h2', { class: 'modal-title' }, 'Alert'),
             crel('p', { style: 'padding: 0; margin: 0;' }, data.message),
-            crel('span', { style: 'font-style: italic' }, `Sent from ${data.sender || '$Unknown'}`)
+            crel('span', `Sent from ${data.sender || '$Unknown'}`)
           ), { closeExisting: false });
         });
         socket.on('received_report', (data) => {
@@ -6438,12 +6438,12 @@ window.App = (function() {
         }
       },
       makeDomForNotification(notification) {
-        return crel('div', { class: 'notification', 'data-notification-id': notification.id },
-          crel('div', { class: 'notification-title' }, notification.title),
+        return crel('article', { class: 'notification', 'data-notification-id': notification.id },
+          crel('header', { class: 'notification-title' }, crel('h2', notification.title)),
           chat.processMessage('div', 'notification-body', notification.content),
-          crel('div', { class: 'notification-footer' },
+          crel('footer', { class: 'notification-footer' },
             notification.who ? document.createTextNode(`Posted by ${notification.who}`) : null,
-            notification.expiry !== 0 ? crel('span', { class: 'notification-expiry' },
+            notification.expiry !== 0 ? crel('span', { class: 'notification-expiry float-left' },
               crel('i', { class: 'far fa-clock fa-is-left' }),
               crel('span', { title: moment.unix(notification.expiry).format('MMMM DD, YYYY, hh:mm:ss A') }, `Expires ${moment.unix(notification.expiry).format('MMM DD YYYY')}`)
             ) : null

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -501,11 +501,11 @@ body .message {
 
 #ui {
     position: fixed;
-    width: 100%;
-    height: 100%;
     top: 0;
+    bottom: 0;
     left: 0;
-    transition: width ease-in-out .25s, left ease-in-out .25s;
+    right: 0;
+    transition: left ease-in-out .25s, right ease-in-out .25s;
     user-select: none;
     -moz-user-select: none;
     -ms-user-select: none;
@@ -1037,7 +1037,10 @@ footer {
 aside.panel {
     position: fixed;
     top: 0;
-    max-width: 30%;
+    /* NOTE ([  ]): Ideally this would be max-width and we could set an overriding fixed min-width.
+                    This is just width because the main ui currently can't know how much of the min-with is used
+                    and can't adjust its own width accordingly. */
+    width: 30%;
     height: 100%;
     z-index: 21;
     cursor: initial !important;
@@ -1046,7 +1049,7 @@ aside.panel {
 aside.panel.left {
     right: initial;
     transition: left ease-in-out .25s;
-    left: -55%;
+    left: -35%;
 }
 
 aside.panel.left.open, .panel.left[data-state=open] {
@@ -1056,7 +1059,7 @@ aside.panel.left.open, .panel.left[data-state=open] {
 aside.panel.right {
     left: initial;
     transition: right ease-in-out .25s;
-    right: -55%;
+    right: -35%;
 }
 
 aside.panel.right.open, .panel.right[data-state=open] {
@@ -1067,6 +1070,19 @@ aside.panel .panel-body {
     overflow: auto;
     height: 100%;
     height: calc(100% - 2.75em);
+}
+
+aside.panel.half-width {
+    width: 50%;
+    max-width: 50%;
+}
+
+aside.panel.half-width.left {
+    left: -55%;
+}
+
+aside.panel.half-width.right {
+    right: -55%;
 }
 
 aside.panel.horizontal {
@@ -1229,38 +1245,28 @@ aside.panel.horizontal.right {
     margin: 0 !important;
 }
 
-body.panel-open:not(.panel-horizontal) #ui {
-    width: 70vw;
+body.panel-open.panel-left #ui {
+    left: 30%;
 }
 
-body.panel-open.panel-left:not(.panel-horizontal) #ui {
-    left: 30vw;
+body.panel-open.panel-right #ui {
+    right: 30%;
+}
+
+body.panel-open.panel-left.panel-left-halfwidth #ui {
+    left: 50%;
+}
+
+body.panel-open.panel-right.panel-right-halfwidth #ui {
+    right: 50%;
+}
+
+body.panel-open.panel-left.panel-left-horizontal #ui {
+    left: 0;
+}
+
+body.panel-open.panel-right.panel-right-horizontal #ui {
     right: 0;
-}
-
-body.panel-open.panel-left:not(.panel-horizontal).panel-left-halfwidth #ui {
-    left: 50vw;
-    width: 50vw;
-}
-
-body.panel-open.panel-right:not(.panel-horizontal).panel-right-halfwidth #ui {
-    right: 50vw;
-    width: 50vw;
-}
-
-body.panel-left.panel-right:not(.panel-horizontal) #ui {
-    left: 30vw;
-    width: 40vw;
-}
-
-body.panel-left.panel-left-halfwidth.panel-right:not(.panel-horizontal) #ui {
-    left: 50vw;
-    width: 20vw;
-}
-
-body.panel-left.panel-right:not(.panel-horizontal).panel-right-halfwidth #ui {
-    right: 50vw;
-    width: 20vw;
 }
 
 /* CHAT */

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -139,9 +139,9 @@ html {
     --emoji-picker-emoji-color: #333333;
     --emoji-picker-emoji-background: transparent;
     --emoji-picker-emoji-background-hover: #E8F4F9;
-    --emoji-picker-emoji-search-input-border-color: #CCCCCC;
-    --emoji-picker-emoji-search-input-background: #fff;
-    --emoji-picker-emoji-search-input-text-color: #000;
+    --emoji-picker-search-input-border-color: #CCCCCC;
+    --emoji-picker-search-input-background: #fff;
+    --emoji-picker-search-input-text-color: #000;
     --emoji-picker-search-icon-color: #CCCCCC;
     --emoji-picker-search-no-results-color: #666666;
     --emoji-picker-variant-overlay-background: rgba(0, 0, 0, 0.7);
@@ -1740,9 +1740,9 @@ body .emoji-picker {
     border: 1px solid #CCCCCC;
     border: 1px solid var(--emoji-picker-search-input-border-color);
     background: #fff;
-    background: var(--emoji-picker-emoji-search-input-background);
+    background: var(--emoji-picker-search-input-background);
     color: #000;
-    color: var(--emoji-picker-emoji-search-input-text-color);
+    color: var(--emoji-picker-search-input-text-color);
 }
 
 .emoji-picker .emoji-picker__search-icon {

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -1518,11 +1518,14 @@ li.chat-line .actions [data-action]:not(:last-of-type):not(:only-child) {
 
 #typeahead ul {
     list-style: none;
+}
+
+#typeahead ul, #typeahead ul li {
     margin: 0;
     padding: 0;
 }
 
-#typeahead ul li {
+#typeahead ul li button {
     font-size: 1em;
     line-height: 1.5em;
     cursor: pointer;
@@ -1535,14 +1538,16 @@ li.chat-line .actions [data-action]:not(:last-of-type):not(:only-child) {
     margin: 4px 0;
     color: inherit;
     color: var(--chat-typeahead-item-text-color);
+    width: 100%;
+    text-align: left;
 }
 
-#typeahead ul li:hover {
+#typeahead ul li button:hover {
     background-color: #949494;
     background-color: var(--chat-typeahead-item-background-color-hover);
 }
 
-#typeahead ul li.active {
+#typeahead ul li button.active {
     background-color: #828282;
     background-color: var(--chat-typeahead-item-background-color-active);
 }

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -470,15 +470,6 @@ body .message {
     margin-left: -1.25rem;
 }
 
-.chatmod-container .buttons {
-    text-align: right;
-}
-
-.chatmod-container .buttons button {
-    position: initial;
-    margin-right: .25rem;
-}
-
 .chatmod-container textarea {
     width: 100%;
     border: 1px solid #999;
@@ -502,6 +493,9 @@ body .message {
     border-radius: 3px;
 }
 
+.buttons {
+    text-align: right;
+}
 
 /*//////////////////////////*\
 | UI

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -25,39 +25,39 @@ z-index:
 
 html {
     --general-text-color: #000;
-    --general-background-color: #CDCDCD;
+    --general-background: #CDCDCD;
     
-    --kbd-background-color: #eee;
+    --kbd-background: #eee;
     --kbd-border-color: #ddd;
     --kbd-text-color: black;
         
-    --button-background-color: #ddd;
+    --button-background: #ddd;
     --button-border-color: #999;
     --button-text-color: #000;
     --button-text-color-disabled: #555;
     --button-border-color-disabled: #777;
-    --button-background-color-disabled: #aaa;
+    --button-background-disabled: #aaa;
     --button-text-color-hover: #fff;
     --button-border-color-hover: #999;
-    --button-background-color-hover: #ce4747;
+    --button-background-hover: #ce4747;
     
     --dangerous-button-text-color: #fff;
-    --dangerous-button-background-color: #e20;
+    --dangerous-button-background: #e20;
     --dangerous-button-border-color: unset;
     --dangerous-button-text-color-hover: var(--dangerous-button-text-color);
-    --dangerous-button-background-color-hover: #f10;
+    --dangerous-button-background-hover: #f10;
     --dangerous-button-border-color-hover: var(--dangerous-button-border-color);
     
     --floating-panel-text-color: inherit;
     --floating-panel-border-color: #ccc;
-    --floating-panel-background-color: #eee;
+    --floating-panel-background: #eee;
     
-    --bubble-background-color: rgba(0, 0, 0, 0.7);
+    --bubble-background: rgba(0, 0, 0, 0.7);
     --bubble-text-color: #fff;
     
-    --palette-background-color: rgba(255, 255, 255, 0.8);
+    --palette-background: rgba(255, 255, 255, 0.8);
     --palette-item-border-color: black;
-    --palette-overlay-background-color: rgba(255, 255, 255, 0.9);
+    --palette-overlay-background: rgba(255, 255, 255, 0.9);
     --palette-overlay-text-color: #000;
     --palette-deselect-button-color: inherit;
     
@@ -66,7 +66,7 @@ html {
     --undo-border-color: #000;
     
     --input-text-color: #000;
-    --input-background-color: #fff;
+    --input-background: #fff;
     --input-border-color: #ccc;
     
     --text-blue-color:#00a;
@@ -84,7 +84,7 @@ html {
     --ping-counter-color: #ffa500;
     --notification-expiry-color: #b66;
         
-    --panel-background-color: #dfdfdf;
+    --panel-background: #dfdfdf;
     --panel-text-color: inherit;
     --panel-border-color: #000;
     --panel-header-text-color: inherit;
@@ -95,7 +95,7 @@ html {
     --panel-close-button-color-hover: var(--panel-close-button-color);
     --panel-close-button-color-active: var(--panel-close-button-color);
     
-    --panel-article-background-color: #0002;
+    --panel-article-background: #0002;
     --panel-article-text-color: var(--panel-text-color);
     --panel-article-border-color: var(--panel-border-color);
     --panel-article-header-text-color: inherit;
@@ -106,32 +106,32 @@ html {
     --panel-trigger-outline-color: #AAA;
     
     --option-bubble-position-border-color-hovered: #6495ED;
-    --option-bubble-position-background-color-hovered: rgba(0, 0, 0, 0);
-    --option-bubble-position-background-color-selected: #eee;
+    --option-bubble-position-background-hovered: rgba(0, 0, 0, 0);
+    --option-bubble-position-background-selected: #eee;
     
     --chat-separator-color: #bfbfbf;
-    --chat-odd-background-color: #d5d5d5;
+    --chat-odd-background: #d5d5d5;
     --chat-abbr-underline-color: #aaa;
-    --chat-badge-background-color: #ccc;
+    --chat-badge-background: #ccc;
     --chat-badge-text-color: #770;
     --chat-server-action-text-color: #555;
     --chat-user-text-shadow-color: #ccc;
     --chat-purged-text-color: #888;
     
     --chat-tobottom-text-color: #fff;
-    --chat-tobottom-background-color: #66a;
+    --chat-tobottom-background: #66a;
     --chat-tobottom-text-color-hover: var(--chat-tobottom-text-color);
-    --chat-tobottom-background-color-hover: #5c5ca0;
+    --chat-tobottom-background-hover: #5c5ca0;
     
-    --chat-typeahead-menu-background-color: #b9b9b9;
+    --chat-typeahead-menu-background: #b9b9b9;
     --chat-typeahead-item-text-color: inherit;
-    --chat-typeahead-item-background-color: #a3a3a3;
-    --chat-typeahead-item-background-color-hover: #949494;
-    --chat-typeahead-item-background-color-active: #828282;
+    --chat-typeahead-item-background: #a3a3a3;
+    --chat-typeahead-item-background-hover: #949494;
+    --chat-typeahead-item-background-active: #828282;
 
     --emoji-picker-border-color: #999999;
     --emoji-picker-shadow-color: #CCCCCC;
-    --emoji-picker-background-color: #FFFFFF;
+    --emoji-picker-background: #FFFFFF;
     --emoji-picker-preview-name-text-color: #666666;
     --emoji-picker-tab-icon-color: inherit;
     --emoji-picker-tab-icon-color-selected: #4F81E5;
@@ -140,7 +140,7 @@ html {
     --emoji-picker-emoji-background: transparent;
     --emoji-picker-emoji-background-hover: #E8F4F9;
     --emoji-picker-emoji-search-input-border-color: #CCCCCC;
-    --emoji-picker-emoji-search-input-background-color: #fff;
+    --emoji-picker-emoji-search-input-background: #fff;
     --emoji-picker-emoji-search-input-text-color: #000;
     --emoji-picker-search-icon-color: #CCCCCC;
     --emoji-picker-search-no-results-color: #666666;
@@ -159,8 +159,8 @@ html, body {
     height: 100%;
     color: #000;
     color: var(--general-text-color);
-    background-color: #CDCDCD;
-    background-color: var(--general-background-color);
+    background: #CDCDCD;
+    background: var(--general-background);
     overflow: hidden;
     position: relative;
     font-family: sans-serif;
@@ -201,8 +201,8 @@ a, a:hover, a:visited, a:active, .link, .link:hover, .link:active {
 }
 
 kbd {
-    background-color: #eee;
-    background-color: var(--kbd-background-color);
+    background: #eee;
+    background: var(--kbd-background);
     border: 1px solid #ddd;
     border: 1px solid var(--kbd-border-color);
     border-radius: 4px;
@@ -244,8 +244,8 @@ input[type="text"], input[type="number"], textarea, select {
     padding: 0.5em;
     border: 1px solid #ccc;
     border: 1px solid var(--input-border-color);
-    background-color: #fff;
-    background-color: var(--input-background-color);
+    background: #fff;
+    background: var(--input-background);
     color: #000;
     color: var(--input-text-color);
 }
@@ -270,8 +270,8 @@ button.text-button {
     border: 1px solid var(--button-border-color);
     padding: 5px 10px;
     border-radius: 3px;
-    background-color: #ddd;
-    background-color: var(--button-background-color);
+    background: #ddd;
+    background: var(--button-background);
     color: #000;
     color: var(--button-text-color);
 }
@@ -279,8 +279,8 @@ button.text-button {
 button.text-button:disabled {
     border: 1px solid #777;
     border: 1px solid var(--button-border-color-disabled);
-    background-color: #aaa;
-    background-color: var(--button-background-color-disabled);
+    background: #aaa;
+    background: var(--button-background-disabled);
     color: #555;
     color: var(--button-text-color-disabled);
 }
@@ -289,13 +289,13 @@ button.text-button:hover {
     color: #fff;
     color: var(--button-text-color-hover);
     background: #ce4747;
-    background: var(--button-background-color-hover);
+    background: var(--button-background-hover);
     border-color: var(--button-border-color-hover);
 }
 
 button.dangerous-button {
-    background-color: #e20;
-    background-color: var(--dangerous-button-background-color);
+    background: #e20;
+    background: var(--dangerous-button-background);
     color: #fff;
     color: var(--dangerous-button-text-color);
     border-color: unset;
@@ -305,8 +305,8 @@ button.dangerous-button {
 button.dangerous-button:hover {
     color: #fff;
     color: var(--dangerous-button-text-color-hover);
-    background-color: #f10;
-    background-color: var(--dangerous-button-background-color-hover);
+    background: #f10;
+    background: var(--dangerous-button-background-hover);
     border-color: unset;
     border-color: var(--dangerous-button-border-color-hover);
 }
@@ -428,8 +428,8 @@ body .message {
     border-radius: 8px;
     border: 1px solid #ccc;
     border: 1px solid var(--floating-panel-border-color);
-    background-color: #eee;
-    background-color: var(--floating-panel-background-color);
+    background: #eee;
+    background: var(--floating-panel-background);
     color: inherit;
     color: var(--floating-panel-text-color);
     box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.3);
@@ -532,8 +532,8 @@ body .message {
     position: absolute;
     display: inline-block;
     padding: 8px 16px;
-    background-color: rgba(0, 0, 0, 0.7);
-    background-color: var(--bubble-background-color);
+    background: rgba(0, 0, 0, 0.7);
+    background: var(--bubble-background);
     border-radius: 5px;
     color: #fff;
     color: var(--bubble-text-color);
@@ -588,8 +588,8 @@ body .message {
     padding: 0 8px;
     width: 100%;
     height: 100%;
-    background-color: rgba(255, 255, 255, 0.9);
-    background-color: var(--palette-overlay-background-color);
+    background: rgba(255, 255, 255, 0.9);
+    background: var(--palette-overlay-background);
     color: #000;
     color: var(--palette-overlay-text-color);
     font-weight: 700;
@@ -609,8 +609,8 @@ body .message {
     overflow-x: auto;
     text-align: center;
     white-space: nowrap;
-    background-color: rgba(255, 255, 255, 0.8);
-    background-color: var(--palette-background-color);
+    background: rgba(255, 255, 255, 0.8);
+    background: var(--palette-background);
 
     /* Scrollbar, Firefox only */
     scrollbar-width: thin;
@@ -1073,8 +1073,8 @@ aside.panel .panel-body {
 
 .panel {
     box-shadow: 0 0 10px 5px #0009;
-    background-color: #dfdfdf;
-    background-color: var(--panel-background-color);
+    background: #dfdfdf;
+    background: var(--panel-background);
     color: inherit;
     color: var(--panel-text-color);
 }
@@ -1167,8 +1167,8 @@ aside.panel .panel-body {
     color: var(--panel-article-text-color);
     border: 1px solid #000;
     border-bottom: 1px solid var(--panel-article-border-color);
-    background-color: #0002;
-    background-color: var(--panel-article-background-color);
+    background: #0002;
+    background: var(--panel-article-background);
 }
 
 .panel-body article:not(.naked) > header {
@@ -1277,8 +1277,8 @@ ul.chat-body li.chat-line {
 }
 
 ul.chat-body li.chat-line:nth-child(odd) {
-    background-color: #d5d5d5;
-    background-color: var(--chat-odd-background-color);
+    background: #d5d5d5;
+    background: var(--chat-odd-background);
 }
 
 ul.chat-body li.chat-line:not(:last-child):not(:only-of-type) {
@@ -1297,8 +1297,8 @@ li.chat-line i[title] {
 
 .text-badge {
     line-height: 1em;
-    background-color: #ccc;
-    background-color: var(--chat-badge-background-color);
+    background: #ccc;
+    background: var(--chat-badge-background);
     padding: .15em .5em;
     border-radius: 1em;
     color: #770;
@@ -1468,8 +1468,8 @@ li.chat-line .actions [data-action]:not(:last-of-type):not(:only-child) {
     font-size: .8rem;
     font-weight: bold;
     border-radius: 5px 5px 0 0;
-    background-color: #66a;
-    background-color: var(--chat-tobottom-background-color);
+    background: #66a;
+    background: var(--chat-tobottom-background);
     cursor: pointer;
     position: absolute;
     top: -1.25rem;
@@ -1480,8 +1480,8 @@ li.chat-line .actions [data-action]:not(:last-of-type):not(:only-child) {
 #jump-to-bottom:hover {
     color: #fff;
     color: var(--chat-tobottom-text-color-hover);
-    background-color: #5c5ca0;
-    background-color: var(--chat-tobottom-background-color-hover);
+    background: #5c5ca0;
+    background: var(--chat-tobottom-background-hover);
 }
 
 #emojiPanelTrigger {
@@ -1510,8 +1510,8 @@ li.chat-line .actions [data-action]:not(:last-of-type):not(:only-child) {
     bottom: 3rem;
     margin-bottom: -1px;
     padding: 5px;
-    background-color: #b9b9b9;
-    background-color: var(--chat-typeahead-menu-background-color);
+    background: #b9b9b9;
+    background: var(--chat-typeahead-menu-background);
     border-radius: 5px 5px 0 0;
 }
 
@@ -1530,8 +1530,8 @@ li.chat-line .actions [data-action]:not(:last-of-type):not(:only-child) {
     cursor: pointer;
     user-select: none;
     text-indent: .75em;
-    background-color: #a3a3a3;
-    background-color: var(--chat-typeahead-item-background-color);
+    background: #a3a3a3;
+    background: var(--chat-typeahead-item-background);
     border-radius: 4px;
     padding: 3px;
     margin: 4px 0;
@@ -1542,13 +1542,13 @@ li.chat-line .actions [data-action]:not(:last-of-type):not(:only-child) {
 }
 
 #typeahead ul li button:hover {
-    background-color: #949494;
-    background-color: var(--chat-typeahead-item-background-color-hover);
+    background: #949494;
+    background: var(--chat-typeahead-item-background-hover);
 }
 
 #typeahead ul li button.active {
-    background-color: #828282;
-    background-color: var(--chat-typeahead-item-background-color-active);
+    background: #828282;
+    background: var(--chat-typeahead-item-background-active);
 }
 
 /* PINGS */
@@ -1556,16 +1556,16 @@ li.chat-line .actions [data-action]:not(:last-of-type):not(:only-child) {
 /* NOTE ([  ]): this seems to not respond to css vars (at least on firefox when I tested it) so I'm leaving it fixed for now */
 @keyframes -scrolled-flash {
     from {
-        background-color: #feedd1;
+        background: #feedd1;
     }
     to {
-        background-color: #8ef7d1;
+        background: #8ef7d1;
     }
 }
 
 ul.chat-body .chat-line[data-id].has-ping {
-    background-color: #feedd1;
-    background-color: var(--ping-highlight-color);
+    background: #feedd1;
+    background: var(--ping-highlight-color);
 }
 
 ul.chat-body .chat-line[data-id].has-ping.-scrolled-to {
@@ -1687,7 +1687,7 @@ body .emoji-picker {
     box-shadow: 0px 0px 3px 1px #CCCCCC;
     box-shadow: 0px 0px 3px 1px var(--emoji-picker-shadow-color);
     background: #FFFFFF;
-    background: var(--emoji-picker-background-color);
+    background: var(--emoji-picker-background);
 }
 
 .emoji-picker img.emoji {
@@ -1741,8 +1741,8 @@ body .emoji-picker {
 .emoji-picker .emoji-picker__search-container input {
     border: 1px solid #CCCCCC;
     border: 1px solid var(--emoji-picker-search-input-border-color);
-    background-color: #fff;
-    background-color: var(--emoji-picker-emoji-search-input-background-color);
+    background: #fff;
+    background: var(--emoji-picker-emoji-search-input-background);
     color: #000;
     color: var(--emoji-picker-emoji-search-input-text-color);
 }
@@ -1791,8 +1791,8 @@ body .emoji-picker {
 
 .popup .actions-wrapper {
     width: 35%;
-    background-color: #0002;
-    background-color: var(--panel-article-background-color);
+    background: #0002;
+    background: var(--panel-article-background);
 }
 
 .popup .pane {
@@ -1861,13 +1861,13 @@ body .emoji-picker {
 #bubble-position label:hover > div {
     border: 2px solid #6495ED;
     border: 2px solid var(--option-bubble-position-border-color-hovered);
-    background-color: rgba(0, 0, 0, 0);
-    background-color: var(--option-bubble-position-background-color-hovered);
+    background: rgba(0, 0, 0, 0);
+    background: var(--option-bubble-position-background-hovered);
 }
 
 #bubble-position label input:checked ~ div {
-    background-color: #eee;
-    background-color: var(--option-bubble-position-background-color-selected);
+    background: #eee;
+    background: var(--option-bubble-position-background-selected);
 }
 
 /* Chat settings tweaks */

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -100,7 +100,7 @@ html {
     --panel-article-border-color: var(--panel-border-color);
     --panel-article-header-text-color: inherit;
     --panel-article-header-background: var(--panel-header-background);
-    --panel-article-footer-text-color: var(--panel-header-text-color);
+    --panel-article-footer-text-color: var(--panel-footer-text-color);
     --panel-article-footer-background: var(--panel-footer-background);
     
     --panel-trigger-outline-color: #AAA;

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -41,10 +41,12 @@ html {
     --button-border-color-hover: #999;
     --button-background-color-hover: #ce4747;
     
-    --report-button-text-color: #fff;
-    --report-button-background-color: #e20;
-    --report-button-background-color-hover: #f10;
-    --report-button-border-color: unset;
+    --dangerous-button-text-color: #fff;
+    --dangerous-button-background-color: #e20;
+    --dangerous-button-border-color: unset;
+    --dangerous-button-text-color-hover: var(--dangerous-button-text-color);
+    --dangerous-button-background-color-hover: #f10;
+    --dangerous-button-border-color-hover: var(--dangerous-button-border-color);
     
     --floating-panel-text-color: inherit;
     --floating-panel-border-color: #ccc;
@@ -291,18 +293,22 @@ button.text-button:hover {
     border-color: var(--button-border-color-hover);
 }
 
-button.report-button {
+button.dangerous-button {
     background-color: #e20;
-    background-color: var(--report-button-background-color);
+    background-color: var(--dangerous-button-background-color);
     color: #fff;
-    color: var(--report-button-text-color);
+    color: var(--dangerous-button-text-color);
     border-color: unset;
-    border-color: var(--report-button-border-color);
+    border-color: var(--dangerous-button-border-color);
 }
 
-button.report-button:hover {
+button.dangerous-button:hover {
+    color: #fff;
+    color: var(--dangerous-button-text-color-hover);
     background-color: #f10;
-    background-color: var(--report-button-background-color-hover);
+    background-color: var(--dangerous-button-background-color-hover);
+    border-color: unset;
+    border-color: var(--dangerous-button-border-color-hover);
 }
 
 .use-mono {

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -411,9 +411,7 @@ dt {
 
 /* body preselector is to give more precident to .message than to .floating-panel */
 body .message {
-    padding: 30px 30px 10px;
     max-width: 40%;
-    min-width: 20%;
     z-index: 22;
 
     position: fixed;
@@ -438,11 +436,11 @@ body .message {
 }
 
 .floating-panel .content {
-    margin-bottom: 10px;
+    margin-bottom: 5px;
 }
 
 .floating-panel .content > div:not(:first-of-type) {
-    margin-top: 10px;
+    margin-top: 5px;
 }
 
 #lookup {

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -79,6 +79,7 @@ html {
     --notification-color: #b20;
     --ping-highlight-color: #feedd1;
     --ping-flash-color: #8ef7d1;
+    --ping-counter-color: #ffa500;
     --notification-expiry-color: #b66;
         
     --panel-background-color: #dfdfdf;
@@ -220,22 +221,6 @@ kbd {
     user-select: none;
 }
 
-#reconnecting {
-    position: fixed;
-    display: none;
-    top: 0;
-    left: 0;
-    z-index: 98;
-    width: 100vw;
-    background: #333;
-    text-align: center;
-    margin: 0;
-    padding: 20px;
-    font-weight: 800;
-    color: #fff;
-    font-size: 25px;
-}
-
 .indent-1 {
     text-indent: 0.75em;
 }
@@ -249,20 +234,78 @@ kbd {
     margin-left:1.2rem;
 }
 
-input:disabled {
+input:disabled, button:disabled {
     cursor: not-allowed;
 }
 
-.longTextInputWrapper {
-    max-width: 100% !important;
+input[type="text"], input[type="number"], textarea, select {
+    padding: 0.5em;
+    border: 1px solid #ccc;
+    border: 1px solid var(--input-border-color);
+    background-color: #fff;
+    background-color: var(--input-background-color);
+    color: #000;
+    color: var(--input-text-color);
 }
 
-.longTextInputWrapper > input[type='text'] {
-    width: 100% !important;
-    margin-bottom: 2px;
+button {
+    cursor: pointer;
+    display: inline-block;
+    color: inherit;
+    background: transparent;
+    padding: 0;
+    margin: 0;
+    border: 0;
+    line-height: 1.1em;
 }
 
-.useMono {
+button.text-button {
+    margin-top: 6px;
+    margin-right: 4.5px;
+    display: inline-block;
+    font-size: 12px;
+    border: 1px solid #999;
+    border: 1px solid var(--button-border-color);
+    padding: 5px 10px;
+    border-radius: 3px;
+    background-color: #ddd;
+    background-color: var(--button-background-color);
+    color: #000;
+    color: var(--button-text-color);
+}
+
+button.text-button:disabled {
+    border: 1px solid #777;
+    border: 1px solid var(--button-border-color-disabled);
+    background-color: #aaa;
+    background-color: var(--button-background-color-disabled);
+    color: #555;
+    color: var(--button-text-color-disabled);
+}
+
+button.text-button:hover {
+    color: #fff;
+    color: var(--button-text-color-hover);
+    background: #ce4747;
+    background: var(--button-background-color-hover);
+    border-color: var(--button-border-color-hover);
+}
+
+button.report-button {
+    background-color: #e20;
+    background-color: var(--report-button-background-color);
+    color: #fff;
+    color: var(--report-button-text-color);
+    border-color: unset;
+    border-color: var(--report-button-border-color);
+}
+
+button.report-button:hover {
+    background-color: #f10;
+    background-color: var(--report-button-background-color-hover);
+}
+
+.use-mono {
     font-family: monospace;
 }
 
@@ -273,10 +316,6 @@ dt:not(:first-of-type) {
 dt {
     font-weight: bold;
     font-size: 1.15rem;
-}
-
-dd a {
-    display: inline !important;
 }
 
 @keyframes rainbow-move {
@@ -293,6 +332,16 @@ dd a {
     background-size: 500px 100%;
     animation: rainbow-move 4s linear 1ms infinite;
     transform: rotateZ(360deg); /* force rainbow rendering onto GPU if available */
+}
+
+.error {
+    color: #cc3333;
+    color: var(--error-color);
+    font-weight: 700;
+}
+
+.no-border {
+    border: none !important;
 }
 
 .halves {
@@ -313,6 +362,22 @@ dd a {
 /*//////////////////////////*\
 | Overlays
 \*\\\\\\\\\\\\\\\\\\\\\\\\\\*/
+
+#reconnecting {
+    position: fixed;
+    display: none;
+    top: 0;
+    left: 0;
+    z-index: 98;
+    width: 100vw;
+    background: #333;
+    text-align: center;
+    margin: 0;
+    padding: 20px;
+    font-weight: 800;
+    color: #fff;
+    font-size: 25px;
+}
 
 #loading {
     position: fixed;
@@ -349,50 +414,6 @@ body .message {
     overflow-wrap: break-word;
 }
 
-button {
-    cursor: pointer;
-    display: inline-block;
-    color: inherit;
-    background: transparent;
-    padding: 0;
-    margin: 0;
-    border: 0;
-    line-height: 1.1em;
-}
-
-button.text-button {
-    margin-top: 6px;
-    margin-right: 4.5px;
-    display: inline-block;
-    font-size: 12px;
-    border: 1px solid #999;
-    border: 1px solid var(--button-border-color);
-    padding: 5px 10px;
-    border-radius: 3px;
-    background-color: #ddd;
-    background-color: var(--button-background-color);
-    color: #000;
-    color: var(--button-text-color);
-}
-
-button.text-button:disabled {
-    cursor: not-allowed;
-    border: 1px solid #777;
-    border: 1px solid var(--button-border-color-disabled);
-    background-color: #aaa;
-    background-color: var(--button-background-color-disabled);
-    color: #555;
-    color: var(--button-text-color-disabled);
-}
-
-button.text-button:hover {
-    color: #fff;
-    color: var(--button-text-color-hover);
-    background: #ce4747;
-    background: var(--button-background-color-hover);
-    border-color: var(--button-border-color-hover);
-}
-
 .floating-panel {
     border-radius: 8px;
     border: 1px solid #ccc;
@@ -421,42 +442,6 @@ button.text-button:hover {
     z-index: 22;
 }
 
-button.report-button {
-    background-color: #e20;
-    background-color: var(--report-button-background-color);
-    color: #fff;
-    color: var(--report-button-text-color);
-    border-color: unset;
-    border-color: var(--report-button-border-color);
-}
-
-button.report-button:hover {
-    background-color: #f10;
-    background-color: var(--report-button-background-color-hover);
-}
-
-.palette-number {
-    position: absolute;
-    transform: translate(-50%, 50%);
-    left: 50%;
-    bottom: 100%;
-    border-radius: 16px;
-    text-align: center;
-    color: #000;
-    background-color: #fff;
-    border: 1px solid #000;
-    width: 2em;
-    font-size: .75em;
-    user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    -webkit-user-select: none;
-}
-
-#palette.no-pills .palette-number {
-    display: none !important;
-}
-
 /* moderator action popup styles */
 .chatmod-container th {
     text-align: right;
@@ -465,13 +450,6 @@ button.report-button:hover {
 
 .chatmod-container th[title] {
     border-bottom: 1px dashed #666;
-}
-
-.chatmod-container .error-label {
-    font-size: .8rem;
-    color: #e00;
-    font-weight: bold;
-    text-indent: 1rem;
 }
 
 .chatmod-container h3 {
@@ -684,8 +662,26 @@ button.report-button:hover {
     bottom: 11px;
 }
 
-.palette-color.no-border {
-    border: none;
+.palette-number {
+    position: absolute;
+    transform: translate(-50%, 50%);
+    left: 50%;
+    bottom: 100%;
+    border-radius: 16px;
+    text-align: center;
+    color: #000;
+    background-color: #fff;
+    border: 1px solid #000;
+    width: 2em;
+    font-size: .75em;
+    user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    -webkit-user-select: none;
+}
+
+#palette.no-pills .palette-number {
+    display: none !important;
 }
 
 #reticule {
@@ -780,27 +776,6 @@ body:not(.show-placeable-bubble) #placeableInfoBubble {
 .copyPulse {
     color: rgba(0, 211, 221, 0.7);
     color: var(--copypulse-color);
-}
-
-.userinfo .logout {
-    font-size: 0.75em;
-    text-decoration: underline;
-}
-
-input[type="text"], input[type="number"], textarea, select {
-    padding: 0.5em;
-    border: 1px solid #ccc;
-    border: 1px solid var(--input-border-color);
-    background-color: #fff;
-    background-color: var(--input-background-color);
-    color: #000;
-    color: var(--input-text-color);
-}
-
-.error {
-    color: #cc3333;
-    color: var(--error-color);
-    font-weight: 700;
 }
 
 .ban-alert-content > p:not(:nth-last-of-type(2)) {
@@ -936,24 +911,29 @@ input[type="text"], input[type="number"], textarea, select {
 /*//////////////////////////*\
 | Button Bar
 \*\\\\\\\\\\\\\\\\\\\\\\\\\\*/
-.ButtonBar {
+
+.button-bar {
     display: flex !important;
 }
-.ButtonBar.inline {
-    display: flex !important;
+
+.button-bar.inline {
+    display: inline-flex !important;
 }
-.ButtonBar > button {
+
+.button-bar > button {
     flex: 1 0 auto;
     padding: 5px;
     margin: 0;
     border-width: 1px;
     border-radius: 0;
 }
-.ButtonBar > button:first-child {
+
+.button-bar > button:first-child {
     border-top-left-radius: 5px;
     border-bottom-left-radius: 5px;
 }
-.ButtonBar > button:last-child {
+
+.button-bar > button:last-child {
     border-top-right-radius: 5px;
     border-bottom-right-radius: 5px;
 }
@@ -977,15 +957,6 @@ header.controls {
     user-select: none;
     margin-top: 5px;
     z-index: 18;
-}
-
-header.slim {
-    height: 1.75rem;
-    line-height: 1.75rem;
-}
-
-header.no-border {
-    border: none !important;
 }
 
 header >.left, header >.right, header >.mid {
@@ -1071,6 +1042,32 @@ aside.panel {
     cursor: initial !important;
 }
 
+aside.panel.left {
+    right: initial;
+    transition: left ease-in-out .25s;
+    left: -55%;
+}
+
+aside.panel.left.open, .panel.left[data-state=open] {
+    left: 0;
+}
+
+aside.panel.right {
+    left: initial;
+    transition: right ease-in-out .25s;
+    right: -55%;
+}
+
+aside.panel.right.open, .panel.right[data-state=open] {
+    right: 0;
+}
+
+aside.panel .panel-body {
+    overflow: auto;
+    height: 100%;
+    height: calc(100% - 2.75em);
+}
+
 .panel {
     box-shadow: 0 0 10px 5px #0009;
     background-color: #dfdfdf;
@@ -1079,54 +1076,9 @@ aside.panel {
     color: var(--panel-text-color);
 }
 
-.panel.half-width {
-    width: 50% !important;
-}
-
-.panel.horizontal {
-    width: 100%;
-    height: 50%;
-    max-width: initial;
-    min-height: initial;
-}
-
-.panel.left {
-    right: initial;
-    transition: left ease-in-out .25s;
-    left: -55%;
-}
-
-.panel.left.horizontal {
-    left: -105%;
-}
-
-.panel.left.open, .panel.left[data-state=open] {
-    left: 0;
-}
-
-.panel.right {
-    left: initial;
-    transition: right ease-in-out .25s;
-    right: -55%;
-}
-
-.panel.right.horizontal {
-    right: -105%;
-}
-
-.panel.right.open, .panel.right[data-state=open] {
-    right: 0;
-}
-
 .panel-body {
     padding: 0 .5rem;
     word-wrap: break-word;
-}
-
-aside.panel .panel-body {
-    overflow: auto;
-    height: 100%;
-    height: calc(100% - 2.75em);
 }
 
 .panel-header, .panel-footer {
@@ -1195,16 +1147,14 @@ aside.panel .panel-body {
     color: var(--panel-close-button-color-active);
 }
 
-article .body {
-    padding: .5rem;
-}
-
 .panel-body article:not(:last-of-type) {
     margin-bottom: 1rem;
 }
+
 .panel-body article:first-of-type {
     margin-top: .5rem;
 }
+
 .panel-body article:last-of-type {
     margin-bottom: .5rem;
 }
@@ -1254,10 +1204,6 @@ article .body {
 
 .panel-body article .pad-wrapper {
     padding: .5rem;
-}
-
-.panel-body article a {
-    display: block;
 }
 
 .panel-body article input[type="range"] {
@@ -1492,11 +1438,9 @@ li.chat-line .actions [data-action]:not(:last-of-type):not(:only-child) {
     font-size: 1.5rem;
     display: inline-flex;
     text-align: center;
-    vertical-align: middle;
     align-items: center;
     justify-content: center;
     align-content: center;
-    flex-flow: column;
     user-select: none;
 }
 
@@ -1544,6 +1488,7 @@ li.chat-line .actions [data-action]:not(:last-of-type):not(:only-child) {
     cursor: pointer;
     color: #aaa;
 }
+
 #emojiPanelTrigger:hover {
     color: #ccc;
 }
@@ -1654,6 +1599,7 @@ ul.chat-history, ul.chatban-history {
     font-size: 1rem;
     font-weight: bold;
     color: #ffa500;
+    color: var(--ping-counter-color);
 }
 
 .panel-trigger:not(.has-ping) .ping-counter {
@@ -1669,17 +1615,17 @@ ul.chat-history, ul.chatban-history {
     max-height: 73vh;
     list-style: none;
     margin: 0;
-    padding: .5rem .5rem 0 .5rem;
+    padding: .5rem;
     overflow-y: auto;
 }
 
 .popup .pings-list:empty::before {
     content: "No pings here";
     position: absolute;
-    top: 50%;
-    width: 100%;
+    display: block;
     text-align: center;
-    opacity: .5;
+    color: #8c8c8c;
+    color: var(--text-muted-color);
 }
 
 .popup .pings-list li {
@@ -1823,45 +1769,31 @@ body .emoji-picker {
 .popup {
     position: absolute;
     z-index: 22;
-    width: 100px;
-    max-width: 200px;
-    height: auto;
     border-radius: 5px;
     font-size: 1rem !important;
     line-height: 1rem !important;
     overflow: hidden;
-}
-
-.popup.panels {
-    width: 99%;
-    max-height: 99vh;
     max-width: 400px;
     min-width: 300px;
 }
 
-.popup.panels .details-wrapper {
+.popup .details-wrapper {
     width: 65%;
 }
 
-.popup.panels .actions-wrapper {
+.popup .actions-wrapper {
     width: 35%;
     background-color: #0002;
     background-color: var(--panel-article-background-color);
 }
 
-.popup.panels .pane {
+.popup .pane {
     display: inline-block;
-    height: 100%;
     vertical-align: top;
 }
 
-.popup.panels .pane.pane-full {
+.popup .pane.pane-full {
     width: 100%;
-}
-
-.popup.panels header:first-of-type {
-    border-top-left-radius: 5px;
-    border-top-right-radius: 5px;
 }
 
 .pane p {
@@ -1875,8 +1807,6 @@ body .emoji-picker {
     padding: 0;
     padding-bottom: .5em;
     list-style: none;
-    max-height: 100%;
-    max-width: 100%;
     border-left: 1px solid #000;
     border-left: 1px solid var(--panel-border-color);
 }
@@ -1944,10 +1874,6 @@ body .emoji-picker {
     border: 1px solid #888;
 }
 
-.d-block {
-    display: block !important;
-}
-
 /* Notifications */
 .notification {
     margin: 15px 10px;
@@ -1982,10 +1908,7 @@ body .emoji-picker {
     max-height: 99vh;
     padding: 0;
     outline: 0;
-}
-
-.modal .modal-footer {
-    text-align: right;
+    overflow: hidden;
 }
 
 .modal .modal-header, .modal .modal-footer {
@@ -1993,34 +1916,11 @@ body .emoji-picker {
     min-height: 2em;
 }
 
-.modal .modal-header {
-    border-radius: 8px 8px 0 0;
-}
-
-.modal .modal-footer {
-    border-radius: 0 0 8px 8px;
-}
-
 .modal .modal-body {
     padding: 15px 10px;
     max-width: 98vw;
     max-height: 88vh;
     overflow: auto;
-}
-
-.modal-title {
-    text-align: center;
-}
-
-.modal-footer button {
-    margin: 0 0 0 5px;
-}
-
-.modal-header h1, .modal-header h2, .modal-header h3, .modal-header h4, .modal-header h5, .modal-header h6,
-.modal-footer h1, .modal-footer h2, .modal-footer h3, .modal-footer h4, .modal-footer h5, .modal-footer h6
-/*.modal-body p*/ {
-    margin: 0;
-    padding: 0;
 }
 
 /*//////////////////////////*\
@@ -2038,16 +1938,16 @@ body .emoji-picker {
 }
 
 @media (max-width: 768px) {
-    .panel, .panel.half-width {
+    aside.panel {
         max-width: 100% !important;
         width: 100% !important;
     }
 
-    .panel.left {
+    aside.panel.left {
         left: -105%;
     }
 
-    .panel.right {
+    aside.panel.right {
         right: -105%;
     }
 
@@ -2070,11 +1970,10 @@ body .emoji-picker {
         width: 100%;
     }
 
-    .message {
+    body .message {
         max-width: 100%;
         max-height: 100%;
         overflow: auto;
-        width: 95%;
     }
 
     #chat-hint {

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -9,6 +9,7 @@ z-index:
  8 - login overlay
  9 - ui blobs
 10 - admin boxes
+18 - controls header
 
 21 - panels
 22 - lookup, emoji-picker
@@ -948,20 +949,19 @@ input[type="text"], input[type="number"], textarea, select {
 
 header {
     display: flex;
-    height: 2.5rem;
-    line-height: 2.5rem;
-    border-bottom: 1px solid #000;
     padding: 0 1rem;
-    background-image: linear-gradient(to bottom, #ccc, #bbb);
-    background: var(--panel-header-background);
-    user-select: none;
-    z-index: 18;
 }
 
 header.transparent {
     background-image: none;
     background-color: #fff0;
     border: 0;
+}
+
+header.controls {
+    user-select: none;
+    margin-top: 5px;
+    z-index: 18;
 }
 
 header .fas {
@@ -1081,16 +1081,6 @@ aside.panel {
     min-height: initial;
 }
 
-.panel > header, .panel > .modal-wrapper > header {
-    border-bottom: 1px solid #000;
-    border-bottom: 1px solid var(--panel-borders-color);
-}
-
-.panel > footer, .panel > .modal-wrapper > footer {
-    border-top: 1px solid #000;
-    border-top: 1px solid var(--panel-borders-color);
-}
-
 .panel.left {
     right: initial;
     transition: left ease-in-out .25s;
@@ -1127,6 +1117,23 @@ aside.panel {
     bottom: 0;
     word-wrap: break-word;
     width: 100%;
+}
+
+.panel-header, .panel-footer {
+    height: 2.5rem;
+    line-height: 2.5rem;
+}
+
+.panel-header {
+    background-image: linear-gradient(to bottom, #ccc, #bbb);
+    background: var(--panel-header-background);
+    border-bottom: 1px solid #000;
+    border-bottom: 1px solid var(--panel-borders-color);
+}
+
+.panel-footer {
+    border-top: 1px solid #000;
+    border-top: 1px solid var(--panel-borders-color);
 }
 
 .panel-trigger {
@@ -1170,6 +1177,12 @@ article .body {
     border: 1px solid var(--panel-borders-color);
     background-color: #0002;
     background-color: var(--panel-article-background-color);
+}
+
+.panel-body article:not(.naked) > header {
+    border-bottom: 1px solid var(--panel-borders-color);
+    background: linear-gradient(to bottom, #ccc, #bbb);
+    background: var(--panel-header-background);
 }
 
 .panel-body article p {

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -405,12 +405,16 @@ dt {
     transform: translate(-50%, -50%);
 }
 
+#prompt, #signup {
+    z-index: 99;
+}
+
 /* body preselector is to give more precident to .message than to .floating-panel */
 body .message {
     padding: 30px 30px 10px;
     max-width: 40%;
     min-width: 20%;
-    z-index: 99;
+    z-index: 22;
 
     position: fixed;
     top: 45vh;

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -1039,8 +1039,7 @@ footer {
 aside.panel {
     position: fixed;
     top: 0;
-    max-width: 50%;
-    min-width: 30%;
+    max-width: 30%;
     height: 100%;
     z-index: 21;
     cursor: initial !important;

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -1050,7 +1050,7 @@ aside.panel.left {
 }
 
 aside.panel.left.open, .panel.left[data-state=open] {
-    left: 0;
+    left: 0 !important;
 }
 
 aside.panel.right {
@@ -1060,13 +1060,27 @@ aside.panel.right {
 }
 
 aside.panel.right.open, .panel.right[data-state=open] {
-    right: 0;
+    right: 0 !important;
 }
 
 aside.panel .panel-body {
     overflow: auto;
     height: 100%;
     height: calc(100% - 2.75em);
+}
+
+aside.panel.horizontal {
+    width: 100%;
+    max-width: 100%;
+    max-height: 50%;
+}
+
+aside.panel.horizontal.left {
+    left: -105%;
+}
+
+aside.panel.horizontal.right {
+    right: -105%;
 }
 
 .panel {

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -1122,12 +1122,13 @@ aside.panel {
 
 .panel-body {
     padding: 0 .5rem;
-    overflow: auto;
-    position: absolute;
-    top: 2.65rem;
-    bottom: 0;
     word-wrap: break-word;
-    width: 100%;
+}
+
+aside.panel .panel-body {
+    overflow: auto;
+    height: 100%;
+    height: calc(100% - 2.75em);
 }
 
 .panel-header, .panel-footer {

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -367,7 +367,7 @@ dd a {
     text-align: right;
 }
 
-.button {
+button {
     cursor: pointer;
     margin-top: 6px;
     margin-right: 4.5px;
@@ -383,13 +383,7 @@ dd a {
     color: var(--button-text-color);
 }
 
-.button.dark {
-    background-color: #444;
-    border: 1px solid #222;
-    color: #fff;
-}
-
-button.button:disabled {
+button:disabled {
     cursor: not-allowed;
     border: 1px solid #777;
     border: 1px solid var(--button-border-color-disabled);
@@ -399,11 +393,12 @@ button.button:disabled {
     color: var(--button-text-color-disabled);
 }
 
-button.button.dark:disabled {
-    cursor: not-allowed;
-    background-color: #222;
-    border: 1px solid #000;
-    color: #444;
+button:hover {
+    color: #fff;
+    color: var(--button-text-color-hover);
+    background: #ce4747;
+    background: var(--button-background-color-hover);
+    border-color: var(--button-border-color-hover);
 }
 
 #lookup {
@@ -439,14 +434,6 @@ button.button.dark:disabled {
 #lookup .report-button:hover {
     background-color: #f10;
     background-color: var(--report-button-background-color-hover);
-}
-
-.button:hover {
-    color: #fff;
-    color: var(--button-text-color-hover);
-    background: #ce4747;
-    background: var(--button-background-color-hover);
-    border-color: var(--button-border-color-hover);
 }
 
 .content {
@@ -2077,7 +2064,7 @@ body .emoji-picker {
     text-align: center;
 }
 
-.modal-footer .button {
+.modal-footer button {
     margin: 0 0 0 5px;
 }
 

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -121,10 +121,6 @@ html {
     --chat-typeahead-item-background-color-hover: #949494;
     --chat-typeahead-item-background-color-active: #828282;
     
-    --mod-lookup-chatban-history-item-background-color: rgba(177, 177, 177, 0.3);
-    --mod-lookup-chatban-history-item-border-color: #828282;
-    --mod-lookup-chatban-history-item-heading-background-color: #82828233;
-    
     --popup-background-color: #eee;
     --popup-border-color: #000;
     --popup-text-color: inherit;
@@ -1248,9 +1244,8 @@ article .body {
     margin: .5rem 0;
 }
 
-.panel-body article h2 {
-    margin: 0;
-    padding: 0;
+.panel-body article > header h1, .panel-body article > header h2, .panel-body article > header h3, .panel-body article > header h4, .panel-body article > header h5, .panel-body article > header h6 {
+    font-size: x-large;
     text-align: center;
     width:  100%;
 }
@@ -1629,23 +1624,6 @@ ul.chat-history, ul.chatban-history {
 
 .chatban-history li {
     margin: 7px;
-    border-radius: 7px;
-    background-color: rgba(177, 177, 177, 0.3);
-    background-color: var(--mod-lookup-chatban-history-item-background-color);
-    border: 1px solid #828282;
-    border: 1px solid var(--mod-lookup-chatban-history-item-border-color);
-}
-
-.chatban-history h4 {
-    margin: 0 0 1em 0;
-    background-color: #82828233;
-    background-color: var(--mod-lookup-chatban-history-item-heading-background-color);
-    border-radius: 7px 7px 0 0;
-    text-align: center;
-    font-size: 1.25em;
-    line-height: 1.25em;
-    border-bottom: 1px solid #828282;
-    border-bottom: 1px solid var(--mod-lookup-chatban-history-item-border-color);
 }
 
 .chatban-history table {

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -48,9 +48,9 @@ html {
     --report-button-background-color-hover: #f10;
     --report-button-border-color: unset;
     
-    --lookup-text-color: inherit;
-    --lookup-border-color: #ccc;
-    --lookup-background-color: #eee;
+    --floating-panel-text-color: inherit;
+    --floating-panel-border-color: #ccc;
+    --floating-panel-background-color: #eee;
     
     --bubble-background-color: rgba(0, 0, 0, 0.7);
     --bubble-text-color: #fff;
@@ -150,12 +150,6 @@ html {
     --emoji-picker-variant-overlay-background: rgba(0, 0, 0, 0.7);
     --emoji-picker-variant-popup-background: #FFFFFF;
     --emoji-picker-variant-close-button-color: inherit;
-    
-    --admin-background: #333;
-    --admin-text-color: #fff;
-    --admin-check-border-color: #ccc;
-    --admin-check-text-color: inherit;
-    --admin-check-background-color: #eee;
 }
 
 /*//////////////////////////*\
@@ -401,25 +395,27 @@ button:hover {
     border-color: var(--button-border-color-hover);
 }
 
+.floating-panel {
+    border-radius: 8px;
+    border: 1px solid #ccc;
+    border: 1px solid var(--floating-panel-border-color);
+    background-color: #eee;
+    background-color: var(--floating-panel-background-color);
+    color: inherit;
+    color: var(--floating-panel-text-color);
+    padding: 16px;
+    max-width: 300px;
+}
+
+.floating-panel .content > div:not(:first-of-type) {
+    margin-top: 10px;
+}
+
 #lookup {
+    position: fixed;
     top: 50px;
     right: 16px;
     z-index: 22;
-    border-radius: 8px;
-    border: 1px solid #ccc;
-    border: 1px solid var(--lookup-border-color);
-    background-color: #eee;
-    background-color: var(--lookup-background-color);
-    color: inherit;
-    color: var(--lookup-text-color);
-    padding: 16px;
-    max-width: 300px;
-
-    position: fixed;
-}
-
-#lookup .content > div:not(:first-of-type) {
-    margin-top: 10px;
 }
 
 #lookup .report-button {

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -189,6 +189,10 @@ html, body {
     display: none !important;
 }
 
+.fullwidth {
+    width: 100%;
+}
+
 a, a:hover, a:visited, a:active, .link, .link:hover, .link:active {
     color: inherit;
     cursor: pointer;
@@ -419,7 +423,7 @@ button.text-button:hover {
     z-index: 22;
 }
 
-#lookup .report-button {
+button.report-button {
     background-color: #e20;
     background-color: var(--report-button-background-color);
     color: #fff;
@@ -428,7 +432,7 @@ button.text-button:hover {
     border-color: var(--report-button-border-color);
 }
 
-#lookup .report-button:hover {
+button.report-button:hover {
     background-color: #f10;
     background-color: var(--report-button-background-color-hover);
 }
@@ -1835,9 +1839,7 @@ body .emoji-picker {
     width: 99%;
     max-height: 99vh;
     max-width: 400px;
-    min-height: 200px;
     min-width: 300px;
-    padding-bottom: .5rem;
 }
 
 .popup.panels .details-wrapper {
@@ -1872,37 +1874,17 @@ body .emoji-picker {
 .pane ul.actions-list {
     margin: 0;
     padding: 0;
+    padding-bottom: .5em;
     list-style: none;
-    display: flex;
-    flex-flow: column;
     max-height: 100%;
     max-width: 100%;
-}
-
-.pane ul.actions-list li[data-action] {
-    border-bottom: 1px solid #000;
-    border-bottom: 1px solid var(--popup-border-color);
     border-left: 1px solid #000;
     border-left: 1px solid var(--popup-border-color);
-    flex: 1 0 2em;
+}
+
+.pane ul.actions-list li {
     line-height: 2em;
-    text-align: center;
-    background-image: linear-gradient(0deg, #eee, #ccc, #eee);
-    background: var(--pane-button-background);
-    padding: 0 1em;
-}
-
-.pane ul.actions-list li[data-action]:hover {
-    background-image: linear-gradient(0deg, #ddd, #bbb, #ddd);
-    background: var(--pane-button-background-hover);
-}
-
-.pane ul.actions-list li[data-action]:not(:only-of-type):last-child {
-    border-radius: 0 0 0 5px;
-}
-
-.pane ul.actions-list li[data-action]:hover {
-    cursor: pointer;
+    padding: 0 .5em;
 }
 
 .popup-timestamp-header {

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -29,10 +29,7 @@ html {
     --kbd-background-color: #eee;
     --kbd-border-color: #ddd;
     --kbd-text-color: black;
-    
-    --message-background-color: #fff;
-    --message-text-color: #333;
-    
+        
     --button-background-color: #ddd;
     --button-border-color: #999;
     --button-text-color: #000;
@@ -336,14 +333,9 @@ dd a {
     transform: translate(-50%, -50%);
 }
 
-.message {
+/* body preselector is to give more precident to .message than to .floating-panel */
+body .message {
     padding: 30px 30px 10px;
-    border-radius: 7px;
-    background-color: #fff;
-    background-color: var(--message-background-color);
-    color: #333;
-    color: var(--message-text-color);
-    box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.3);
     max-width: 40%;
     min-width: 20%;
     z-index: 99;
@@ -354,11 +346,6 @@ dd a {
     transform: translateX(-50%) translateY(-50%);
     word-wrap: break-word;
     overflow-wrap: break-word;
-}
-
-.message .buttons {
-    margin-top: 1em;
-    text-align: right;
 }
 
 button {
@@ -403,8 +390,13 @@ button:hover {
     background-color: var(--floating-panel-background-color);
     color: inherit;
     color: var(--floating-panel-text-color);
+    box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.3);
     padding: 16px;
     max-width: 300px;
+}
+
+.floating-panel .content {
+    margin-bottom: 10px;
 }
 
 .floating-panel .content > div:not(:first-of-type) {
@@ -430,11 +422,6 @@ button:hover {
 #lookup .report-button:hover {
     background-color: #f10;
     background-color: var(--report-button-background-color-hover);
-}
-
-.content {
-    margin-bottom: 10px;
-    white-space: pre-wrap;
 }
 
 .palette-number {
@@ -1300,6 +1287,10 @@ li.chat-line .text-badge, header .text-badge {
     -moz-user-select: none;
     -ms-user-select: none;
     user-select: none;
+}
+
+li.chat-line .content {
+    white-space: pre-wrap;
 }
 
 header .text-badge {

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -1344,7 +1344,7 @@ li.chat-line i[title] {
     padding-bottom: 1px;
 }
 
-li.chat-line .text-badge, header .text-badge {
+.text-badge {
     line-height: 1em;
     background-color: #ccc;
     background-color: var(--chat-badge-background-color);
@@ -1359,7 +1359,7 @@ li.chat-line .text-badge, header .text-badge {
     user-select: none;
 }
 
-li.chat-line .content {
+.chat-line .content {
     white-space: pre-wrap;
 }
 

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -115,6 +115,11 @@ html {
     --chat-user-text-shadow-color: #ccc;
     --chat-purged-text-color: #888;
     
+    --chat-tobottom-text-color: #fff;
+    --chat-tobottom-background-color: #66a;
+    --chat-tobottom-text-color-hover: var(--chat-tobottom-text-color);
+    --chat-tobottom-background-color-hover: #5c5ca0;
+    
     --chat-typeahead-menu-background-color: #b9b9b9;
     --chat-typeahead-item-text-color: inherit;
     --chat-typeahead-item-background-color: #a3a3a3;
@@ -1511,11 +1516,13 @@ li.chat-line .actions [data-action]:not(:last-of-type):not(:only-child) {
 #jump-to-bottom {
     text-align: center;
     color: #fff;
+    color: var(--chat-tobottom-text-color);
     line-height: 1.25rem;
     font-size: .8rem;
     font-weight: bold;
     border-radius: 5px 5px 0 0;
     background-color: #66a;
+    background-color: var(--chat-tobottom-background-color);
     cursor: pointer;
     position: absolute;
     top: -1.25rem;
@@ -1524,7 +1531,10 @@ li.chat-line .actions [data-action]:not(:last-of-type):not(:only-child) {
 }
 
 #jump-to-bottom:hover {
+    color: #fff;
+    color: var(--chat-tobottom-text-color-hover);
     background-color: #5c5ca0;
+    background-color: var(--chat-tobottom-background-color-hover);
 }
 
 #emojiPanelTrigger {

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -1647,7 +1647,6 @@ ul.chat-history, ul.chatban-history {
 
 .popup .pings-list:empty::before {
     content: "No pings here";
-    position: absolute;
     display: block;
     text-align: center;
     color: #8c8c8c;

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -84,6 +84,9 @@ html {
     --panel-background-color: #dfdfdf;
     --panel-text-color: inherit;
     --panel-borders-color: #000;
+    --panel-close-button-color: #a00;
+    --panel-close-button-color-hover: var(--panel-close-button-color);
+    --panel-close-button-color-active: var(--panel-close-button-color);
     --panel-article-background-color: #0002;
     
     --panel-trigger-outline-color: #AAA;
@@ -347,6 +350,16 @@ body .message {
 
 button {
     cursor: pointer;
+    display: inline-block;
+    color: inherit;
+    background: transparent;
+    padding: 0;
+    margin: 0;
+    border: 0;
+    line-height: 1.1em;
+}
+
+button.text-button {
     margin-top: 6px;
     margin-right: 4.5px;
     display: inline-block;
@@ -361,7 +374,7 @@ button {
     color: var(--button-text-color);
 }
 
-button:disabled {
+button.text-button:disabled {
     cursor: not-allowed;
     border: 1px solid #777;
     border: 1px solid var(--button-border-color-disabled);
@@ -371,7 +384,7 @@ button:disabled {
     color: var(--button-text-color-disabled);
 }
 
-button:hover {
+button.text-button:hover {
     color: #fff;
     color: var(--button-text-color-hover);
     background: #ce4747;
@@ -423,7 +436,9 @@ button:hover {
 
 .palette-number {
     position: absolute;
-    transform: translate(-50%, -50%);
+    transform: translate(-50%, 50%);
+    left: 50%;
+    bottom: 100%;
     border-radius: 16px;
     text-align: center;
     color: #000;
@@ -635,6 +650,7 @@ button:hover {
 
 .palette-color {
     display: inline-block;
+    position: relative;
 
     min-width: 32px;
     min-height: 32px;
@@ -644,6 +660,8 @@ button:hover {
     margin-right: 10px;
     cursor: pointer;
     bottom: 0;
+    /* the default of `baseline` causes the deselect button to be raised on Firefox */
+    vertical-align: top;
 }
 
 .palette-color:first-child {
@@ -652,15 +670,11 @@ button:hover {
 
 .palette-color.active,
 .palette-color.no-touch:hover {
-    position: relative;
     bottom: 7px;
 }
 
 .palette-color.deselect-button {
     font-size: 1.75rem;
-    position: relative;
-    bottom: 4px;
-    left: 4px;
     color: inherit;
     color: var(--palette-deselect-button-color);
 }
@@ -964,12 +978,6 @@ header.controls {
     z-index: 18;
 }
 
-header .fas {
-    font-size: 2rem;
-    margin-top: .2rem;
-    cursor: pointer;
-}
-
 header.slim {
     height: 1.75rem;
     line-height: 1.75rem;
@@ -1012,14 +1020,6 @@ header h1, header h2, header h3, header h4, header h5, header h6 {
 
 .fas.fa-is-right, .far.fa-is-right {
     margin-left: .25rem;
-}
-
-.fa-1x {
-    font-size: 1rem !important;
-}
-
-.fa-1_5x {
-    font-size: 1.5rem !important;
 }
 
 .text-blue {
@@ -1131,6 +1131,10 @@ aside.panel {
     border-bottom: 1px solid var(--panel-borders-color);
 }
 
+.panel-header button {
+    font-size: 2rem;
+}
+
 .panel-footer {
     border-top: 1px solid #000;
     border-top: 1px solid var(--panel-borders-color);
@@ -1143,7 +1147,10 @@ aside.panel {
     text-shadow: 1px 1px 0 #AAA, -1px 1px 0 #AAA, 1px -1px 0 #AAA, -1px -1px 0 #AAA, 0px 1px 0 #AAA, 0px -1px 0 #AAA, -1px 0px 0 #AAA, 1px 0px 0 #AAA;
     text-shadow: 1px 1px 0 var(--panel-trigger-outline-color), -1px 1px 0 var(--panel-trigger-outline-color), 1px -1px 0 var(--panel-trigger-outline-color), -1px -1px 0 var(--panel-trigger-outline-color), 0px 1px 0 var(--panel-trigger-outline-color), 0px -1px 0 var(--panel-trigger-outline-color), -1px 0px 0 var(--panel-trigger-outline-color), 1px 0px 0 var(--panel-trigger-outline-color);
     display: inline-block;
-    cursor: pointer;
+    font-size: 2.5rem;
+    border: 0;
+    padding: 0;
+    margin: 0 .2rem 0 0;
 }
 
 .panel-trigger:hover {
@@ -1154,8 +1161,22 @@ aside.panel {
     color: #555;
 }
 
-.panel-trigger .fas, .panel-trigger .far, .panel-trigger .fal {
-    font-size: 2.5rem;
+.panel-closer {
+    color: #a00;
+    color: var(--panel-close-button-color);
+    border: 0;
+    padding: 0;
+    margin: .2rem 0 0 0;
+}
+
+.panel-closer:hover {
+    color: #a00;
+    color: var(--panel-close-button-color-hover);
+}
+
+.panel-closer:active {
+    color: #a00;
+    color: var(--panel-close-button-color-active);
 }
 
 article .body {

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -124,11 +124,7 @@ html {
     --notification-footer-background-color: #d6d6d6;
     --notification-footer-text-color: #666;
     --notification-expiry-color: #b66;
-    
-    --modal-text-color: inherit;
-    --modal-background-color: #f5f5f5;
-    --modal-headfoot-background-color: #b8b8b8;
-    
+        
     --emoji-picker-border-color: #999999;
     --emoji-picker-shadow-color: #CCCCCC;
     --emoji-picker-background-color: #FFFFFF;
@@ -1062,13 +1058,16 @@ aside.panel {
     max-width: 50%;
     min-width: 30%;
     height: 100%;
+    z-index: 21;
+    cursor: initial !important;
+}
+
+.panel {
     box-shadow: 0 0 10px 5px #0009;
     background-color: #dfdfdf;
     background-color: var(--panel-background-color);
     color: inherit;
     color: var(--panel-text-color);
-    z-index: 21;
-    cursor: initial !important;
 }
 
 .panel.half-width {
@@ -1082,9 +1081,14 @@ aside.panel {
     min-height: initial;
 }
 
-.panel header {
+.panel > header, .panel > .modal-wrapper > header {
     border-bottom: 1px solid #000;
     border-bottom: 1px solid var(--panel-borders-color);
+}
+
+.panel > footer, .panel > .modal-wrapper > footer {
+    border-top: 1px solid #000;
+    border-top: 1px solid var(--panel-borders-color);
 }
 
 .panel.left {
@@ -1991,45 +1995,17 @@ body .emoji-picker {
     min-width: 10vw;
     max-width: 96vw;
     max-height: 99vh;
-    background-color: #f5f5f5;
-    background-color: var(--modal-background-color);
     padding: 0;
     outline: 0;
-    color: inherit;
-    color: var(--modal-text-color);
-}
-
-.modal a.close-modal {
-    position: absolute;
-    font-size: 1.25em;
-    top: 0;
-    right: 0;
-    background: #660000;
-    width: 1.5em;
-    height: 1.5em;
-    line-height: 1.5em;
-    text-align: center;
-    color: #eee;
-    text-decoration: none;
-    text-indent: 0;
-    border-radius: 0 6px 0 12px;
-    box-shadow: 1px 1px 5px #660000aa;
 }
 
 .modal .modal-footer {
     text-align: right;
 }
 
-.modal .close-modal {
-    outline: none;
-}
-
 .modal .modal-header, .modal .modal-footer {
     margin: 0;
-    padding: 5px 7px;
     min-height: 2em;
-    background-color: #b8b8b8;
-    background-color: var(--modal-headfoot-background-color);
 }
 
 .modal .modal-header {

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -79,15 +79,26 @@ html {
     --notification-color: #b20;
     --ping-highlight-color: #feedd1;
     --ping-flash-color: #8ef7d1;
+    --notification-expiry-color: #b66;
         
-    --panel-header-background: linear-gradient(to bottom, #ccc, #bbb);
     --panel-background-color: #dfdfdf;
     --panel-text-color: inherit;
-    --panel-borders-color: #000;
+    --panel-border-color: #000;
+    --panel-header-text-color: inherit;
+    --panel-header-background: linear-gradient(to bottom, #ccc, #bbb);
+    --panel-footer-text-color: #666;
+    --panel-footer-background: #d6d6d6;
     --panel-close-button-color: #a00;
     --panel-close-button-color-hover: var(--panel-close-button-color);
     --panel-close-button-color-active: var(--panel-close-button-color);
+    
     --panel-article-background-color: #0002;
+    --panel-article-text-color: var(--panel-text-color);
+    --panel-article-border-color: var(--panel-border-color);
+    --panel-article-header-text-color: inherit;
+    --panel-article-header-background: var(--panel-header-background);
+    --panel-article-footer-text-color: var(--panel-header-text-color);
+    --panel-article-footer-background: var(--panel-footer-background);
     
     --panel-trigger-outline-color: #AAA;
     
@@ -120,14 +131,6 @@ html {
     --popup-timestamp-text-color: #aaa;
     --pane-button-background: linear-gradient(0deg, #eee, #ccc, #eee);
     --pane-button-background-hover: linear-gradient(0deg, #ddd, #bbb, #ddd);
-    
-    --notification-background-color: #f5f5f5;
-    --notification-border-color: #8f8f8f;
-    --notification-title-text-color: inherit;
-    --notification-title-background-color: #b8b8b8;
-    --notification-footer-background-color: #d6d6d6;
-    --notification-footer-text-color: #666;
-    --notification-expiry-color: #b66;
         
     --emoji-picker-border-color: #999999;
     --emoji-picker-shadow-color: #CCCCCC;
@@ -1014,6 +1017,14 @@ header h1, header h2, header h3, header h4, header h5, header h6 {
     padding: 0;
 }
 
+footer {
+    font-size: .75rem;
+    font-weight: bold;
+    font-style: italic;
+    text-align: right;
+    padding: 0 1rem;
+}
+
 .fas.fa-is-left, .far.fa-is-left {
     margin-right: .25rem;
 }
@@ -1125,10 +1136,12 @@ aside.panel {
 }
 
 .panel-header {
+    color: inherit;
+    color: var(--panel-header-text-color);
     background-image: linear-gradient(to bottom, #ccc, #bbb);
     background: var(--panel-header-background);
     border-bottom: 1px solid #000;
-    border-bottom: 1px solid var(--panel-borders-color);
+    border-bottom: 1px solid var(--panel-border-color);
 }
 
 .panel-header button {
@@ -1136,8 +1149,12 @@ aside.panel {
 }
 
 .panel-footer {
+    color: inherit;
+    color: var(--panel-footer-text-color);
     border-top: 1px solid #000;
-    border-top: 1px solid var(--panel-borders-color);
+    border-top: 1px solid var(--panel-border-color);
+    background-image: #;
+    background: var(--panel-footer-background);
 }
 
 .panel-trigger {
@@ -1194,16 +1211,35 @@ article .body {
 }
 
 .panel-body article:not(.naked) {
+    color: inherit;
+    color: var(--panel-article-text-color);
     border: 1px solid #000;
-    border: 1px solid var(--panel-borders-color);
+    border-bottom: 1px solid var(--panel-article-border-color);
     background-color: #0002;
     background-color: var(--panel-article-background-color);
 }
 
 .panel-body article:not(.naked) > header {
-    border-bottom: 1px solid var(--panel-borders-color);
+    color: inherit;
+    color: var(--panel-article-header-text-color);
+    border-bottom: 1px solid #000;
+    border-bottom: 1px solid var(--panel-article-border-color);
     background: linear-gradient(to bottom, #ccc, #bbb);
-    background: var(--panel-header-background);
+    background: var(--panel-article-header-background);
+    border-top-left-radius: inherit;
+    border-top-right-radius: inherit;
+}
+
+.panel-body article:not(.naked) > footer {
+    padding: 0.833em .5em;
+    color: #666;
+    color: var(--panel-article-footer-text-color);
+    border-top: 1px solid #000;
+    border-top: 1px solid var(--panel-article-border-color);
+    background: linear-gradient(to bottom, #ccc, #bbb);
+    background: var(--panel-article-footer-background);
+    border-bottom-left-radius: inherit;
+    border-bottom-right-radius: inherit;
 }
 
 .panel-body article p {
@@ -1957,50 +1993,9 @@ body .emoji-picker {
 /* Notifications */
 .notification {
     margin: 15px 10px;
-    border-radius: 5px;
-    background-color: #f5f5f5;
-    background-color: var(--notification-background-color);
-    border: 1px solid #8f8f8f;
-    border: 1px solid var(--notification-border-color);
 }
 
-.notification .notification-title {
-    height: 2rem;
-    line-height: 2rem;
-    font-size: 1.25rem;
-    font-weight: bold;
-    text-align: center;
-    white-space: pre;
-    overflow: hidden;
-    border-radius: 4px 4px 0 0;
-    background-color: #b8b8b8;
-    background-color: var(--notification-title-background-color);
-    border-bottom: 1px solid #8f8f8f;
-    border-bottom: 1px solid var(--notification-border-color);
-    color: inherit;
-    color: var(--notification-title-text-color);
-}
-
-.notification .notification-footer {
-    height: 2rem;
-    line-height: 2rem;
-    font-size: .75rem;
-    font-weight: bold;
-    font-style: italic;
-    text-align: right;
-    color: #666;
-    color: var(--notification-footer-text-color);
-    white-space: pre;
-    overflow: hidden;
-    border-radius: 0 0 4px 4px;
-    background-color: #d6d6d6;
-    background-color: var(--notification-footer-background-color);
-    border-top: 1px solid #8f8f8f;
-    border-top: 1px solid var(--notification-border-color);
-    padding-right: .5rem;
-}
-
-.notification .notification-body {
+.notification-body {
     padding: 10px 5px;
     word-break: break-word;
     white-space: pre-wrap;
@@ -2010,8 +2005,6 @@ body .emoji-picker {
     cursor: default;
     color: #b66;
     color: var(--notification-expiry-color);
-    float: left;
-    margin-left: .5rem;
 }
 
 /*//////////////////////////*\

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -120,14 +120,7 @@ html {
     --chat-typeahead-item-background-color: #a3a3a3;
     --chat-typeahead-item-background-color-hover: #949494;
     --chat-typeahead-item-background-color-active: #828282;
-    
-    --popup-background-color: #eee;
-    --popup-border-color: #000;
-    --popup-text-color: inherit;
-    --popup-timestamp-text-color: #aaa;
-    --pane-button-background: linear-gradient(0deg, #eee, #ccc, #eee);
-    --pane-button-background-hover: linear-gradient(0deg, #ddd, #bbb, #ddd);
-        
+
     --emoji-picker-border-color: #999999;
     --emoji-picker-shadow-color: #CCCCCC;
     --emoji-picker-background-color: #FFFFFF;
@@ -1823,16 +1816,10 @@ body .emoji-picker {
     width: 100px;
     max-width: 200px;
     height: auto;
-    background-color: #eee;
-    background-color: var(--popup-background-color);
     border-radius: 5px;
-    border: 1px solid #000;
-    border: 1px solid var(--popup-border-color);
     font-size: 1rem !important;
     line-height: 1rem !important;
     overflow: hidden;
-    color: inherit;
-    color: var(--popup-text-color);
 }
 
 .popup.panels {
@@ -1848,6 +1835,8 @@ body .emoji-picker {
 
 .popup.panels .actions-wrapper {
     width: 35%;
+    background-color: #0002;
+    background-color: var(--panel-article-background-color);
 }
 
 .popup.panels .pane {
@@ -1879,7 +1868,7 @@ body .emoji-picker {
     max-height: 100%;
     max-width: 100%;
     border-left: 1px solid #000;
-    border-left: 1px solid var(--popup-border-color);
+    border-left: 1px solid var(--panel-border-color);
 }
 
 .pane ul.actions-list li {
@@ -1891,10 +1880,8 @@ body .emoji-picker {
     margin: 0;
     padding: 8px 0;
     border-bottom: 1px solid #000;
-    border-bottom: 1px solid var(--popup-border-color);
+    border-bottom: 1px solid var(--panel-border-color);
     text-align: center;
-    color: #aaa;
-    color: var(--popup-timestamp-text-color);
 }
 
 /* Settings tweaks */

--- a/resources/public/themes/dark.css
+++ b/resources/public/themes/dark.css
@@ -6,9 +6,6 @@ html {
     --kbd-border-color: #333;
     --kbd-text-color: #fff;
     
-    --message-background-color: #333;
-    --message-text-color: #eee;
-    
     --input-text-color: #eee;
     --input-background-color: #222;
     --input-border-color: #333;

--- a/resources/public/themes/dark.css
+++ b/resources/public/themes/dark.css
@@ -17,7 +17,7 @@ html {
     --floating-panel-background-color: #333;
     --floating-panel-text-color: #eee;
     
-    --report-button-border-color: #333;
+    --dangerous-button-border-color: #333;
 
     --palette-background-color: rgba(0, 0, 0, 0.5);
     --palette-overlay-background-color: rgba(0, 0, 0, 0.9);

--- a/resources/public/themes/dark.css
+++ b/resources/public/themes/dark.css
@@ -44,10 +44,6 @@ html {
     --chat-server-action-text-color: #9f9f9f;
     --chat-user-text-shadow-color: #333;
     
-    --mod-lookup-chatban-history-item-background-color: rgba(37, 37, 37, 0.3);
-    --mod-lookup-chatban-history-item-border-color: #828282;
-    --mod-lookup-chatban-history-item-heading-background-color: #82828233;
-    
     --popup-background-color: #333;
     --popup-border-color: #000;
     --popup-text-color: #ccc;

--- a/resources/public/themes/dark.css
+++ b/resources/public/themes/dark.css
@@ -79,10 +79,6 @@ html {
     --notification-footer-background-color: #2e2e2e;
     --notification-footer-text-color: #666;
     --notification-expiry-color: #995050;
-    
-    --modal-text-color: #ddd;
-    --modal-background-color: #3d3d3d;
-    --modal-headfoot-background-color: #292929;
 }
 
 hr {

--- a/resources/public/themes/dark.css
+++ b/resources/public/themes/dark.css
@@ -35,6 +35,8 @@ html {
     --panel-background-color: #333;
     --panel-text-color: #eee;
     --panel-close-button-color: #f44;
+    --panel-footer-background: #2e2e2e;
+    --panel-footer-text-color: #666;
     
     --option-bubble-position-background-color-selected: #9d9d9d;
     --chat-separator-color: #4f4f4f;
@@ -73,12 +75,7 @@ html {
     --chat-typeahead-item-background-color: #2c2c2c;
     --chat-typeahead-item-background-color-hover: #3b3b3b;
     --chat-typeahead-item-background-color-active: #595959;
-        
-    --notification-background-color: #3d3d3d;
-    --notification-border-color: #111111;
-    --notification-title-background-color: #292929;
-    --notification-footer-background-color: #2e2e2e;
-    --notification-footer-text-color: #666;
+
     --notification-expiry-color: #995050;
 }
 

--- a/resources/public/themes/dark.css
+++ b/resources/public/themes/dark.css
@@ -16,9 +16,9 @@ html {
     --button-background-color: #bbb;
     --button-border-color-hover: #844;
     
-    --lookup-border-color: #222;
-    --lookup-background-color: #333;
-    --lookup-text-color: #eee;
+    --floating-panel-border-color: #222;
+    --floating-panel-background-color: #333;
+    --floating-panel-text-color: #eee;
     
     --report-button-border-color: #333;
 
@@ -75,11 +75,7 @@ html {
     --chat-typeahead-item-background-color: #2c2c2c;
     --chat-typeahead-item-background-color-hover: #3b3b3b;
     --chat-typeahead-item-background-color-active: #595959;
-    
-    --admin-check-border-color: #222;
-    --admin-check-text-color: #eee;
-    --admin-check-background-color: #333;
-    
+        
     --notification-background-color: #3d3d3d;
     --notification-border-color: #111111;
     --notification-title-background-color: #292929;

--- a/resources/public/themes/dark.css
+++ b/resources/public/themes/dark.css
@@ -44,12 +44,6 @@ html {
     --chat-server-action-text-color: #9f9f9f;
     --chat-user-text-shadow-color: #333;
     
-    --popup-background-color: #333;
-    --popup-border-color: #000;
-    --popup-text-color: #ccc;
-    --pane-button-background: linear-gradient(0,#333,#3f3f3f,#333);
-    --pane-button-background-hover: linear-gradient(0,#2a2a2a,#3a3a3a,#2a2a2a);
-    
     --emoji-picker-border-color: #515151;
     --emoji-picker-shadow-color: #1f1f1f;
     --emoji-picker-background-color: #333333;

--- a/resources/public/themes/dark.css
+++ b/resources/public/themes/dark.css
@@ -1,26 +1,26 @@
 html {
     --general-text-color: #fff;
-    --general-background-color: #1A1A1A;
+    --general-background: #1A1A1A;
     
-    --kbd-background-color: #444;
+    --kbd-background: #444;
     --kbd-border-color: #333;
     --kbd-text-color: #fff;
     
     --input-text-color: #eee;
-    --input-background-color: #222;
+    --input-background: #222;
     --input-border-color: #333;
     
-    --button-background-color: #bbb;
+    --button-background: #bbb;
     --button-border-color-hover: #844;
     
     --floating-panel-border-color: #222;
-    --floating-panel-background-color: #333;
+    --floating-panel-background: #333;
     --floating-panel-text-color: #eee;
     
     --dangerous-button-border-color: #333;
 
-    --palette-background-color: rgba(0, 0, 0, 0.5);
-    --palette-overlay-background-color: rgba(0, 0, 0, 0.9);
+    --palette-background: rgba(0, 0, 0, 0.5);
+    --palette-overlay-background: rgba(0, 0, 0, 0.9);
     --palette-overlay-text-color: #eee;
     --palette-deselect-button-color: #DDD;
     
@@ -32,21 +32,21 @@ html {
     --ping-highlight-color: #5b5345;
     
     --panel-header-background: linear-gradient(to bottom, #444, #333);
-    --panel-background-color: #333;
+    --panel-background: #333;
     --panel-text-color: #eee;
     --panel-close-button-color: #f44;
     --panel-footer-background: #2e2e2e;
     --panel-footer-text-color: #666;
     
-    --option-bubble-position-background-color-selected: #9d9d9d;
+    --option-bubble-position-background-selected: #9d9d9d;
     --chat-separator-color: #4f4f4f;
-    --chat-odd-background-color: #3f3f3f;
+    --chat-odd-background: #3f3f3f;
     --chat-server-action-text-color: #9f9f9f;
     --chat-user-text-shadow-color: #333;
     
     --emoji-picker-border-color: #515151;
     --emoji-picker-shadow-color: #1f1f1f;
-    --emoji-picker-background-color: #333333;
+    --emoji-picker-background: #333333;
     --emoji-picker-preview-name-text-color: #ccc;
     --emoji-picker-tab-icon-color: #ccc;
     --emoji-picker-tab-icon-color-selected: #6fd1ff;
@@ -54,17 +54,17 @@ html {
     --emoji-picker-emoji-color: white;
     --emoji-picker-emoji-background-hover: #656565;
     --emoji-picker-emoji-search-input-border-color: #333;
-    --emoji-picker-emoji-search-input-background-color: #222;
+    --emoji-picker-emoji-search-input-background: #222;
     --emoji-picker-emoji-search-input-text-color: #ddd;
     --emoji-picker-search-icon-color: #aaa;
     --emoji-picker-search-no-results-color: #666666;
     --emoji-picker-variant-overlay-background: rgba(0, 0, 0, 0.7);
     --emoji-picker-variant-popup-background: #FFFFFF;
     
-    --chat-typeahead-menu-background-color: #1d1d1d;
-    --chat-typeahead-item-background-color: #2c2c2c;
-    --chat-typeahead-item-background-color-hover: #3b3b3b;
-    --chat-typeahead-item-background-color-active: #595959;
+    --chat-typeahead-menu-background: #1d1d1d;
+    --chat-typeahead-item-background: #2c2c2c;
+    --chat-typeahead-item-background-hover: #3b3b3b;
+    --chat-typeahead-item-background-active: #595959;
 
     --notification-expiry-color: #995050;
 }
@@ -76,9 +76,9 @@ hr {
 
 @keyframes -scrolled-flash {
     from {
-        background-color: #5b5345;
+        background: #5b5345;
     }
     to {
-        background-color: #58a78a;
+        background: #58a78a;
     }
 }

--- a/resources/public/themes/dark.css
+++ b/resources/public/themes/dark.css
@@ -34,6 +34,7 @@ html {
     --panel-header-background: linear-gradient(to bottom, #444, #333);
     --panel-background-color: #333;
     --panel-text-color: #eee;
+    --panel-close-button-color: #f44;
     
     --option-bubble-position-background-color-selected: #9d9d9d;
     --chat-separator-color: #4f4f4f;

--- a/resources/public/themes/dark.css
+++ b/resources/public/themes/dark.css
@@ -53,9 +53,9 @@ html {
     --emoji-picker-section-text-color: #ccc;
     --emoji-picker-emoji-color: white;
     --emoji-picker-emoji-background-hover: #656565;
-    --emoji-picker-emoji-search-input-border-color: #333;
-    --emoji-picker-emoji-search-input-background: #222;
-    --emoji-picker-emoji-search-input-text-color: #ddd;
+    --emoji-picker-search-input-border-color: #333;
+    --emoji-picker-search-input-background: #222;
+    --emoji-picker-search-input-text-color: #ddd;
     --emoji-picker-search-icon-color: #aaa;
     --emoji-picker-search-no-results-color: #666666;
     --emoji-picker-variant-overlay-background: rgba(0, 0, 0, 0.7);

--- a/resources/public/themes/darker.css
+++ b/resources/public/themes/darker.css
@@ -6,9 +6,6 @@ html {
     --kbd-border-color: #333;
     --kbd-text-color: #fff;
     
-    --message-background-color: #000;
-    --message-text-color: #fff;
-    
     --button-background-color: #000;
     --button-text-color: #fff;
     --button-border-color-hover: transparent;

--- a/resources/public/themes/darker.css
+++ b/resources/public/themes/darker.css
@@ -91,10 +91,6 @@ html {
     --notification-title-background-color: #232323;
     --notification-footer-background-color: #252525;
     --notification-expiry-color: #c45454;
-    
-    --modal-text-color: #ddd;
-    --modal-background-color: #1a1a1a;
-    --modal-headfoot-background-color: #000000;
 }
 
 

--- a/resources/public/themes/darker.css
+++ b/resources/public/themes/darker.css
@@ -49,10 +49,6 @@ html {
     --chat-server-action-text-color:#ccc;
     --chat-user-text-shadow-color: #111;
     
-    --mod-lookup-chatban-history-item-background-color: #000;
-    --mod-lookup-chatban-history-item-border-color: #464646;
-    --mod-lookup-chatban-history-item-heading-background-color: #46464633;
-    
     --popup-background-color: #111;
     --popup-text-color: #fff;
     --pane-button-background: linear-gradient(0,#111,#1f1f1f,#111);

--- a/resources/public/themes/darker.css
+++ b/resources/public/themes/darker.css
@@ -65,9 +65,9 @@ html {
     --emoji-picker-emoji-color: #fff;
     --emoji-picker-emoji-background: transparent;
     --emoji-picker-emoji-background-hover: #656565;
-    --emoji-picker-emoji-search-input-border-color: #2f2f2f;
-    --emoji-picker-emoji-search-input-background: #111;
-    --emoji-picker-emoji-search-input-text-color: #fff;
+    --emoji-picker-search-input-border-color: #2f2f2f;
+    --emoji-picker-search-input-background: #111;
+    --emoji-picker-search-input-text-color: #fff;
     --emoji-picker-search-icon-color: #bbb;
     --emoji-picker-search-no-results-color: #bbb;
     --emoji-picker-variant-overlay-background: rgba(0, 0, 0, 0.7);

--- a/resources/public/themes/darker.css
+++ b/resources/public/themes/darker.css
@@ -17,8 +17,9 @@ html {
     --floating-panel-border-color: #222;
     --floating-panel-background-color: #000;
     
-    --report-button-background-color: #d00;
-    --report-button-background-color-hover: #d50000;
+    --dangerous-button-background-color: #d00;
+    --dangerous-button-background-color-hover: #d50000;
+    --dangerous-button-border-color: var(--dangerous-button-background-color);
     
     --palette-background-color: #000;
     --palette-overlay-background-color: #000;
@@ -85,10 +86,6 @@ html {
 
 .message {
     border: 2px solid #333;
-}
-
-#lookup .report-button {
-    border: 1px solid var(--report-button-background-color);
 }
 
 hr {

--- a/resources/public/themes/darker.css
+++ b/resources/public/themes/darker.css
@@ -16,9 +16,9 @@ html {
     
     --bubble-background-color: #000;
     
-    --lookup-text-color: #fff;
-    --lookup-border-color: #222;
-    --lookup-background-color: #000;
+    --floating-panel-text-color: #fff;
+    --floating-panel-border-color: #222;
+    --floating-panel-background-color: #000;
     
     --report-button-background-color: #d00;
     --report-button-background-color-hover: #d50000;
@@ -87,11 +87,7 @@ html {
     --chat-typeahead-item-background-color: #1a1a1a;
     --chat-typeahead-item-background-color-hover: #2b2b2b;
     --chat-typeahead-item-background-color-active: #3b3b3b;
-    
-    --admin-check-border-color: #222;
-    --admin-check-text-color: #fff;
-    --admin-check-background-color: #000;
-    
+        
     --notification-background-color: #191919;
     --notification-border-color: #111111;
     --notification-footer-text-color: #999;

--- a/resources/public/themes/darker.css
+++ b/resources/public/themes/darker.css
@@ -39,6 +39,8 @@ html {
     --panel-background-color: #000;
     --panel-text-color: #fff;
     --panel-close-button-color: #f00;
+    --panel-footer-background: #252525;
+    --panel-footer-text-color: #999;
     
     --option-bubble-position-background-color-selected: #fff;
     
@@ -85,12 +87,7 @@ html {
     --chat-typeahead-item-background-color: #1a1a1a;
     --chat-typeahead-item-background-color-hover: #2b2b2b;
     --chat-typeahead-item-background-color-active: #3b3b3b;
-        
-    --notification-background-color: #191919;
-    --notification-border-color: #111111;
-    --notification-footer-text-color: #999;
-    --notification-title-background-color: #232323;
-    --notification-footer-background-color: #252525;
+
     --notification-expiry-color: #c45454;
 }
 

--- a/resources/public/themes/darker.css
+++ b/resources/public/themes/darker.css
@@ -49,11 +49,6 @@ html {
     --chat-server-action-text-color:#ccc;
     --chat-user-text-shadow-color: #111;
     
-    --popup-background-color: #111;
-    --popup-text-color: #fff;
-    --pane-button-background: linear-gradient(0,#111,#1f1f1f,#111);
-    --pane-button-background-hover: linear-gradient(0,#000,#111,#000);
-    
     --panel-trigger-outline-color: #666;
     
     --ping-highlight-color: #5b5345;

--- a/resources/public/themes/darker.css
+++ b/resources/public/themes/darker.css
@@ -1,28 +1,28 @@
 html {
     --general-text-color: #fff;
-    --general-background-color: #000;
+    --general-background: #000;
     
-    --kbd-background-color: #444;
+    --kbd-background: #444;
     --kbd-border-color: #333;
     --kbd-text-color: #fff;
     
-    --button-background-color: #000;
+    --button-background: #000;
     --button-text-color: #fff;
     --button-border-color-hover: transparent;
-    --button-background-color-hover: #252525;
+    --button-background-hover: #252525;
     
-    --bubble-background-color: #000;
+    --bubble-background: #000;
     
     --floating-panel-text-color: #fff;
     --floating-panel-border-color: #222;
-    --floating-panel-background-color: #000;
+    --floating-panel-background: #000;
     
-    --dangerous-button-background-color: #d00;
-    --dangerous-button-background-color-hover: #d50000;
-    --dangerous-button-border-color: var(--dangerous-button-background-color);
+    --dangerous-button-background: #d00;
+    --dangerous-button-background-hover: #d50000;
+    --dangerous-button-border-color: var(--dangerous-button-background);
     
-    --palette-background-color: #000;
-    --palette-overlay-background-color: #000;
+    --palette-background: #000;
+    --palette-overlay-background: #000;
     --palette-overlay-text-color: #eee;
     --palette-deselect-button-color: #c00;
     
@@ -30,23 +30,23 @@ html {
     --undo-text-color: #fff;
     
     --input-text-color: #fff;
-    --input-background-color: #111;
+    --input-background: #111;
     --input-border-color: #2f2f2f;
     
     --text-red-color: #f00;
     --text-yellow-color: #ee0;
     
     --panel-header-background: #222;
-    --panel-background-color: #000;
+    --panel-background: #000;
     --panel-text-color: #fff;
     --panel-close-button-color: #f00;
     --panel-footer-background: #252525;
     --panel-footer-text-color: #999;
     
-    --option-bubble-position-background-color-selected: #fff;
+    --option-bubble-position-background-selected: #fff;
     
     --chat-separator-color:#2f2f2f;
-    --chat-odd-background-color:#111;
+    --chat-odd-background:#111;
     --chat-server-action-text-color:#ccc;
     --chat-user-text-shadow-color: #111;
     
@@ -57,7 +57,7 @@ html {
     
     --emoji-picker-border-color: #383838;
     --emoji-picker-shadow-color: #111;
-    --emoji-picker-background-color: #000;
+    --emoji-picker-background: #000;
     --emoji-picker-preview-name-text-color: #fff;
     --emoji-picker-tab-icon-color: #fff;
     --emoji-picker-tab-icon-color-selected: #6fd1ff;
@@ -66,7 +66,7 @@ html {
     --emoji-picker-emoji-background: transparent;
     --emoji-picker-emoji-background-hover: #656565;
     --emoji-picker-emoji-search-input-border-color: #2f2f2f;
-    --emoji-picker-emoji-search-input-background-color: #111;
+    --emoji-picker-emoji-search-input-background: #111;
     --emoji-picker-emoji-search-input-text-color: #fff;
     --emoji-picker-search-icon-color: #bbb;
     --emoji-picker-search-no-results-color: #bbb;
@@ -74,11 +74,11 @@ html {
     --emoji-picker-variant-popup-background: #222;
     --emoji-picker-variant-close-button-color: #fff;
     
-    --chat-typeahead-menu-background-color: #000;
+    --chat-typeahead-menu-background: #000;
     --chat-typeahead-item-text-color: #fff;
-    --chat-typeahead-item-background-color: #1a1a1a;
-    --chat-typeahead-item-background-color-hover: #2b2b2b;
-    --chat-typeahead-item-background-color-active: #3b3b3b;
+    --chat-typeahead-item-background: #1a1a1a;
+    --chat-typeahead-item-background-hover: #2b2b2b;
+    --chat-typeahead-item-background-active: #3b3b3b;
 
     --notification-expiry-color: #c45454;
 }
@@ -95,9 +95,9 @@ hr {
 
 @keyframes -scrolled-flash {
     from {
-        background-color: #3d382e;
+        background: #3d382e;
     }
     to {
-        background-color: #2c5445;
+        background: #2c5445;
     }
 }

--- a/resources/public/themes/darker.css
+++ b/resources/public/themes/darker.css
@@ -38,6 +38,7 @@ html {
     --panel-header-background: #222;
     --panel-background-color: #000;
     --panel-text-color: #fff;
+    --panel-close-button-color: #f00;
     
     --option-bubble-position-background-color-selected: #fff;
     

--- a/resources/public/themes/purple.css
+++ b/resources/public/themes/purple.css
@@ -114,9 +114,9 @@ html {
     --emoji-picker-emoji-color: var(--general-text-color);
     --emoji-picker-emoji-background: transparent;
     --emoji-picker-emoji-background-hover: rgba(0, 0, 0, 0.1);
-    --emoji-picker-emoji-search-input-border-color: var(--input-border-color);
-    --emoji-picker-emoji-search-input-background: var(--input-background);
-    --emoji-picker-emoji-search-input-text-color: var(--input-text-color);
+    --emoji-picker-search-input-border-color: var(--input-border-color);
+    --emoji-picker-search-input-background: var(--input-background);
+    --emoji-picker-search-input-text-color: var(--input-text-color);
     --emoji-picker-search-icon-color: var(--text-muted-color);
     --emoji-picker-search-no-results-color: var(--text-muted-color);
     --emoji-picker-variant-overlay-background: rgba(0, 0, 0, 0.7);

--- a/resources/public/themes/purple.css
+++ b/resources/public/themes/purple.css
@@ -6,9 +6,6 @@ html {
     --kbd-border-color: #ddd;
     --kbd-text-color: #000;
 
-    --message-background-color: #5a2f71;
-    --message-text-color: inherit;
-
     --button-background-color: #f8f9fa;
     --button-border-color: #f8f9fa;
     --button-text-color: #212529;
@@ -19,14 +16,16 @@ html {
     --button-border-color-hover: #dae0e5;
     --button-background-color-hover: #e2e6ea;
 
-    --report-button-text-color: #fff;
-    --report-button-background-color: #ff5959;
-    --report-button-background-color-hover: #f33;
-    --report-button-border-color: #ff5959;
+    --dangerous-button-text-color: #fff;
+    --dangerous-button-background-color: #ff5959;
+    --dangerous-button-border-color: #ff5959;
+    --dangerous-button-text-color-hover: var(--dangerous-button-text-color);
+    --dangerous-button-background-color-hover: #f33;
+    --dangerous-button-border-color-hover: var(--dangerous-button-border-color);
 
-    --lookup-text-color: inherit;
-    --lookup-border-color: #000;
-    --lookup-background-color: var(--message-background-color);
+    --floating-panel-text-color: inherit;
+    --floating-panel-border-color: #000;
+    --floating-panel-background-color: #5a2f71;
 
     --bubble-background-color: rgba(0, 0, 0, 0.7);
     --bubble-text-color: #fff;
@@ -57,12 +56,27 @@ html {
     --notification-color: #b20;
     --ping-highlight-color: #860d82;
     --ping-flash-color: #8ef7d1;
+    --ping-counter-color: #ffa500;
+    --notification-expiry-color: var(--text-orange-color);
       
-    --panel-header-background: #320241;
     --panel-background-color: #3d204d;
     --panel-text-color: inherit;
-    --panel-borders-color: #000;
+    --panel-border-color: #000;
+    --panel-header-text-color: inherit;
+    --panel-header-background: #320241;
+    --panel-footer-text-color: var(--text-muted-color);
+    --panel-footer-background: var(--panel-header-background);
+    --panel-close-button-color: var(--text-red-color);
+    --panel-close-button-color-hover: var(--panel-close-button-color);
+    --panel-close-button-color-active: var(--panel-close-button-color);
+
     --panel-article-background-color: #5a2f71;
+    --panel-article-text-color: var(--panel-text-color);
+    --panel-article-border-color: var(--panel-border-color);
+    --panel-article-header-text-color: inherit;
+    --panel-article-header-background: var(--panel-header-background);
+    --panel-article-footer-text-color: var(--panel-footer-text-color);
+    --panel-article-footer-background: var(--panel-footer-background);
 
     --panel-trigger-outline-color: #AAA;
 
@@ -78,6 +92,11 @@ html {
     --chat-server-action-text-color: var(--text-muted-color);
     --chat-user-text-shadow-color: #555;
     --chat-purged-text-color: var(--text-muted-color);
+    
+    --chat-tobottom-text-color: #fff;
+    --chat-tobottom-background-color: #683683;
+    --chat-tobottom-text-color-hover: var(--chat-tobottom-text-color);
+    --chat-tobottom-background-color-hover: #8445a7;
 
     --chat-typeahead-menu-background-color: var(--panel-article-background-color);
     --chat-typeahead-item-text-color: inherit;
@@ -85,32 +104,9 @@ html {
     --chat-typeahead-item-background-color-hover: #683683;
     --chat-typeahead-item-background-color-active: #8445a7;
 
-    --mod-lookup-chatban-history-item-background-color: var(--panel-article-background-color);
-    --mod-lookup-chatban-history-item-border-color: var(--panel-borders-color);
-    --mod-lookup-chatban-history-item-heading-background-color: var(--panel-header-background);
-
-    --popup-background-color: var(--panel-background-color);
-    --popup-border-color: var(--panel-borders-color);
-    --popup-text-color: var(--panel-text-color);
-    --popup-timestamp-text-color: var(--text-muted-color);
-    --pane-button-background: #683683;
-    --pane-button-background-hover: #8445a7;
-
-    --notification-background-color: var(--panel-article-background-color);
-    --notification-border-color: var(--panel-borders-color);
-    --notification-title-text-color: inherit;
-    --notification-title-background-color: var(--panel-header-background);
-    --notification-footer-background-color: var(--panel-header-background);
-    --notification-footer-text-color: var(--text-muted-color);
-    --notification-expiry-color: var(--text-orange-color);
-
-    --modal-text-color: inherit;
-    --modal-background-color: var(--panel-background-color);
-    --modal-headfoot-background-color: var(--panel-header-background);
-
-    --emoji-picker-border-color: var(--lookup-border-color);
+    --emoji-picker-border-color: var(--floating-panel-border-color);
     --emoji-picker-shadow-color: #0009;
-    --emoji-picker-background-color: var(--lookup-background-color);
+    --emoji-picker-background-color: var(--floating-panel-background-color);
     --emoji-picker-preview-name-text-color: var(--text-muted-color);
     --emoji-picker-tab-icon-color: inherit;
     --emoji-picker-tab-icon-color-selected: #ae5cdb;
@@ -124,14 +120,8 @@ html {
     --emoji-picker-search-icon-color: var(--text-muted-color);
     --emoji-picker-search-no-results-color: var(--text-muted-color);
     --emoji-picker-variant-overlay-background: rgba(0, 0, 0, 0.7);
-    --emoji-picker-variant-popup-background: var(--lookup-background-color);
+    --emoji-picker-variant-popup-background: var(--floating-panel-background-color);
     --emoji-picker-variant-close-button-color: var(--text-red-color);
-
-    --admin-background: var(--bubble-background-color);
-    --admin-text-color: var(--bubble-text-color);
-    --admin-check-border-color: var(--lookup-border-color);
-    --admin-check-text-color: inherit;
-    --admin-check-background-color: var(--lookup-background-color);
 }
 
 .button:disabled {

--- a/resources/public/themes/purple.css
+++ b/resources/public/themes/purple.css
@@ -1,38 +1,38 @@
 html {
     --general-text-color: #ddd;
-    --general-background-color: #111;
+    --general-background: #111;
 
-    --kbd-background-color: #eee;
+    --kbd-background: #eee;
     --kbd-border-color: #ddd;
     --kbd-text-color: #000;
 
-    --button-background-color: #f8f9fa;
+    --button-background: #f8f9fa;
     --button-border-color: #f8f9fa;
     --button-text-color: #212529;
     --button-text-color-disabled: var(--button-text-color);
     --button-border-color-disabled: var(--button-border-color);
-    --button-background-color-disabled: var(--button-background-color);
+    --button-background-disabled: var(--button-background);
     --button-text-color-hover: var(--button-text-color);
     --button-border-color-hover: #dae0e5;
-    --button-background-color-hover: #e2e6ea;
+    --button-background-hover: #e2e6ea;
 
     --dangerous-button-text-color: #fff;
-    --dangerous-button-background-color: #ff5959;
+    --dangerous-button-background: #ff5959;
     --dangerous-button-border-color: #ff5959;
     --dangerous-button-text-color-hover: var(--dangerous-button-text-color);
-    --dangerous-button-background-color-hover: #f33;
+    --dangerous-button-background-hover: #f33;
     --dangerous-button-border-color-hover: var(--dangerous-button-border-color);
 
     --floating-panel-text-color: inherit;
     --floating-panel-border-color: #000;
-    --floating-panel-background-color: #5a2f71;
+    --floating-panel-background: #5a2f71;
 
-    --bubble-background-color: rgba(0, 0, 0, 0.7);
+    --bubble-background: rgba(0, 0, 0, 0.7);
     --bubble-text-color: #fff;
 
-    --palette-background-color: #5a2f71cc;
+    --palette-background: #5a2f71cc;
     --palette-item-border-color: #000;
-    --palette-overlay-background-color: #5a2f71ee;
+    --palette-overlay-background: #5a2f71ee;
     --palette-overlay-text-color: inherit;
     --palette-deselect-button-color: #fff;
 
@@ -41,7 +41,7 @@ html {
     --undo-border-color: #000;
 
     --input-text-color: #ccc;
-    --input-background-color: #2d0c39;
+    --input-background: #2d0c39;
     --input-border-color: #16061c;
 
     --text-blue-color:#1ea1bb;
@@ -59,7 +59,7 @@ html {
     --ping-counter-color: #ffa500;
     --notification-expiry-color: var(--text-orange-color);
       
-    --panel-background-color: #3d204d;
+    --panel-background: #3d204d;
     --panel-text-color: inherit;
     --panel-border-color: #000;
     --panel-header-text-color: inherit;
@@ -70,7 +70,7 @@ html {
     --panel-close-button-color-hover: var(--panel-close-button-color);
     --panel-close-button-color-active: var(--panel-close-button-color);
 
-    --panel-article-background-color: #5a2f71;
+    --panel-article-background: #5a2f71;
     --panel-article-text-color: var(--panel-text-color);
     --panel-article-border-color: var(--panel-border-color);
     --panel-article-header-text-color: inherit;
@@ -81,32 +81,32 @@ html {
     --panel-trigger-outline-color: #AAA;
 
     --option-bubble-position-border-color-hovered: #797979;
-    --option-bubble-position-background-color-hovered: #683683;
-    --option-bubble-position-background-color-selected: #8445a7;
+    --option-bubble-position-background-hovered: #683683;
+    --option-bubble-position-background-selected: #8445a7;
 
     --chat-separator-color: #000;
-    --chat-odd-background-color: rgba(0, 0, 0, 0.1);
+    --chat-odd-background: rgba(0, 0, 0, 0.1);
     --chat-abbr-underline-color: var(--general-text-color);
-    --chat-badge-background-color: #ccc;
+    --chat-badge-background: #ccc;
     --chat-badge-text-color: #770;
     --chat-server-action-text-color: var(--text-muted-color);
     --chat-user-text-shadow-color: #555;
     --chat-purged-text-color: var(--text-muted-color);
     
     --chat-tobottom-text-color: #fff;
-    --chat-tobottom-background-color: #683683;
+    --chat-tobottom-background: #683683;
     --chat-tobottom-text-color-hover: var(--chat-tobottom-text-color);
-    --chat-tobottom-background-color-hover: #8445a7;
+    --chat-tobottom-background-hover: #8445a7;
 
-    --chat-typeahead-menu-background-color: var(--panel-article-background-color);
+    --chat-typeahead-menu-background: var(--panel-article-background);
     --chat-typeahead-item-text-color: inherit;
-    --chat-typeahead-item-background-color: #5a2f71;
-    --chat-typeahead-item-background-color-hover: #683683;
-    --chat-typeahead-item-background-color-active: #8445a7;
+    --chat-typeahead-item-background: #5a2f71;
+    --chat-typeahead-item-background-hover: #683683;
+    --chat-typeahead-item-background-active: #8445a7;
 
     --emoji-picker-border-color: var(--floating-panel-border-color);
     --emoji-picker-shadow-color: #0009;
-    --emoji-picker-background-color: var(--floating-panel-background-color);
+    --emoji-picker-background: var(--floating-panel-background);
     --emoji-picker-preview-name-text-color: var(--text-muted-color);
     --emoji-picker-tab-icon-color: inherit;
     --emoji-picker-tab-icon-color-selected: #ae5cdb;
@@ -115,12 +115,12 @@ html {
     --emoji-picker-emoji-background: transparent;
     --emoji-picker-emoji-background-hover: rgba(0, 0, 0, 0.1);
     --emoji-picker-emoji-search-input-border-color: var(--input-border-color);
-    --emoji-picker-emoji-search-input-background-color: var(--input-background-color);
+    --emoji-picker-emoji-search-input-background: var(--input-background);
     --emoji-picker-emoji-search-input-text-color: var(--input-text-color);
     --emoji-picker-search-icon-color: var(--text-muted-color);
     --emoji-picker-search-no-results-color: var(--text-muted-color);
     --emoji-picker-variant-overlay-background: rgba(0, 0, 0, 0.7);
-    --emoji-picker-variant-popup-background: var(--floating-panel-background-color);
+    --emoji-picker-variant-popup-background: var(--floating-panel-background);
     --emoji-picker-variant-close-button-color: var(--text-red-color);
 }
 
@@ -135,16 +135,16 @@ hr {
 
 @keyframes -scrolled-flash {
     from {
-        background-color: #860d82;
+        background: #860d82;
     }
     to {
-        background-color: #8ef7d1;
+        background: #8ef7d1;
     }
 }
 
 /* The purple looks a bit ridiculous on the bubble background */
 .admin input {
-    background-color: #fff;
+    background: #fff;
     border-color: #ccc;
     color: #000;
 }


### PR DESCRIPTION
This touches basically everything with the goal of reducing the amount of unique code used for UI components.

At the same time, I couldn't help myself from cleaning up some somewhat unrelated things so there's some miscellaneous changes and fixes thrown in because that's *definitely how this is supposed to work 🙃*.

The overall gist of the reduction in UI components is that before there were 8 identifiable components: 
- Side Panels
- UI Bubbles
- Panel Articles/Sections
- Lookup Dialog
- System messages
- Modal Dialogs
- Notifications
- Popups

With special cases arising for moderation tools such as user lookups, the mod sidepanel, and chatban history.

This PR reduces this to just 4 core components:
- UI Bubbles (which now includes the mod sidepanel)
- Panels (side panels, modal dialogs, and popups)
- Panel Articles/Sections (which are used by notifications and chatban history)
- Floating Panels (lookups and system messages)

Perhaps the most significant other changes are those made to buttons. The summary of this is that anything a user is expected to click on to perform an action is now a button. This is mostly just an HTML semantics things which isn't even all that related to CSS but resolving it at the same time resulted in more consistent button styling methods for traditional text-buttons.

Hopefully this can be merged without too much change, but I wouldn't be surprised to be told "go back and break it into more appropriate pieces".