### PR TITLE
Fix internal jump anchor

### DIFF
--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -4850,7 +4850,7 @@ window.App = (function() {
             if (isNaN(group1) || isNaN(group2)) return match;
             if (!board.validateCoordinates(parseFloat(group1), parseFloat(group2))) return match;
             const group3Str = !(parseFloat(group3)) ? '' : `, ${group3}x`;
-            return `<a class="link -internal-jump" data-x="${group1}" data-y="${group2}" data-scale="${group3}">(${group1}, ${group2}${group3Str})</a>`;
+            return `<a class="link -internal-jump" href="#x=${group1}&y=${group2}&scale=${!(parseFloat(group3)) ? 1 : group3}" data-x="${group1}" data-y="${group2}" data-scale="${group3}">(${group1}, ${group2}${group3Str})</a>`;
           });
 
           // insert <a>'s

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -4850,7 +4850,7 @@ window.App = (function() {
             if (isNaN(group1) || isNaN(group2)) return match;
             if (!board.validateCoordinates(parseFloat(group1), parseFloat(group2))) return match;
             const group3Str = !(parseFloat(group3)) ? '' : `, ${group3}x`;
-            return `<span class="link -internal-jump" data-x="${group1}" data-y="${group2}" data-scale="${group3}">(${group1}, ${group2}${group3Str})</span>`;
+            return `<a class="link -internal-jump" data-x="${group1}" data-y="${group2}" data-scale="${group3}">(${group1}, ${group2}${group3Str})</a>`;
           });
 
           // insert <a>'s


### PR DESCRIPTION
This allows browser functions such as middle-mouse open in new tab and link previews to work on such generated links. It's also good for semantics since these do actually target the url.