### PR TITLE
Add purple theme

### DIFF
--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -2871,6 +2871,11 @@ window.App = (function() {
           name: 'Darker',
           location: '/themes/darker.css',
           color: '#000'
+        },
+        {
+          name: 'Purple',
+          location: '/themes/purple.css',
+          color: '#5a2f71'
         }
       ],
       specialChatColorClasses: ['rainbow'],

--- a/resources/public/themes/purple.css
+++ b/resources/public/themes/purple.css
@@ -143,6 +143,15 @@ hr {
     border-top: 1px solid #919191aa;
 }
 
+@keyframes -scrolled-flash {
+    from {
+        background-color: #860d82;
+    }
+    to {
+        background-color: #8ef7d1;
+    }
+}
+
 /* The purple looks a bit ridiculous on the bubble background */
 .admin input {
     background-color: #fff;

--- a/resources/public/themes/purple.css
+++ b/resources/public/themes/purple.css
@@ -1,0 +1,151 @@
+html {
+    --general-text-color: #ddd;
+    --general-background-color: #111;
+
+    --kbd-background-color: #eee;
+    --kbd-border-color: #ddd;
+    --kbd-text-color: #000;
+
+    --message-background-color: #5a2f71;
+    --message-text-color: inherit;
+
+    --button-background-color: #f8f9fa;
+    --button-border-color: #f8f9fa;
+    --button-text-color: #212529;
+    --button-text-color-disabled: var(--button-text-color);
+    --button-border-color-disabled: var(--button-border-color);
+    --button-background-color-disabled: var(--button-background-color);
+    --button-text-color-hover: var(--button-text-color);
+    --button-border-color-hover: #dae0e5;
+    --button-background-color-hover: #e2e6ea;
+
+    --report-button-text-color: #fff;
+    --report-button-background-color: #ff5959;
+    --report-button-background-color-hover: #f33;
+    --report-button-border-color: #ff5959;
+
+    --lookup-text-color: inherit;
+    --lookup-border-color: #000;
+    --lookup-background-color: var(--message-background-color);
+
+    --bubble-background-color: rgba(0, 0, 0, 0.7);
+    --bubble-text-color: #fff;
+
+    --palette-background-color: #5a2f71cc;
+    --palette-item-border-color: #000;
+    --palette-overlay-background-color: #5a2f71ee;
+    --palette-overlay-text-color: inherit;
+    --palette-deselect-button-color: #fff;
+
+    --undo-text-color: #fff;
+    --undo-background: linear-gradient(to top, #5a2f71cc, #5a2f71);
+    --undo-border-color: #000;
+
+    --input-text-color: #ccc;
+    --input-background-color: #2d0c39;
+    --input-border-color: #16061c;
+
+    --text-blue-color:#1ea1bb;
+    --text-green-color:#34bd53;
+    --text-red-color:#ff2626;
+    --text-muted-color:#999;
+    --text-yellow-color:#fffb07;
+    --text-orange-color:#ff8707;
+
+    --copypulse-color: rgba(0, 211, 221, 0.7);
+    --error-color: #cc3333;
+    --notification-color: #b20;
+    --ping-highlight-color: #860d82;
+    --ping-flash-color: #8ef7d1;
+      
+    --panel-header-background: #320241;
+    --panel-background-color: #3d204d;
+    --panel-text-color: inherit;
+    --panel-borders-color: #000;
+    --panel-article-background-color: #5a2f71;
+
+    --panel-trigger-outline-color: #AAA;
+
+    --option-bubble-position-border-color-hovered: #797979;
+    --option-bubble-position-background-color-hovered: #683683;
+    --option-bubble-position-background-color-selected: #8445a7;
+
+    --chat-separator-color: #000;
+    --chat-odd-background-color: rgba(0, 0, 0, 0.1);
+    --chat-abbr-underline-color: var(--general-text-color);
+    --chat-badge-background-color: #ccc;
+    --chat-badge-text-color: #770;
+    --chat-server-action-text-color: var(--text-muted-color);
+    --chat-user-text-shadow-color: #555;
+    --chat-purged-text-color: var(--text-muted-color);
+
+    --chat-typeahead-menu-background-color: var(--panel-article-background-color);
+    --chat-typeahead-item-text-color: inherit;
+    --chat-typeahead-item-background-color: #5a2f71;
+    --chat-typeahead-item-background-color-hover: #683683;
+    --chat-typeahead-item-background-color-active: #8445a7;
+
+    --mod-lookup-chatban-history-item-background-color: var(--panel-article-background-color);
+    --mod-lookup-chatban-history-item-border-color: var(--panel-borders-color);
+    --mod-lookup-chatban-history-item-heading-background-color: var(--panel-header-background);
+
+    --popup-background-color: var(--panel-background-color);
+    --popup-border-color: var(--panel-borders-color);
+    --popup-text-color: var(--panel-text-color);
+    --popup-timestamp-text-color: var(--text-muted-color);
+    --pane-button-background: #683683;
+    --pane-button-background-hover: #8445a7;
+
+    --notification-background-color: var(--panel-article-background-color);
+    --notification-border-color: var(--panel-borders-color);
+    --notification-title-text-color: inherit;
+    --notification-title-background-color: var(--panel-header-background);
+    --notification-footer-background-color: var(--panel-header-background);
+    --notification-footer-text-color: var(--text-muted-color);
+    --notification-expiry-color: var(--text-orange-color);
+
+    --modal-text-color: inherit;
+    --modal-background-color: var(--panel-background-color);
+    --modal-headfoot-background-color: var(--panel-header-background);
+
+    --emoji-picker-border-color: var(--lookup-border-color);
+    --emoji-picker-shadow-color: #0009;
+    --emoji-picker-background-color: var(--lookup-background-color);
+    --emoji-picker-preview-name-text-color: var(--text-muted-color);
+    --emoji-picker-tab-icon-color: inherit;
+    --emoji-picker-tab-icon-color-selected: #ae5cdb;
+    --emoji-picker-section-text-color: var(--general-text-color);
+    --emoji-picker-emoji-color: var(--general-text-color);
+    --emoji-picker-emoji-background: transparent;
+    --emoji-picker-emoji-background-hover: rgba(0, 0, 0, 0.1);
+    --emoji-picker-emoji-search-input-border-color: var(--input-border-color);
+    --emoji-picker-emoji-search-input-background-color: var(--input-background-color);
+    --emoji-picker-emoji-search-input-text-color: var(--input-text-color);
+    --emoji-picker-search-icon-color: var(--text-muted-color);
+    --emoji-picker-search-no-results-color: var(--text-muted-color);
+    --emoji-picker-variant-overlay-background: rgba(0, 0, 0, 0.7);
+    --emoji-picker-variant-popup-background: var(--lookup-background-color);
+    --emoji-picker-variant-close-button-color: var(--text-red-color);
+
+    --admin-background: var(--bubble-background-color);
+    --admin-text-color: var(--bubble-text-color);
+    --admin-check-border-color: var(--lookup-border-color);
+    --admin-check-text-color: inherit;
+    --admin-check-background-color: var(--lookup-background-color);
+}
+
+.button:disabled {
+    opacity: .65;
+}
+
+hr {
+    border: none;
+    border-top: 1px solid #919191aa;
+}
+
+/* The purple looks a bit ridiculous on the bubble background */
+.admin input {
+    background-color: #fff;
+    border-color: #ccc;
+    color: #000;
+}


### PR DESCRIPTION
This adds a new theme in the same style as the stats page and profile pages.

This is more or less what it looks like:
![main-ui](https://user-images.githubusercontent.com/64389261/81314634-43bf1a80-9081-11ea-98d5-7ba4e33be08c.png)
![info](https://user-images.githubusercontent.com/64389261/81314576-2f7b1d80-9081-11ea-89b5-584c6ca782ad.png)
![settings](https://user-images.githubusercontent.com/64389261/81314614-3c980c80-9081-11ea-908a-3b30ad5260c8.png)
("Update" button is hovered in the above screenshot)
![chat](https://user-images.githubusercontent.com/64389261/81314672-5174a000-9081-11ea-82be-4b7d621faf3f.png)
![chat-popup](https://user-images.githubusercontent.com/64389261/81314686-546f9080-9081-11ea-9c33-d448ec978e06.png)
![chat-settings](https://user-images.githubusercontent.com/64389261/81314699-56d1ea80-9081-11ea-8fa0-0adc11928e2a.png)
![emoji](https://user-images.githubusercontent.com/64389261/81314726-5d606200-9081-11ea-8a1e-aa8ab1c72fa3.png)
![emoji-variant](https://user-images.githubusercontent.com/64389261/81314732-5e918f00-9081-11ea-89c5-d5ab82c17a96.png)
![notification](https://user-images.githubusercontent.com/64389261/81314743-618c7f80-9081-11ea-8191-e51694ce23b4.png)
![signup](https://user-images.githubusercontent.com/64389261/81314750-63564300-9081-11ea-9b76-1451b1d7deed.png)
![chat-lookup](https://user-images.githubusercontent.com/64389261/81314777-694c2400-9081-11ea-9ba8-520c9de9c63a.png)

Hopefully all those screenshots are more helpful than they are obnoxiously large.