### PR TITLE
Add icons and change spacing to #main-bubble

### DIFF
--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -83,20 +83,26 @@
         </div>
         <div id="main-bubble" class="bubble">
             <div id="user-info">
+                <i class="fas fa-user"></i>
                 <!-- TODO: link to position on stats page -->
                 <span id="username"></span>
-                <a href="/logout" class="logout"><i class="fas fa-sign-out-alt" id="logout-icon"></i></a>
-                <br>
+                <a href="/logout" class="logout"><i title="Logout" class="fas fa-sign-out-alt" id="logout-icon"></i></a>
             </div>
-            <span id="online-count">Waiting for online count...</span>
-            <br><br>
+            <div>
+              <i class="fas fa-users"></i>
+              <span id="online-count">Loading online user count&hellip;</span>
+            </div>
             <div id="coords-info">
                 <a class="coords"></a>
                 <i id="canvas-lock-icon" class="fas fa-lock"></i>
             </div>
             <div id="placement-info">
-                <span>Pixels available: </span><span id="placeable-count">N/A</span> <i class="fas fa-spinner fa-spin captcha-loading-icon"></i>
-                <br>
+                <span id="placeable-count">N/A</span>
+                <span>Pixels</span>
+                <i class="fas fa-spinner fa-spin captcha-loading-icon"></i>
+            </div>
+            <div id="cooldown">
+                <i class="far fa-clock"></i>
                 <span id="cooldown-timer"></span>
             </div>
         </div>

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -5791,7 +5791,8 @@ window.App = (function() {
       elements: {
         palette: $('#palette'),
         timer_overlay: $('#cd-timer-overlay'),
-        timer_bubble: $('#cooldown-timer'),
+        timer_bubble_container: $('#cooldown'),
+        timer_bubble_countdown: $('#cooldown-timer'),
         timer_chat: $('#txtMobileChatCooldown')
       },
       isOverlay: false,
@@ -5809,12 +5810,13 @@ window.App = (function() {
 
         if (self.runningTimer === false) {
           self.isOverlay = ls.get('autoReset') === true;
-          self.elements.timer = self.isOverlay ? self.elements.timer_overlay : self.elements.timer_bubble;
+          self.elements.timer_container = self.isOverlay ? self.elements.timer_overlay : self.elements.timer_bubble_container;
+          self.elements.timer_countdown = self.isOverlay ? self.elements.timer_overlay : self.elements.timer_bubble_countdown;
           self.elements.timer_overlay.hide();
         }
 
         if (self.status) {
-          self.elements.timer.text(self.status);
+          self.elements.timer_countdown.text(self.status);
         }
 
         const alertDelay = parseInt(ls.get('alert_delay'));
@@ -5834,17 +5836,17 @@ window.App = (function() {
         }
 
         if (delta > 0) {
-          self.elements.timer.show();
+          self.elements.timer_container.show();
           if (self.isOverlay) {
             self.elements.palette.css('overflow-x', 'hidden');
-            self.elements.timer.css('left', `${self.elements.palette.scrollLeft()}px`);
+            self.elements.timer_container.css('left', `${self.elements.palette.scrollLeft()}px`);
           }
           delta++; // real people don't count seconds zero-based (programming is more awesome)
           const secs = Math.floor(delta % 60);
           const secsStr = secs < 10 ? '0' + secs : secs;
           const minutes = Math.floor(delta / 60);
           const minuteStr = minutes < 10 ? '0' + minutes : minutes;
-          self.elements.timer.text(`${minuteStr}:${secsStr}`);
+          self.elements.timer_countdown.text(`${minuteStr}:${secsStr}`);
           self.elements.timer_chat.text(`(${minuteStr}:${secsStr})`);
 
           document.title = uiHelper.getTitle(`[${minuteStr}:${secsStr}]`);
@@ -5864,9 +5866,9 @@ window.App = (function() {
         document.title = uiHelper.getTitle();
         if (self.isOverlay) {
           self.elements.palette.css('overflow-x', 'auto');
-          self.elements.timer.css('left', '0');
+          self.elements.timer_container.css('left', '0');
         }
-        self.elements.timer.hide();
+        self.elements.timer_container.hide();
         self.elements.timer_chat.text('');
 
         if (alertDelay > 0) {
@@ -5898,10 +5900,10 @@ window.App = (function() {
       },
       init: function() {
         self.title = document.title;
-        self.elements.timer = ls.get('autoReset') === true
+        self.elements.timer_container = ls.get('autoReset') === true
           ? self.elements.timer_overlay
-          : self.elements.timer_bubble;
-        self.elements.timer.hide();
+          : self.elements.timer_bubble_container;
+        self.elements.timer_container.hide();
         self.elements.timer_chat.text('');
 
         setTimeout(function() {

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -610,6 +610,16 @@ button.button.dark:disabled {
     pointer-events: auto;
 }
 
+#main-bubble .fas {
+    width: 1.25em;
+    text-align: center;
+}
+
+#coords-info {
+    margin-top: 16px;
+    margin-bottom: 8px;
+}
+
 #ui-bottom {
     z-index: 6;
     width: 100%;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/64389261/81474177-886ec100-91fb-11ea-8098-37190615f825.png)
![image](https://user-images.githubusercontent.com/64389261/81474226-d1bf1080-91fb-11ea-876c-614e33548df5.png)
The most questionable change here is probably the changing of the `Pixels available: X` text to just `X Pixels`. While the original is very clear it also borders on cumbersome and overly verbose. On the other hand, it also leaves the useful information on the right which is closer to the board if the bubble is in the original left-side position.

I wanted to do more in this PR but was unable to come up with a good design that factored in the adaptive size of the username.