### PR TITLE
Refactor settings

### DIFF
--- a/developer.md
+++ b/developer.md
@@ -61,6 +61,23 @@ App.ls.remove('blah');
 App.ls.get('blah'); // undefined
 ```
 
+## Settings
+
+It is possible to change settings using the settings object in a program-friendly way.
+Using the following functions will cause the changes to be reflected internally as well as update settings controls to reflect new values.
+
+```js
+App.settings.board.heatmap.enable.set(true); // enable the heatmap
+App.settings.ui.cursor.enable.toggle(); // enable/disable the cursor
+App.settings.board.zoom.sensitivity.set(2); // set the zoom sensitivity
+App.settings.audio.alert.volume.get(); // returns the current alert volume
+```
+
+The various settings keys can be found in-code or through a browser auto-complete if needed.
+They will generally be named like this: `component.feature.subfeature.setting`.
+
+Also note that the `.toggle()` function is only available for boolean settings (usually those ending in `.enable`).
+
 ## Lookup Hooks
 
 Hooks are objects that provide extra functionality for lookups.

--- a/resources/public/admin/admin.js
+++ b/resources/public/admin/admin.js
@@ -366,14 +366,6 @@
             $.map(
               [
                 {
-                  text: 'Disable hand reset',
-                  onChange: function () {
-                    admin.place.setAutoReset(!this.checked);
-                  },
-                  checkState: false,
-                  disabled: false
-                },
-                {
                   text: 'Override cooldown',
                   onChange: function () {
                     admin.socket.send({ type: 'admin_cdoverride', override: this.checked });

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -336,7 +336,7 @@
                     <p><label class="text-orange fake-indent"><i class="fas fa-exclamation-triangle"></i> Warning: Known to cause fuzziness in Chrome on some Mac/Linux installs</label></p>
                     <p><label class="fake-indent">Color Brightness: <input type="range" min="0" max="1" step="0.01" value="1" id="setting-ui-brightness-value"></label></p>
                 </div>
-                <label id="chrome-canvas-offset-setting"><input id="chrome-canvas-offset-toggle" type="checkbox"/>Attempt to fix Canvas displacement bug in Chrome 78+</label>
+                <label id="chrome-canvas-offset-setting"><input id="setting-fix-chrome-offset-enable" type="checkbox"/>Attempt to fix Canvas displacement bug in Chrome 78+</label>
             </div>
         </article>
         <article>

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -386,7 +386,7 @@
                     <input type="range" id="rangeAlertVolume" min=0 max=1 step=".01" value=1>
                     <span id="lblAlertVolume"></span>
                 </div>
-                <label style="display: block;">Delay (Seconds): <input type="text" width="30px" value="0" id="alertDelay"></label>
+                <label style="display: block;">Delay (Seconds): <input type="number" width="30px" value="0" id="alertDelay"></label>
             </div>
         </article>
         <article>

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -232,75 +232,75 @@
                 <div class="settingToggles">
                     <div class="lblwrap">
                         <label>Theme:
-                            <select id="themeSelect">
+                            <select id="setting-ui-theme-index">
                                 <option value="-1" selected>Default</option>
                             </select>
                         </label>
                     </div>
                     <div>
-                        <label><input id="audiotoggle" type="checkbox"/>Mute sound</label>
+                        <label><input id="setting-audio-enable" type="checkbox"/>Enable sound</label>
                     </div>
                     <div>
-                        <label><input id="heatmaptoggle" type="checkbox"/>Turn on heatmap (toggle with <kbd>H</kbd>)</label>
+                        <label><input id="setting-board-heatmap-enable" type="checkbox"/>Turn on heatmap (toggle with <kbd>H</kbd>)</label>
                     </div>
                     <div>
-                        <label><input id="virginmaptoggle" type="checkbox"/>Turn on virginmap (toggle with <kbd>X</kbd>)</label>
+                        <label><input id="setting-board-virginmap-enable" type="checkbox"/>Turn on virginmap (toggle with <kbd>X</kbd>)</label>
                     </div>
                     <div>
                         <button class="text-button" id="hvmapClear">Clear heatmap and virginmap</button> (hotkey: <kbd>O</kbd>)
                     </div>
                     <div>
-                        <label><input id="gridtoggle" type="checkbox"/>Turn on grid (toggle with <kbd>G</kbd>)</label>
+                        <label><input id="setting-board-grid-enable" type="checkbox"/>Turn on grid (toggle with <kbd>G</kbd>)</label>
                     </div>
                     <div>
-                        <label><input type="checkbox" id="lockCanvasToggle">Lock the canvas (disallow canvas drag/zoom with mouse/fingers)</label>
+                        <label><input type="checkbox" id="setting-board-lock-enable">Lock the canvas (disallow canvas drag/zoom with mouse/fingers)</label>
                     </div>
                     <div>
-                        <label><input id="native-notification-toggle" type="checkbox"/>Enable pixel available notification</label>
+                        <label><input id="setting-place-notification-enable" type="checkbox"/>Enable pixel available notification</label>
                     </div>
                     <div>
-                        <label><input id="stickyColorToggle" type="checkbox"/>Keep color selected</label>
+                        <label><input id="setting-place-deselectonplace-enable" type="checkbox"/>Deselect color after placing</label>
                     </div>
                     <div>
-                        <label><input id="monospaceToggle" type="checkbox"/>Toggle monospace font for lookups</label>
+                        <label><input id="setting-lookup-monospace-enable" type="checkbox"/>Toggle monospace font for lookups</label>
                     </div>
                     <div class="d-block">
-                      <label>Zoom Sensitivity: <input id="zoomBaseValue" type="range" min="1.01" max="3" step="0.01"/></label>
+                      <label>Zoom Sensitivity: <input id="setting-board-zoom-sensitivity" type="range" min="1.01" max="3" step="0.01"/></label>
                     </div>
                     <div class="d-block">
-                        <label><input id="increasedZoomToggle" type="checkbox"/>Allow zoom values greater than 50x</label>
+                        <label><input id="setting-board-zoom-limit-enable" type="checkbox"/>Limit zoom to 50x</label>
                     </div>
                     <div>
-                        <label><input id="scrollSwitchToggle" type="checkbox"/>Enable scrolling on the palette to switch colors</label>
+                        <label><input id="setting-place-palette-scrolling-enable" type="checkbox"/>Enable scrolling on the palette to switch colors</label>
                     </div>
                     <div>
-                        <label style="text-indent:1em"><input id="scrollDirectionToggle" type="checkbox"/>Invert scroll direction</label>
+                        <label style="text-indent:1em"><input id="setting-place-palette-scrolling-invert" type="checkbox"/>Invert scroll direction</label>
                     </div>
                     <div>
-                        <label><input id="showReticuleToggle" type="checkbox"/>Show Reticule</label>
+                        <label><input id="setting-ui-reticule-enable" type="checkbox"/>Show Reticule</label>
                     </div>
                     <div>
-                        <label><input id="showCursorToggle" type="checkbox"/>Show Cursor</label>
+                        <label><input id="setting-ui-cursor-enable" type="checkbox"/>Show Cursor</label>
                     </div>
                     <div>
-                        <label><input id="templateBeneathHeatmapToggle" type="checkbox"/>Layer Template Underneath Heatmap</label>
+                        <label><input id="setting-board-template-beneathoverlays" type="checkbox"/>Layer Template Underneath Heatmap</label>
                     </div>
                     <div>
-                        <label><input id="cbEnableMiddleMouseSelect" type="checkbox"> Enable middle mouse button selecting color from board</label>
+                        <label><input id="setting-place-picker-enable" type="checkbox">Enable middle mouse button selecting color from board</label>
                     </div>
                     <div>
-                        <label><input id="cbNumberedPalette" type="checkbox"> Add numbers to palette entries</label>
+                        <label><input id="setting-ui-palette-numbers-enable" type="checkbox"> Add numbers to palette entries</label>
                     </div>
                     <div>
-                        <label>Heatmap Background Opacity: <input type="range" min="0" max="1" step="0.01" id="heatmap-opacity"></label>
+                        <label>Heatmap Background Opacity: <input type="range" min="0" max="1" step="0.01" id="setting-board-heatmap-opacity"></label>
                     </div>
                     <div>
-                        <label>Virginmap Background Opacity: <input type="range" min="0" max="1" step="0.01" id="virginmap-opacity"></label>
+                        <label>Virginmap Background Opacity: <input type="range" min="0" max="1" step="0.01" id="setting-board-virginmap-opacity"></label>
                     </div>
                     <div>
                         <label>
                             Snapshot (hotkey: <kbd>P</kbd>) image format
-                            <select id="snapshotImageFormat">
+                            <select id="setting-board-snapshot-format">
                                 <option value="image/png" selected>PNG</option>
                                 <option value="image/jpeg">JPEG</option>
                                 <option value="image/webp">WEBP (Chrome only)</option>
@@ -311,19 +311,19 @@
                         Bubble position
                         <div id="bubble-position">
                             <label>
-                                <input type="radio" name="bubble-position" value="top left" />
+                                <input type="radio" name="setting-ui-bubble-position" value="top left" />
                                 <div></div>
                             </label>
                             <label>
-                                <input type="radio" name="bubble-position" value="top right" />
+                                <input type="radio" name="setting-ui-bubble-position" value="top right" />
                                 <div></div>
                             </label>
                             <label>
-                                <input type="radio" name="bubble-position" value="bottom left" />
+                                <input type="radio" name="setting-ui-bubble-position" value="bottom left" />
                                 <div></div>
                             </label>
                             <label>
-                                <input type="radio" name="bubble-position" value="bottom right" />
+                                <input type="radio" name="setting-ui-bubble-position" value="bottom right" />
                                 <div></div>
                             </label>
                         </div>
@@ -332,9 +332,9 @@
 
                 </div>
                 <div>
-                    <p><label class="vertical-spacing"><input type="checkbox" id="color-brightness-toggle"> Enable Color Brightness</label></p>
+                    <p><label class="vertical-spacing"><input type="checkbox" id="setting-ui-brightness-enable"> Enable Color Brightness</label></p>
                     <p><label class="text-orange fake-indent"><i class="fas fa-exclamation-triangle"></i> Warning: Known to cause fuzziness in Chrome on some Mac/Linux installs</label></p>
-                    <p><label class="fake-indent">Color Brightness: <input type="range" min="0" max="1" step="0.01" value="1" id="color-brightness"></label></p>
+                    <p><label class="fake-indent">Color Brightness: <input type="range" min="0" max="1" step="0.01" value="1" id="setting-ui-brightness-value"></label></p>
                 </div>
                 <label id="chrome-canvas-offset-setting"><input id="chrome-canvas-offset-toggle" type="checkbox"/>Attempt to fix Canvas displacement bug in Chrome 78+</label>
             </div>
@@ -375,18 +375,18 @@
                 <h2>Pixel Ready Alert Settings</h2>
             </header>
             <div class="pad-wrapper">
-                <p><label for="txtAlertLocation">Alert URL:</label><input class="fullwidth" type="text" placeholder="notify.wav" id="txtAlertLocation"></p>
+                <p><label for="setting-audio-alert-src">Alert URL:</label><input class="fullwidth" type="text" placeholder="notify.wav" id="setting-audio-alert-src"></p>
                 <div class="button-bar">
                     <button class="text-button" id="btnForceAudioUpdate">Update</button>
                     <button class="text-button" id="btnAlertAudioTest">Test</button>
                     <button class="text-button" id="btnAlertReset">Reset</button>
                 </div>
                 <div>
-                    <label for="rangeAlertVolume">Volume:</label>
-                    <input type="range" id="rangeAlertVolume" min=0 max=1 step=".01" value=1>
+                    <label for="setting-audio-alert-volume">Volume:</label>
+                    <input type="range" id="setting-audio-alert-volume" min=0 max=1 step=".01" value=1>
                     <span id="lblAlertVolume"></span>
                 </div>
-                <label style="display: block;">Delay (Seconds): <input type="number" width="30px" value="0" id="alertDelay"></label>
+                <label style="display: block;">Delay (Seconds): <input type="number" width="30px" value="0" id="setting-place-alert-delay"></label>
             </div>
         </article>
         <article>

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -539,7 +539,7 @@ window.App = (function() {
     };
 
     // these are the settings which have gone from being toggle-off to toggle-on
-    const flippedmappings = ['audio_muted', 'increased_zoom', 'autoReset'];
+    const flippedmappings = ['audio_muted', 'increased_zoom', 'autoReset', 'canvas.unlocked'];
 
     // Convert old settings keys to new keys.
     Object.entries(keymappings).forEach((entry) => {

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -543,9 +543,7 @@ window.App = (function() {
 
     // Convert old settings keys to new keys.
     Object.entries(keymappings).forEach((entry) => {
-      // This is the best we can do to check existance without reacing into localStorage ourselves.
-      // If there we were a ls.has function, that should be used here.
-      if (ls.get(entry[0]) !== null) {
+      if (ls.has(entry[0])) {
         const oldvalue = ls.get(entry[0]);
         ls.set(entry[1], flippedmappings.indexOf(entry[0]) === -1 ? oldvalue : !oldvalue);
         ls.remove(entry[0]);

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -474,35 +474,135 @@ window.App = (function() {
 
     const possiblyMobile = window.innerWidth < 768 && nua.includes('Mobile');
 
+    const keymappings = {
+      currentTheme: 'ui.theme.index',
+      audio_muted: 'audio.enable',
+      heatmap: 'board.heatmap.enable',
+      virgimap: 'board.virginmap.enable',
+      view_grid: 'board.grid.enable',
+      'canvas.unlocked': 'board.lock.enable',
+      'nativenotifications.pixel-avail': 'place.notification.enable',
+      autoReset: 'place.deselectonplace.enable',
+      monospace_lookup: 'lookup.monospace.enable',
+      zoomBaseValue: 'board.zoom.sensitivity',
+      increased_zoom: 'board.zoom.limit.enable',
+      scrollSwitchEnabled: 'place.palette.scrolling.enable',
+      scrollSwitchDirectionInverted: 'place.palette.scrolling.invert',
+      'ui.show-reticule': 'ui.reticule.enable',
+      'ui.show-cursor': 'ui.cursor.enable',
+      templateBeneathHeatmap: 'board.template.beneathoverlays',
+      enableMiddleMouseSelect: 'place.picker.enable',
+      enableNumberedPalette: 'ui.palette.numbers.enable',
+      heatmap_background_opacity: 'board.heatmap.opacity',
+      virginmap_background_opacity: 'board.virginmap.opacity',
+      snapshotImageFormat: 'board.snapshot.format',
+      'bubble-position': 'ui.bubble.position',
+      'brightness.enabled': 'ui.brightness.enable',
+      colorBrightness: 'ui.brightness.value',
+      'alert.src': 'audio.alert.src',
+      'alert.volume': 'audio.alert.volume',
+      alert_delay: 'place.alert.delay'
+    };
+
+    // these are the settings which have gone from being toggle-off to toggle-on
+    const flippedmappings = ['audio_muted', 'increased_zoom', 'autoReset'];
+
+    // Convert old settings keys to new keys.
+    Object.entries(keymappings).forEach((entry) => {
+      // This is the best we can do to check existance without reacing into localStorage ourselves.
+      // If there we were a ls.has function, that should be used here.
+      if (ls.get(entry[0]) !== null) {
+        console.debug(`mapping ${entry[0]} (${ls.get(entry[0])}) to ${entry[1]}`);
+        const oldvalue = ls.get(entry[0]);
+        ls.set(entry[1], entry[0] in flippedmappings ? !oldvalue : oldvalue);
+        ls.remove(entry[0]);
+      }
+    });
+
     return {
-      themeSelect: setting('currentTheme', Type.SELECT, '0', $('#themeSelect')),
-      audiotoggle: setting('audio_muted', Type.TOGGLE, false, $('#audiotoggle')),
-      heatmaptoggle: setting('heatmap', Type.TOGGLE, false, $('#heatmaptoggle')),
-      virginmaptoggle: setting('virgimap', Type.TOGGLE, false, $('#virginmaptoggle')),
-      gridtoggle: setting('view_grid', Type.TOGGLE, false, $('#gridtoggle')),
-      // this actually represents the canvas being locked not unlocked.
-      lockCanvasToggle: setting('canvas.unlocked', Type.TOGGLE, false, $('#lockCanvasToggle')),
-      'native-notification-toggle': setting('nativenotifications.pixel-avail', Type.TOGGLE, true, $('#native-notification-toggle')),
-      stickyColorToggle: setting('autoReset', Type.TOGGLE, false, $('#stickyColorToggle')),
-      monospaceToggle: setting('monospace_lookup', Type.TOGGLE, false, $('#monospaceToggle')),
-      zoomBaseValue: setting('zoomBaseValue', Type.RANGE, 1.5, $('#zoomBaseValue')),
-      increasedZoomToggle: setting('increased_zoom', Type.TOGGLE, false, $('#increasedZoomToggle')),
-      scrollSwitchToggle: setting('scrollSwitchEnabled', Type.TOGGLE, false, $('#scrollSwitchToggle')),
-      scrollDirectionToggle: setting('scrollSwitchDirectionInverted', Type.TOGGLE, false, $('#scrollDirectionToggle')),
-      showReticuleToggle: setting('ui.show-reticule', Type.TOGGLE, possiblyMobile, $('#showReticuleToggle')),
-      showCursorToggle: setting('ui.show-cursor', Type.TOGGLE, possiblyMobile, $('#showCursorToggle')),
-      templateBeneathHeatmapToggle: setting('templateBeneathHeatmap', Type.TOGGLE, false, $('#templateBeneathHeatmapToggle')),
-      cbEnableMiddleMouseSelect: setting('enableMiddleMouseSelect', Type.TOGGLE, true, $('#cbEnableMiddleMouseSelect')),
-      cbNumberedPalette: setting('enableNumberedPalette', Type.TOGGLE, false, $('#cbNumberedPalette')),
-      'heatmap-opacity': setting('heatmap_background_opacity', Type.RANGE, 0.5, $('#heatmap-opacity')),
-      'virginmap-opacity': setting('virginmap_background_opacity', Type.RANGE, 0.5, $('#virginmap-opacity')),
-      snapshotImageFormat: setting('snapshotImageFormat', Type.SELECT, 'image/png', $('#snapshotImageFormat')),
-      'bubble-position': setting('ui.bubble-position', Type.RADIO, 'bottom left', $('[name=bubble-position]')),
-      'color-brightness-toggle': setting('brightness.enabled', Type.TOGGLE, false, $('#color-brightness-toggle')),
-      'color-brightness': setting('colorBrightness', Type.RANGE, 1, $('#color-brightness')),
-      txtAlertLocation: setting('alert.src', Type.TEXT, '', $('#txtAlertLocation')),
-      rangeAlertVolume: setting('alert.volume', Type.RANGE, 1, $('#rangeAlertVolume')),
-      alertDelay: setting('alert_delay', Type.NUMBER, 0, $('#alertDelay'))
+      ui: {
+        theme: {
+          index: setting('ui.theme.index', Type.SELECT, '0', $('#setting-ui-theme-index'))
+        },
+        reticule: {
+          enable: setting('ui.reticule.enable', Type.TOGGLE, possiblyMobile, $('#setting-ui-reticule-enable'))
+        },
+        cursor: {
+          enable: setting('ui.cursor.enable', Type.TOGGLE, possiblyMobile, $('#setting-ui-cursor-enable'))
+        },
+        bubble: {
+          position: setting('ui.bubble.position', Type.RADIO, 'bottom left', $('[name=setting-ui-bubble-position]'))
+        },
+        brightness: {
+          enable: setting('ui.brightness.enable', Type.TOGGLE, false, $('#setting-ui-brightness-enable')),
+          value: setting('ui.brightness.value', Type.RANGE, 1, $('#setting-ui-brightness-value'))
+        },
+        palette: {
+          numbers: {
+            enable: setting('ui.palette.numbers.enable', Type.TOGGLE, false, $('#setting-ui-palette-numbers-enable'))
+          }
+        }
+      },
+      audio: {
+        enable: setting('audio.enable', Type.TOGGLE, true, $('#setting-audio-enable')),
+        alert: {
+          src: setting('audio.alert.src', Type.TEXT, '', $('#setting-audio-alert-src')),
+          volume: setting('audio.alert.volume', Type.RANGE, 1, $('#setting-audio-alert-volume'))
+        }
+      },
+      board: {
+        heatmap: {
+          enable: setting('board.heatmap.enable', Type.TOGGLE, false, $('#setting-board-heatmap-enable')),
+          opacity: setting('board.heatmap.opacity', Type.RANGE, 0.5, $('#setting-board-heatmap-opacity'))
+        },
+        virginmap: {
+          enable: setting('board.virginmap.enable', Type.TOGGLE, false, $('#setting-board-virginmap-enable')),
+          opacity: setting('board.virginmap.opacity', Type.RANGE, 0.5, $('#setting-board-virginmap-opacity'))
+        },
+        grid: {
+          enable: setting('board.grid.enable', Type.TOGGLE, false, $('#setting-board-grid-enable'))
+        },
+        lock: {
+          enable: setting('board.lock.enable', Type.TOGGLE, false, $('#setting-board-lock-enable'))
+        },
+        zoom: {
+          sensitivity: setting('board.zoom.sensitivity', Type.RANGE, 1.5, $('#setting-board-zoom-sensitivity')),
+          limit: {
+            enable: setting('board.zoom.limit.enable', Type.TOGGLE, true, $('#setting-board-zoom-limit-enable'))
+          }
+        },
+        template: {
+          beneathoverlays: setting('board.template.beneathoverlays', Type.TOGGLE, false, $('#setting-board-template-beneathoverlays'))
+        },
+        snapshot: {
+          format: setting('board.snapshot.format', Type.SELECT, 'image/png', $('#setting-board-snapshot-format'))
+        }
+      },
+      place: {
+        notification: {
+          enable: setting('place.notification.enable', Type.TOGGLE, true, $('#setting-place-notification-enable'))
+        },
+        deselectonplace: {
+          enable: setting('place.deselectonplace.enable', Type.TOGGLE, true, $('#setting-place-deselectonplace-enable'))
+        },
+        palette: {
+          scrolling: {
+            enable: setting('place.palette.scrolling.enable', Type.TOGGLE, false, $('#setting-place-palette-scrolling-enable')),
+            invert: setting('place.palette.scrolling.invert', Type.TOGGLE, false, $('#setting-place-palette-scrolling-invert'))
+          }
+        },
+        picker: {
+          enable: setting('place.picker.enable', Type.TOGGLE, true, $('#setting-place-picker-enable'))
+        },
+        alert: {
+          delay: setting('place.alert.delay', Type.NUMBER, 0, $('#setting-place-alert-delay'))
+        }
+      },
+      lookup: {
+        monospace: {
+          enable: setting('lookup.monospace.enable', Type.TOGGLE, false, $('#setting-lookup-monospace-enable'))
+        }
+      }
     };
   })();
   // this object is used to access the query parameters (and in the future probably to set them), it is prefered to use # now instead of ? as JS can change them
@@ -1040,7 +1140,7 @@ window.App = (function() {
             case 76: // L
             case 'l':
             case 'L':
-              settings.lockCanvasToggle.toggle();
+              settings.board.lock.enable.toggle();
               break;
             case 'KeyR':
             case 82: // R
@@ -1246,7 +1346,7 @@ window.App = (function() {
           downDelta = 0;
           if (event.button != null) {
             // Is the button pressed the middle mouse button?
-            if (settings.cbEnableMiddleMouseSelect.get() === true && event.button === 1 && dx < 15 && dy < 15) {
+            if (settings.place.picker.enable.get() === true && event.button === 1 && dx < 15 && dy < 15) {
               // If so, switch to the color at the location.
               const { x, y } = self.fromScreen(event.clientX, event.clientY);
               place.switch(self.getPixel(x, y));
@@ -1306,7 +1406,7 @@ window.App = (function() {
         self.ctx = self.elements.board[0].getContext('2d');
         self.initInteraction();
 
-        settings.templateBeneathHeatmapToggle.change(function(value) {
+        settings.board.template.beneathoverlays.change(function(value) {
           self.elements.container.toggleClass('lower-template', value);
         });
       },
@@ -1490,16 +1590,16 @@ window.App = (function() {
         return Math.abs(self.scale);
       },
       setScale: function(scale) {
-        if (settings.increasedZoomToggle.get() !== true && scale > 50) scale = 50;
+        if (settings.board.zoom.limit.enable.get() !== false && scale > 50) scale = 50;
         else if (scale <= 0) scale = 0.5; // enforce the [0.5, 50] limit without blindly resetting to 0.5 when the user was trying to zoom in farther than 50x
         self.scale = scale;
         self.update();
       },
       getZoomBase: function() {
-        return parseFloat(settings.zoomBaseValue.get()) || 1.5;
+        return parseFloat(settings.board.zoom.sensitivity.get()) || 1.5;
       },
       nudgeScale: function(adj) {
-        const maxUnlocked = settings.increasedZoomToggle.get() === true;
+        const maxUnlocked = settings.board.zoom.limit.enable.get() === false;
         const maximumValue = maxUnlocked ? Infinity : 50;
         const minimumValue = maxUnlocked ? 0 : 0.5;
         const zoomBase = self.getZoomBase();
@@ -1602,7 +1702,7 @@ window.App = (function() {
       },
       save: function() {
         const a = document.createElement('a');
-        const format = settings.snapshotImageFormat.get();
+        const format = settings.board.snapshot.format.get();
 
         a.href = self.elements.board[0].toDataURL(format, 1);
         a.download = (new Date()).toISOString().replace(/^(\d+-\d+-\d+)T(\d+):(\d+):(\d).*$/, `pxls canvas $1 $2.$3.$4.${format.split('/')[1]}`);
@@ -1734,7 +1834,7 @@ window.App = (function() {
       },
       init: function() {
         self.elements.heatmap.hide();
-        settings['heatmap-opacity'].change(function(value) {
+        settings.board.heatmap.opacity.change(function(value) {
           self.setBackgroundOpacity(parseFloat(value));
         });
         $('#hvmapClear').click(function() {
@@ -1790,7 +1890,7 @@ window.App = (function() {
           width: self.width,
           height: self.height
         });
-        settings.heatmaptoggle.change(function(value) {
+        settings.board.heatmap.enable.change(function(value) {
           if (value) {
             self.show();
           } else {
@@ -1805,7 +1905,7 @@ window.App = (function() {
           }
 
           if (e.key === 'h' || e.key === 'H' || e.which === 72) { // h key
-            settings.heatmaptoggle.toggle();
+            settings.board.heatmap.enable.toggle();
           }
         });
       }
@@ -1883,7 +1983,7 @@ window.App = (function() {
       },
       init: function() {
         self.elements.virginmap.hide();
-        settings['virginmap-opacity'].change(function(value) {
+        settings.board.virginmap.opacity.change(function(value) {
           self.setBackgroundOpacity(parseFloat(value));
         });
         $('#hvmapClear').click(function() {
@@ -1939,7 +2039,7 @@ window.App = (function() {
           width: self.width,
           height: self.height
         });
-        settings.virginmaptoggle.change(function(value) {
+        settings.board.virginmap.enable.change(function(value) {
           if (value) {
             self.show();
           } else {
@@ -1954,7 +2054,7 @@ window.App = (function() {
           }
 
           if (e.key === 'x' || e.key === 'X' || e.which === 88) { // x key
-            settings.virginmaptoggle.toggle();
+            settings.board.virginmap.enable.toggle();
           }
         });
       }
@@ -2285,7 +2385,7 @@ window.App = (function() {
       },
       init: function() {
         self.elements.grid.hide();
-        settings.gridtoggle.change(function(value) {
+        settings.board.grid.enable.change(function(value) {
           if (value) {
             self.elements.grid.fadeIn({ duration: 100 });
           } else {
@@ -2299,7 +2399,7 @@ window.App = (function() {
           }
 
           if (evt.key === 'g' || evt.key === 'G' || evt.keyCode === 71) {
-            settings.gridtoggle.toggle();
+            settings.board.grid.enable.toggle();
           }
         });
       },
@@ -2412,7 +2512,7 @@ window.App = (function() {
           self.toggleCursor(false);
           return;
         }
-        if (settings.showReticuleToggle.get()) {
+        if (settings.ui.reticule.enable.get()) {
           const screenPos = board.toScreen(self.reticule.x, self.reticule.y);
           const scale = board.getScale();
           self.elements.reticule.css({
@@ -2423,7 +2523,7 @@ window.App = (function() {
           });
           self.toggleReticule(true);
         }
-        if (settings.showCursorToggle.get()) {
+        if (settings.ui.cursor.enable.get()) {
           self.toggleCursor(true);
         }
       },
@@ -2431,14 +2531,14 @@ window.App = (function() {
         self.elements.palette[0].classList.toggle('no-pills', !shouldBeNumbered);
       },
       toggleReticule: (show) => {
-        if (show && settings.showReticuleToggle.get()) {
+        if (show && settings.ui.reticule.enable.get()) {
           self.elements.reticule.show();
         } else if (!show) {
           self.elements.reticule.hide();
         }
       },
       toggleCursor: (show) => {
-        if (show && settings.showCursorToggle.get()) {
+        if (show && settings.ui.cursor.enable.get()) {
           self.elements.cursor.show();
         } else if (!show) {
           self.elements.cursor.hide();
@@ -2458,7 +2558,10 @@ window.App = (function() {
                 $('<span>').addClass('palette-number').text(idx)
               )
               .click(function() {
-                if (ls.get('autoReset') === false || timer.cooledDown()) {
+                // TODO ([  ]): This check should be in switch - not here.
+                //              It's actually not very helpful here because of mmb picker and scrolling.
+                //              These buttons are occluded by the timer anyway.
+                if (settings.place.deselectonplace.enable.get() === false || timer.cooledDown()) {
                   self.switch(idx);
                 }
               });
@@ -2505,7 +2608,7 @@ window.App = (function() {
             y = evt.clientY;
           }
 
-          if (settings.showCursorToggle.get() !== false) {
+          if (settings.ui.cursor.enable.get() !== false) {
             self.elements.cursor.css('transform', 'translate(' + x + 'px, ' + y + 'px)');
           }
           if (self.can_undo) {
@@ -2536,9 +2639,9 @@ window.App = (function() {
           switch (data.ackFor) {
             case 'PLACE':
               $(window).trigger('pxls:ack:place', [data.x, data.y]);
-              if (uiHelper.tabHasFocus() && !settings.audiotoggle.get()) {
+              if (uiHelper.tabHasFocus() && settings.audio.enable.get()) {
                 const clone = self.audio.cloneNode(false);
-                clone.volume = parseFloat(ls.get('alert.volume'));
+                clone.volume = parseFloat(settings.audio.alert.volume.get());
                 clone.play();
               }
               break;
@@ -2594,14 +2697,14 @@ window.App = (function() {
           analytics('send', 'event', 'Captcha', 'Sent');
         };
         self.elements.palette.on('wheel', e => {
-          if (settings.scrollSwitchToggle.get() !== true) return;
+          if (settings.place.palette.scrolling.enable.get() !== true) return;
           const delta = e.originalEvent.deltaY * -40;
-          const newVal = (self.color + ((delta > 0 ? 1 : -1) * (settings.scrollDirectionToggle.get() === true ? -1 : 1))) % self.palette.length;
+          const newVal = (self.color + ((delta > 0 ? 1 : -1) * (settings.place.palette.scrolling.invert.get() === true ? -1 : 1))) % self.palette.length;
           self.switch(newVal <= -1 ? self.palette.length - 1 : newVal);
         });
 
-        settings.stickyColorToggle.change(function(value) {
-          self.setAutoReset(!value);
+        settings.place.deselectonplace.enable.change(function(value) {
+          self.setAutoReset(value);
         });
       },
       hexToRgb: function(hex) {
@@ -2967,7 +3070,7 @@ window.App = (function() {
         coords: $('#coords-info .coords'),
         lblAlertVolume: $('#lblAlertVolume'),
         btnForceAudioUpdate: $('#btnForceAudioUpdate'),
-        themeSelect: $('#themeSelect'),
+        themeSelect: $('#setting-ui-theme-index'),
         themeColorMeta: $('meta[name="theme-color"]'),
         txtDiscordName: $('#txtDiscordName'),
         selUsernameColor: $('#selUsernameColor'),
@@ -3013,15 +3116,15 @@ window.App = (function() {
           new SLIDEIN.Slidein(`A new ${data.report_type.toLowerCase()} report has been received.`, 'info-circle').show().closeAfter(3000);
         });
 
-        settings.monospaceToggle.change(function(value) {
+        settings.lookup.monospace.enable.change(function(value) {
           $('.monoVal').toggleClass('useMono', value);
         });
 
-        settings.cbNumberedPalette.change(function(value) {
+        settings.ui.palette.numbers.enable.change(function(value) {
           place.setNumberedPaletteEnabled(value);
         });
 
-        settings.lockCanvasToggle.change((value) => board.setAllowDrag(!value));
+        settings.board.lock.enable.change((value) => board.setAllowDrag(!value));
 
         const _chatPanel = document.querySelector('aside.panel[data-panel="chat"]');
         if (_chatPanel) {
@@ -3030,31 +3133,31 @@ window.App = (function() {
 
         const numOrDefault = (n, def) => isNaN(n) ? def : n;
 
-        settings['color-brightness-toggle'].change(function(enabled) {
+        settings.ui.brightness.enable.change(function(enabled) {
           if (enabled) {
-            settings['color-brightness'].controls.enable();
+            settings.ui.brightness.value.controls.enable();
           } else {
-            settings['color-brightness'].controls.disable();
+            settings.ui.brightness.value.controls.disable();
           }
-          self.adjustColorBrightness(enabled ? numOrDefault(parseFloat(settings['color-brightness'].get()), 1) : null);
+          self.adjustColorBrightness(enabled ? numOrDefault(parseFloat(settings.ui.brightness.value.get()), 1) : null);
         });
 
-        settings['color-brightness'].change(function(value) {
-          if (settings['color-brightness-toggle'].get() === true) {
+        settings.ui.brightness.value.change(function(value) {
+          if (settings.ui.brightness.enable.get() === true) {
             const level = numOrDefault(parseFloat(value), 1);
             self.adjustColorBrightness(level);
           }
         });
 
-        settings['bubble-position'].change(function(value) {
+        settings.ui.bubble.position.change(function(value) {
           self.elements.mainBubble.attr('position', value);
         });
 
-        settings.showReticuleToggle.change(function(value) {
+        settings.ui.reticule.enable.change(function(value) {
           place.toggleReticule(value && place.color !== -1);
         });
 
-        settings.showCursorToggle.change(function(value) {
+        settings.ui.reticule.enable.change(function(value) {
           place.toggleCursor(value && place.color !== -1);
         });
 
@@ -3116,8 +3219,8 @@ window.App = (function() {
           }));
         }
         // since we just changed the options available, this will coerce the settings into making the control reflect the actual theme.
-        settings.themeSelect.set(settings.themeSelect.get());
-        settings.themeSelect.change(function(value) {
+        settings.ui.theme.index.set(settings.ui.theme.index.get());
+        settings.ui.theme.index.change(function(value) {
           const themeIdx = parseInt(value);
           // If there exists no particular theme for the themeIdx, reset it to default
           if (!(themeIdx in self.themes)) {
@@ -3145,16 +3248,16 @@ window.App = (function() {
           if (console.warn) console.warn('An error occurred on the audioElem node: %o', err);
         });
 
-        settings.txtAlertLocation.change(function(url) { // change should only fire on blur so we normally won't be calling updateAudio for each keystroke. just in case though, we'll lazy update.
+        settings.audio.alert.src.change(function(url) { // change should only fire on blur so we normally won't be calling updateAudio for each keystroke. just in case though, we'll lazy update.
           if (self._alertUpdateTimer !== false) clearTimeout(self._alertUpdateTimer);
           self._alertUpdateTimer = setTimeout(function(url) {
             self.updateAudio(url);
             self._alertUpdateTimer = false;
           }, 250, url);
         });
-        self.elements.btnForceAudioUpdate.click(() => settings.txtAlertLocation.set(settings.txtAlertLocation.get()));
+        self.elements.btnForceAudioUpdate.click(() => settings.audio.alert.src.set(settings.audio.alert.src.get()));
 
-        settings.rangeAlertVolume.change(function(value) {
+        settings.audio.alert.volume.change(function(value) {
           const parsed = parseFloat(value);
           const volume = isNaN(parsed) ? 1 : parsed;
           self.elements.lblAlertVolume.text(`${volume * 100 >> 0}%`);
@@ -3166,7 +3269,7 @@ window.App = (function() {
         $('#btnAlertReset').click(() => {
           // TODO confirm with user
           self.updateAudio('notify.wav');
-          settings.txtAlertLocation.reset();
+          settings.audio.alert.src.reset();
         });
       },
       _initAccount: function() {
@@ -4879,7 +4982,7 @@ window.App = (function() {
           }
 
           const pingAudioState = ls.get('chat.ping-audio-state');
-          const canPlayPingAudio = !isHistory && !settings.audiotoggle.get() &&
+          const canPlayPingAudio = !isHistory && settings.audio.enable.get() &&
               pingAudioState !== 'off' && Date.now() - self.lastPingAudioTimestamp > 5000;
           if ((!panels.isOpen('chat') || !uiHelper.windowHasFocus() || pingAudioState === 'always') &&
               uiHelper.tabHasFocus() && canPlayPingAudio) {
@@ -5826,7 +5929,7 @@ window.App = (function() {
         let delta = (self.cooldown - (new Date()).getTime() - 1) / 1000;
 
         if (self.runningTimer === false) {
-          self.isOverlay = ls.get('autoReset') === true;
+          self.isOverlay = settings.place.deselectonplace.enable.get() === true;
           self.elements.timer = self.isOverlay ? self.elements.timer_overlay : self.elements.timer_bubble;
           self.elements.timer_overlay.hide();
         }
@@ -5835,7 +5938,7 @@ window.App = (function() {
           self.elements.timer.text(self.status);
         }
 
-        const alertDelay = settings.alertDelay.get();
+        const alertDelay = settings.place.alert.delay.get();
         if (alertDelay < 0 && delta < Math.abs(alertDelay) && !self.hasFiredNotification) {
           self.playAudio();
           let notif;
@@ -5916,7 +6019,7 @@ window.App = (function() {
       },
       init: function() {
         self.title = document.title;
-        self.elements.timer = ls.get('autoReset') === true
+        self.elements.timer = settings.place.deselectonplace.enable.get() === false
           ? self.elements.timer_overlay
           : self.elements.timer_bubble;
         self.elements.timer.hide();
@@ -5934,7 +6037,7 @@ window.App = (function() {
         });
       },
       playAudio: function() {
-        if (uiHelper.tabHasFocus() && !settings.audiotoggle.get()) {
+        if (uiHelper.tabHasFocus() && settings.audio.enable.get()) {
           self.audio.play();
         }
       }
@@ -6345,7 +6448,7 @@ window.App = (function() {
     const self = {
       elements: {},
       init: () => {
-        settings['native-notification-toggle'].change(function(value) {
+        settings.place.notification.enable.change(function(value) {
           if (value) {
             self.request();
           }
@@ -6384,7 +6487,7 @@ window.App = (function() {
         return null;
       },
       maybeShow: (body) => {
-        if (settings['native-notification-toggle'].get() &&
+        if (settings.place.notification.enable.get() &&
             uiHelper.tabHasFocus() &&
             Notification.permission === 'granted') {
           return self.show(body);

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -472,8 +472,6 @@ window.App = (function() {
       return self;
     };
 
-    const possiblyMobile = window.innerWidth < 768 && nua.includes('Mobile');
-
     const keymappings = {
       currentTheme: 'ui.theme.index',
       audio_muted: 'audio.enable',
@@ -501,7 +499,8 @@ window.App = (function() {
       colorBrightness: 'ui.brightness.value',
       'alert.src': 'audio.alert.src',
       'alert.volume': 'audio.alert.volume',
-      alert_delay: 'place.alert.delay'
+      alert_delay: 'place.alert.delay',
+      'chrome-canvas-offset-workaround': 'fix.chrome.offset.enable'
     };
 
     // these are the settings which have gone from being toggle-off to toggle-on
@@ -518,6 +517,9 @@ window.App = (function() {
         ls.remove(entry[0]);
       }
     });
+
+    const possiblyMobile = window.innerWidth < 768 && nua.includes('Mobile');
+    const webkitBased = nua.match(/AppleWebKit/);
 
     return {
       ui: {
@@ -601,6 +603,13 @@ window.App = (function() {
       lookup: {
         monospace: {
           enable: setting('lookup.monospace.enable', Type.TOGGLE, false, $('#setting-lookup-monospace-enable'))
+        }
+      },
+      fix: {
+        chrome: {
+          offset: {
+            enable: setting('fix.chrome.offset.enable', Type.TOGGLE, webkitBased, $('#setting-fix-chrome-offset-enable'))
+          }
         }
       }
     };
@@ -6572,8 +6581,7 @@ window.App = (function() {
       isEnabled: false,
       elements: {
         boardContainer: board.getContainer(),
-        setting: $('#chrome-canvas-offset-setting'),
-        checkbox: $('#chrome-canvas-offset-toggle')
+        setting: $('#chrome-canvas-offset-setting')
       },
       init: () => {
         if (!nua.match(/AppleWebKit/)) {
@@ -6581,22 +6589,8 @@ window.App = (function() {
           return;
         }
 
-        self.isEnabled = ls.get('chrome-canvas-offset-workaround');
-        if (self.isEnabled == null) {
-          // default to enabled
-          self.isEnabled = true;
-          ls.set('chrome-canvas-offset-workaround', self.isEnabled);
-        }
-
-        if (self.isEnabled) {
-          self.enable();
-        }
-
-        self.elements.checkbox.prop('checked', self.isEnabled);
-        self.elements.checkbox.on('change', (e) => {
-          self.isEnabled = e.target.checked;
-          ls.set('chrome-canvas-offset-workaround', self.isEnabled);
-          if (self.isEnabled) {
+        settings.fix.chrome.offset.enable.change((value) => {
+          if (value) {
             self.enable();
           } else {
             self.disable();
@@ -6604,7 +6598,6 @@ window.App = (function() {
         });
       },
       enable: () => {
-        self.isEnabled = true;
         window.addEventListener('resize', self.updateContainer);
         self.updateContainer();
       },
@@ -6616,7 +6609,6 @@ window.App = (function() {
         self.elements.boardContainer.css('height', `${window.innerHeight - offsetHeight}px`);
       },
       disable: () => {
-        self.isEnabled = false;
         window.removeEventListener('resize', self.updateContainer);
         self.elements.boardContainer.css('width', '');
         self.elements.boardContainer.css('height', '');

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -126,9 +126,11 @@ window.App = (function() {
     return checkImageRendering('', true, true, false) || checkImageRendering('-o-', true, false, false) || checkImageRendering('-moz-', true, false, false) || checkImageRendering('-webkit-', true, false, true);
   })();
   let haveZoomRendering = false;
-  const iOSSafari = (nua.match(/(iPod|iPhone|iPad)/i) && nua.match(/AppleWebKit/i));
+  const webkitBased = nua.match(/AppleWebKit/i);
+  const iOSSafari = (nua.match(/(iPod|iPhone|iPad)/i) && webkitBased);
   const desktopSafari = (nua.match(/safari/i) && !nua.match(/chrome/i));
   const msEdge = nua.indexOf('Edge') > -1;
+  const possiblyMobile = window.innerWidth < 768 && nua.includes('Mobile');
   if (iOSSafari) {
     const iOS = parseFloat(
       ('' + (/CPU.*OS ([0-9_]{1,5})|(CPU like).*AppleWebKit.*Mobile/i.exec(navigator.userAgent) || [0, ''])[1])
@@ -562,9 +564,6 @@ window.App = (function() {
         ls.remove(entry[0]);
       }
     });
-
-    const possiblyMobile = window.innerWidth < 768 && nua.includes('Mobile');
-    const webkitBased = nua.match(/AppleWebKit/);
 
     return {
       ui: {
@@ -6620,7 +6619,7 @@ window.App = (function() {
         setting: $('#chrome-canvas-offset-setting')
       },
       init: () => {
-        if (!nua.match(/AppleWebKit/)) {
+        if (!webkitBased) {
           self.elements.setting.hide();
           return;
         }

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -315,7 +315,7 @@ window.App = (function() {
   const ss = storageFactory(sessionStorage, 'ss_', null);
 
   const settings = (function() {
-    const Type = {
+    const SettingType = {
       TOGGLE: 0,
       RANGE: 1,
       TEXT: 2,
@@ -326,28 +326,28 @@ window.App = (function() {
 
     const validate = function(value, fallback, type) {
       switch (type) {
-        case Type.TOGGLE:
+        case SettingType.TOGGLE:
           // valid if value is a boolean (either true or false)
           if (value === true || value === false) {
             return value;
           }
           break;
-        case Type.TEXT:
+        case SettingType.TEXT:
           if (typeof value === 'string') {
             return value;
           }
           break;
-        case Type.NUMBER:
+        case SettingType.NUMBER:
           /* falls through */
-        case Type.RANGE:
+        case SettingType.RANGE:
           // valid if value is a number
           if (!isNaN(parseFloat(value))) {
             return value;
           }
           break;
-        case Type.SELECT:
+        case SettingType.SELECT:
           /* falls through */
-        case Type.RADIO:
+        case SettingType.RADIO:
           // select and radios can use practically any values: allow if not void
           if (value != null) {
             return value;
@@ -358,21 +358,29 @@ window.App = (function() {
 
     const filterInput = function(controls, type) {
       switch (type) {
-        case Type.TOGGLE:
+        case SettingType.TOGGLE:
           return controls.filter('input[type=checkbox]');
-        case Type.RANGE:
+        case SettingType.RANGE:
           return controls.filter('input[type=range]');
-        case Type.TEXT:
+        case SettingType.TEXT:
           return controls.filter('input[type=text]');
-        case Type.NUMBER:
+        case SettingType.NUMBER:
           return controls.filter('input[type=number]');
-        case Type.SELECT:
+        case SettingType.SELECT:
           return controls.filter('select');
-        case Type.RADIO:
+        case SettingType.RADIO:
           return controls.filter('input[type=radio]');
       }
     };
 
+    /**
+     * Creates a new setting
+     * @param {String} name the key to use in localstorage for the setting .
+     * @param {SettingType} type the type of setting.
+     * @param defaultValue the default value of the setting.
+     * @param {JQuery|Element|selector} initialControls the inputs to bind as the controls of this setting.
+     * @returns {Object} the setting object with public access to certain functions.
+     */
     const setting = function(name, type, defaultValue, initialControls = $()) {
       const listeners = [];
       let controls = $();
@@ -385,9 +393,9 @@ window.App = (function() {
         const validValue = validate(value, defaultValue, type);
         ls.set(name, validValue);
 
-        if (type === Type.RADIO) {
+        if (type === SettingType.RADIO) {
           controls.each((_, e) => { e.checked = e.value === value; });
-        } else if (type === Type.TOGGLE) {
+        } else if (type === SettingType.TOGGLE) {
           controls.prop('checked', validValue);
         } else {
           controls.prop('value', validValue);
@@ -408,13 +416,13 @@ window.App = (function() {
       let changeEvents = 'change';
 
       switch (type) {
-        case Type.RADIO:
+        case SettingType.RADIO:
           changeEvents = 'click';
           break;
-        case Type.RANGE:
+        case SettingType.RANGE:
           changeEvents = 'input change';
           break;
-        case Type.TOGGLE:
+        case SettingType.TOGGLE:
           changeFunction = (evt) => self.set(evt.target.checked);
           break;
       }
@@ -441,7 +449,7 @@ window.App = (function() {
             const toAdd = filterInput($(control), type);
             controls = controls.add(toAdd);
 
-            if (type === Type.TEXT || type === Type.NUMBER) {
+            if (type === SettingType.TEXT || type === SettingType.NUMBER) {
               toAdd.on('keydown', keydownFunction);
             }
 
@@ -474,7 +482,7 @@ window.App = (function() {
             const toRemove = controls.filter($(control));
             controls = controls.not(toRemove);
 
-            if (type === Type.TEXT || type === Type.NUMBER) {
+            if (type === SettingType.TEXT || type === SettingType.NUMBER) {
               toRemove.off('keydown', keydownFunction);
             }
 
@@ -489,7 +497,7 @@ window.App = (function() {
         }
       };
 
-      if (type === Type.TOGGLE) {
+      if (type === SettingType.TOGGLE) {
         self.toggle = function() { self.set(!self.get()); };
       }
 
@@ -561,133 +569,133 @@ window.App = (function() {
     return {
       ui: {
         theme: {
-          index: setting('ui.theme.index', Type.SELECT, '-1', $('#setting-ui-theme-index'))
+          index: setting('ui.theme.index', SettingType.SELECT, '-1', $('#setting-ui-theme-index'))
         },
         reticule: {
-          enable: setting('ui.reticule.enable', Type.TOGGLE, !possiblyMobile, $('#setting-ui-reticule-enable'))
+          enable: setting('ui.reticule.enable', SettingType.TOGGLE, !possiblyMobile, $('#setting-ui-reticule-enable'))
         },
         cursor: {
-          enable: setting('ui.cursor.enable', Type.TOGGLE, !possiblyMobile, $('#setting-ui-cursor-enable'))
+          enable: setting('ui.cursor.enable', SettingType.TOGGLE, !possiblyMobile, $('#setting-ui-cursor-enable'))
         },
         bubble: {
-          position: setting('ui.bubble.position', Type.RADIO, 'bottom left', $('[name=setting-ui-bubble-position]'))
+          position: setting('ui.bubble.position', SettingType.RADIO, 'bottom left', $('[name=setting-ui-bubble-position]'))
         },
         brightness: {
-          enable: setting('ui.brightness.enable', Type.TOGGLE, false, $('#setting-ui-brightness-enable')),
-          value: setting('ui.brightness.value', Type.RANGE, 1, $('#setting-ui-brightness-value'))
+          enable: setting('ui.brightness.enable', SettingType.TOGGLE, false, $('#setting-ui-brightness-enable')),
+          value: setting('ui.brightness.value', SettingType.RANGE, 1, $('#setting-ui-brightness-value'))
         },
         palette: {
           numbers: {
-            enable: setting('ui.palette.numbers.enable', Type.TOGGLE, false, $('#setting-ui-palette-numbers-enable'))
+            enable: setting('ui.palette.numbers.enable', SettingType.TOGGLE, false, $('#setting-ui-palette-numbers-enable'))
           }
         },
         chat: {
           banner: {
-            enable: setting('ui.chat.banner.enable', Type.TOGGLE, true)
+            enable: setting('ui.chat.banner.enable', SettingType.TOGGLE, true)
           },
           horizontal: {
-            enable: setting('ui.chat.horizontal.enable', Type.TOGGLE, false)
+            enable: setting('ui.chat.horizontal.enable', SettingType.TOGGLE, false)
           }
         }
       },
       audio: {
-        enable: setting('audio.enable', Type.TOGGLE, true, $('#setting-audio-enable')),
+        enable: setting('audio.enable', SettingType.TOGGLE, true, $('#setting-audio-enable')),
         alert: {
-          src: setting('audio.alert.src', Type.TEXT, '', $('#setting-audio-alert-src')),
-          volume: setting('audio.alert.volume', Type.RANGE, 1, $('#setting-audio-alert-volume'))
+          src: setting('audio.alert.src', SettingType.TEXT, '', $('#setting-audio-alert-src')),
+          volume: setting('audio.alert.volume', SettingType.RANGE, 1, $('#setting-audio-alert-volume'))
         }
       },
       board: {
         heatmap: {
-          enable: setting('board.heatmap.enable', Type.TOGGLE, false, $('#setting-board-heatmap-enable')),
-          opacity: setting('board.heatmap.opacity', Type.RANGE, 0.5, $('#setting-board-heatmap-opacity'))
+          enable: setting('board.heatmap.enable', SettingType.TOGGLE, false, $('#setting-board-heatmap-enable')),
+          opacity: setting('board.heatmap.opacity', SettingType.RANGE, 0.5, $('#setting-board-heatmap-opacity'))
         },
         virginmap: {
-          enable: setting('board.virginmap.enable', Type.TOGGLE, false, $('#setting-board-virginmap-enable')),
-          opacity: setting('board.virginmap.opacity', Type.RANGE, 0.5, $('#setting-board-virginmap-opacity'))
+          enable: setting('board.virginmap.enable', SettingType.TOGGLE, false, $('#setting-board-virginmap-enable')),
+          opacity: setting('board.virginmap.opacity', SettingType.RANGE, 0.5, $('#setting-board-virginmap-opacity'))
         },
         grid: {
-          enable: setting('board.grid.enable', Type.TOGGLE, false, $('#setting-board-grid-enable'))
+          enable: setting('board.grid.enable', SettingType.TOGGLE, false, $('#setting-board-grid-enable'))
         },
         lock: {
-          enable: setting('board.lock.enable', Type.TOGGLE, false, $('#setting-board-lock-enable'))
+          enable: setting('board.lock.enable', SettingType.TOGGLE, false, $('#setting-board-lock-enable'))
         },
         zoom: {
-          sensitivity: setting('board.zoom.sensitivity', Type.RANGE, 1.5, $('#setting-board-zoom-sensitivity')),
+          sensitivity: setting('board.zoom.sensitivity', SettingType.RANGE, 1.5, $('#setting-board-zoom-sensitivity')),
           limit: {
-            enable: setting('board.zoom.limit.enable', Type.TOGGLE, true, $('#setting-board-zoom-limit-enable'))
+            enable: setting('board.zoom.limit.enable', SettingType.TOGGLE, true, $('#setting-board-zoom-limit-enable'))
           }
         },
         template: {
-          beneathoverlays: setting('board.template.beneathoverlays', Type.TOGGLE, false, $('#setting-board-template-beneathoverlays'))
+          beneathoverlays: setting('board.template.beneathoverlays', SettingType.TOGGLE, false, $('#setting-board-template-beneathoverlays'))
         },
         snapshot: {
-          format: setting('board.snapshot.format', Type.SELECT, 'image/png', $('#setting-board-snapshot-format'))
+          format: setting('board.snapshot.format', SettingType.SELECT, 'image/png', $('#setting-board-snapshot-format'))
         }
       },
       place: {
         notification: {
-          enable: setting('place.notification.enable', Type.TOGGLE, true, $('#setting-place-notification-enable'))
+          enable: setting('place.notification.enable', SettingType.TOGGLE, true, $('#setting-place-notification-enable'))
         },
         deselectonplace: {
-          enable: setting('place.deselectonplace.enable', Type.TOGGLE, true, $('#setting-place-deselectonplace-enable'))
+          enable: setting('place.deselectonplace.enable', SettingType.TOGGLE, true, $('#setting-place-deselectonplace-enable'))
         },
         palette: {
           scrolling: {
-            enable: setting('place.palette.scrolling.enable', Type.TOGGLE, false, $('#setting-place-palette-scrolling-enable')),
-            invert: setting('place.palette.scrolling.invert', Type.TOGGLE, false, $('#setting-place-palette-scrolling-invert'))
+            enable: setting('place.palette.scrolling.enable', SettingType.TOGGLE, false, $('#setting-place-palette-scrolling-enable')),
+            invert: setting('place.palette.scrolling.invert', SettingType.TOGGLE, false, $('#setting-place-palette-scrolling-invert'))
           }
         },
         picker: {
-          enable: setting('place.picker.enable', Type.TOGGLE, true, $('#setting-place-picker-enable'))
+          enable: setting('place.picker.enable', SettingType.TOGGLE, true, $('#setting-place-picker-enable'))
         },
         alert: {
-          delay: setting('place.alert.delay', Type.NUMBER, 0, $('#setting-place-alert-delay'))
+          delay: setting('place.alert.delay', SettingType.NUMBER, 0, $('#setting-place-alert-delay'))
         }
       },
       lookup: {
         monospace: {
-          enable: setting('lookup.monospace.enable', Type.TOGGLE, false, $('#setting-lookup-monospace-enable'))
+          enable: setting('lookup.monospace.enable', SettingType.TOGGLE, false, $('#setting-lookup-monospace-enable'))
         },
         filter: {
           sensitive: {
-            enable: setting('lookup.filter.sensitive.enable', Type.TOGGLE, false)
+            enable: setting('lookup.filter.sensitive.enable', SettingType.TOGGLE, false)
           }
         }
       },
       chat: {
         timestamps: {
-          '24h': setting('chat.timestamps.24h', Type.TOGGLE, false)
+          '24h': setting('chat.timestamps.24h', SettingType.TOGGLE, false)
         },
         badges: {
-          enable: setting('chat.badges.enable', Type.TOGGLE, false)
+          enable: setting('chat.badges.enable', SettingType.TOGGLE, false)
         },
         factiontags: {
-          enable: setting('chat.factiontags.enable', Type.TOGGLE, true)
+          enable: setting('chat.factiontags.enable', SettingType.TOGGLE, true)
         },
         pings: {
-          enable: setting('chat.pings.enable', Type.TOGGLE, true),
+          enable: setting('chat.pings.enable', SettingType.TOGGLE, true),
           audio: {
-            when: setting('chat.pings.audio.when', Type.SELECT, 'off'),
-            volume: setting('chat.pings.audio.volume', Type.RANGE, 0.5)
+            when: setting('chat.pings.audio.when', SettingType.SELECT, 'off'),
+            volume: setting('chat.pings.audio.volume', SettingType.RANGE, 0.5)
           }
         },
         links: {
           templates: {
-            preferurls: setting('chat.links.templates.preferurls', Type.TOGGLE, false)
+            preferurls: setting('chat.links.templates.preferurls', SettingType.TOGGLE, false)
           },
           internal: {
-            behavior: setting('chat.links.internal.behavior', Type.SELECT, 'ask')
+            behavior: setting('chat.links.internal.behavior', SettingType.SELECT, 'ask')
           }
         },
         font: {
-          size: setting('chat.font.size', Type.NUMBER, 16)
+          size: setting('chat.font.size', SettingType.NUMBER, 16)
         }
       },
       fix: {
         chrome: {
           offset: {
-            enable: setting('fix.chrome.offset.enable', Type.TOGGLE, webkitBased, $('#setting-fix-chrome-offset-enable'))
+            enable: setting('fix.chrome.offset.enable', SettingType.TOGGLE, webkitBased, $('#setting-fix-chrome-offset-enable'))
           }
         }
       }

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -6361,7 +6361,6 @@ window.App = (function() {
               window.initAdmin({
                 socket: socket,
                 user: user,
-                place: place,
                 modal: modal,
                 lookup: lookup,
                 chat: chat,

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -561,13 +561,13 @@ window.App = (function() {
     return {
       ui: {
         theme: {
-          index: setting('ui.theme.index', Type.SELECT, '0', $('#setting-ui-theme-index'))
+          index: setting('ui.theme.index', Type.SELECT, '-1', $('#setting-ui-theme-index'))
         },
         reticule: {
-          enable: setting('ui.reticule.enable', Type.TOGGLE, possiblyMobile, $('#setting-ui-reticule-enable'))
+          enable: setting('ui.reticule.enable', Type.TOGGLE, !possiblyMobile, $('#setting-ui-reticule-enable'))
         },
         cursor: {
-          enable: setting('ui.cursor.enable', Type.TOGGLE, possiblyMobile, $('#setting-ui-cursor-enable'))
+          enable: setting('ui.cursor.enable', Type.TOGGLE, !possiblyMobile, $('#setting-ui-cursor-enable'))
         },
         bubble: {
           position: setting('ui.bubble.position', Type.RADIO, 'bottom left', $('[name=setting-ui-bubble-position]'))

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -4727,33 +4727,21 @@ window.App = (function() {
             lblIgnoresFeedback
           ].map(x => crel('div', x))
         );
-        const chatModal = modal.show(modal.buildDom(
+        modal.show(modal.buildDom(
           crel('h2', { class: 'modal-title' }, 'Chat Settings'),
           body
-        ))[0];
-        // NOTE ([  ]): We can't just listen for $.modal.AFTER_CLOSE since it's entirely possible the modal could be shown again.
-        //              While there's no code I'm currently aware of that does this, it would be a pain to have to know to edit *this* code when changing sucha  behaviour.
-        const observer = new MutationObserver(function() {
-          // NOTE ([  ]): Modal seems to fire many add/remove mutations for the panel itself when adding a new one.
-          //              This means we can't just listen for remove mutations and filter accordingly.
-          if (!$.contains(document.body, chatModal)) {
-            settings.chat.font.size.controls.remove(_txtFontSize);
-            settings.chat.links.internal.behavior.controls.remove(_selInternalClick);
-            settings.chat.timestamps['24h'].controls.remove(_cb24hTimestamps);
-            settings.chat.badges.enable.controls.remove(_cbPixelPlaceBadges);
-            settings.chat.factiontags.enable.controls.remove(_cbFactionTagBadges);
-            settings.chat.pings.enable.controls.remove(_cbPings);
-            settings.chat.pings.audio.when.controls.remove(_cbPingAudio);
-            settings.chat.pings.audio.volume.controls.remove(_rgPingAudioVol);
-            settings.ui.chat.banner.enable.controls.remove(_cbBanner);
-            settings.chat.links.templates.preferurls.controls.remove(_cbTemplateTitles);
-            settings.ui.chat.horizontal.enable.controls.remove(_cbHorizontal);
-            observer.disconnect();
-          }
-        });
-        observer.observe(document, {
-          childList: true,
-          subtree: true
+        )).one($.modal.AFTER_CLOSE, function() {
+          settings.chat.font.size.controls.remove(_txtFontSize);
+          settings.chat.links.internal.behavior.controls.remove(_selInternalClick);
+          settings.chat.timestamps['24h'].controls.remove(_cb24hTimestamps);
+          settings.chat.badges.enable.controls.remove(_cbPixelPlaceBadges);
+          settings.chat.factiontags.enable.controls.remove(_cbFactionTagBadges);
+          settings.chat.pings.enable.controls.remove(_cbPings);
+          settings.chat.pings.audio.when.controls.remove(_cbPingAudio);
+          settings.chat.pings.audio.volume.controls.remove(_rgPingAudioVol);
+          settings.ui.chat.banner.enable.controls.remove(_cbBanner);
+          settings.chat.links.templates.preferurls.controls.remove(_cbTemplateTitles);
+          settings.ui.chat.horizontal.enable.controls.remove(_cbHorizontal);
         });
       },
       _handlePingJumpClick: function() { // must be es5 for expected behavior. don't upgrade syntax, this is attached as an onclick and we need `this` to be bound by dom bubbles.


### PR DESCRIPTION
This adds a new component-level object `settings` which makes managing and keeping track of various settings and controls for them much easier.

Before the process for creating a setting was thusly:
```js
let settingValue = ls.get('setting-key');
if(settingValue == null) {
  // or some other invalid value
  settingValue = defaultValue;
}
$('#settingControl').val(settingValue);
$('#settingControl').change(function() {
  ls.set('setting-key', this.value);
  // do onchange things
});
```

To do something similar with this PR, we would do the following:
```js
settings.component.feature.subfeature.setting = setting('setting-key', SettingType.NUMBER, defaultValue, $('settingControl'));
settings.component.feature.subfeature.setting.listen(function() {
  // do onchange things
});
```

One major benefit of this is the programmatic changing of settings. It is now possible to in one call enable the heatmap, record the setting to localstorage, and update the checkbox for the heatmap being enabled. This works to same for all other settings.

```js
settings.board.heatmap.enable.set(true);
```

In regards to this PR, perhaps my most significant doubts are in the naming of settings keys. Since these names have changed there is code to convert over old ones such that users settings should be retained, but the new choice of keys is still up for debate. As demonstrated above, I have decided to go with `component.feature.subfeature.setting`. 

Even if we agree on this naming though, the decision of which component a given setting counts for is not clear. For example, audio is its own component but many settings that would be associated with a different component may be audio related. To be more specific, a key such as `chat.pings.audio.enable` could just as easily be `audio.pings.enable`—and perhaps should be, given audio is more the relevant category.

One final thing to mention is that this also flips some of the settings from being check-to-disable to being more consistent by being check-to-enable. An example of this is audio becoming "Enable audio" rather than "Mute audio".

Regardless, this code should make handling of settings much easier and more consistent going forward.