### PR TITLE
Implement option to layer template behind heatmap

### DIFF
--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -286,6 +286,9 @@
                         <label><input id="showCursorToggle" type="checkbox"/>Show Cursor</label>
                     </div>
                     <div class="d-block">
+                        <label><input id="templateBeneathHeatmapToggle" type="checkbox"/>Layer Template Underneath Heatmap</label>
+                    </div>
+                    <div class="d-block">
                         <label><input id="cbEnableMiddleMouseSelect" type="checkbox"> Enable middle mouse button selecting color from board</label>
                     </div>
                     <div class="d-block">

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -1123,6 +1123,14 @@ window.App = (function() {
         $('#snapshotImageFormat').on('change input', event => {
           ls.set('snapshotImageFormat', event.target.value);
         });
+
+        const templateBeneathHeatmap = ls.get('templateBeneathHeatmap') === true;
+        $('#templateBeneathHeatmapToggle').prop('checked', templateBeneathHeatmap);
+        self.elements.container.toggleClass('lower-template', templateBeneathHeatmap);
+        $('#templateBeneathHeatmapToggle').on('change input', event => {
+          ls.set('templateBeneathHeatmap', event.target.checked);
+          self.elements.container.toggleClass('lower-template', event.target.checked);
+        });
       },
       start: function() {
         $.get('/info', (data) => {

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -914,6 +914,9 @@ input[type="text"], input[type="number"], textarea, select {
     top: 0;
     left: 0;
     margin: 0;
+}
+
+#board-container:not(.lower-template) #board-template {
     z-index: 3;
 }
 


### PR DESCRIPTION
This also layers it behind the virgin map or any other canvas overlay.

The board init seemed more appropriate than then template init since this option isn't carried in the URL like all other options in the template init.