### PR TITLE
Fix info links layout and make minor semantic changes

### DIFF
--- a/resources/public/admin/admin.css
+++ b/resources/public/admin/admin.css
@@ -27,7 +27,7 @@
     visibility: visible;
 }
 
-.admin > h1 {
+.admin > h2 {
     display: block;
     font-size: 20px;
     font-weight: 700;

--- a/resources/public/admin/admin.js
+++ b/resources/public/admin/admin.js
@@ -360,7 +360,7 @@
       },
       init: function () {
         self.elements.panel.hide().addClass('admin bubble').append(
-          $('<h1>').text('MOD'),
+          $('<h2>').text('MOD'),
           $('<div>').append(
             // first do the checkboxes
             $.map(

--- a/resources/public/faq.html
+++ b/resources/public/faq.html
@@ -1,6 +1,6 @@
 <article>
     <header>
-        <h2>FAQ</h2>
+        <h3>FAQ</h3>
     </header>
     <div class="pad-wrapper">
         <dl>

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -54,55 +54,57 @@
 
 <div id="reconnecting">Lost connection to server, reconnecting...</div>
 
-<div id="board-container" style="touch-action: none">
-    <div id="grid"></div>
-    <div id="board-zoomer">
-        <div id="board-mover">
-            <canvas id="heatmap" class="pixelate noselect"></canvas>
-            <canvas id="virginmap" class="pixelate noselect"></canvas>
-            <canvas id="board" class="pixelate noselect" width="100" height="100"></canvas>
-        </div>
-    </div>
-</div>
+<main>
+  <div id="board-container" style="touch-action: none">
+      <div id="grid"></div>
+      <div id="board-zoomer">
+          <div id="board-mover">
+              <canvas id="heatmap" class="pixelate noselect"></canvas>
+              <canvas id="virginmap" class="pixelate noselect"></canvas>
+              <canvas id="board" class="pixelate noselect" width="100" height="100"></canvas>
+          </div>
+      </div>
+  </div>
 
-<div id="ui">
-    <div id="ui-top">
-        <div id="loading-bubble" class="bubble">
-            <div class="loading-bubble-item" data-process="heatmap">Loading Heatmap (press <kbd>H</kbd> to cancel)</div>
-            <div class="loading-bubble-item" data-process="virginmap">Loading Virginmap (press <kbd>X</kbd> to cancel)</div>
-        </div>
-        <div id="main-bubble" class="bubble">
-            <div id="user-info">
-                <!-- TODO: link to position on stats page -->
-                <span id="username"></span>
-                <a href="/logout" class="logout"><i class="fas fa-sign-out-alt" id="logout-icon"></i></a>
-                <br>
-            </div>
-            <span id="online-count">Waiting for online count...</span>
-            <br><br>
-            <div id="coords-info">
-                <a class="coords"></a>
-                <i id="canvas-lock-icon" class="fas fa-lock"></i>
-            </div>
-            <div id="placement-info">
-                <span>Pixels available: </span><span id="placeable-count">N/A</span> <i class="fas fa-spinner fa-spin captcha-loading-icon"></i>
-                <br>
-                <span id="cooldown-timer"></span>
-            </div>
-        </div>
-    </div>
+  <div id="ui">
+      <div id="ui-top">
+          <div id="loading-bubble" class="bubble">
+              <div class="loading-bubble-item" data-process="heatmap">Loading Heatmap (press <kbd>H</kbd> to cancel)</div>
+              <div class="loading-bubble-item" data-process="virginmap">Loading Virginmap (press <kbd>X</kbd> to cancel)</div>
+          </div>
+          <div id="main-bubble" class="bubble">
+              <div id="user-info">
+                  <!-- TODO: link to position on stats page -->
+                  <span id="username"></span>
+                  <a href="/logout" class="logout"><i class="fas fa-sign-out-alt" id="logout-icon"></i></a>
+                  <br>
+              </div>
+              <span id="online-count">Waiting for online count...</span>
+              <br><br>
+              <div id="coords-info">
+                  <a class="coords"></a>
+                  <i id="canvas-lock-icon" class="fas fa-lock"></i>
+              </div>
+              <div id="placement-info">
+                  <span>Pixels available: </span><span id="placeable-count">N/A</span> <i class="fas fa-spinner fa-spin captcha-loading-icon"></i>
+                  <br>
+                  <span id="cooldown-timer"></span>
+              </div>
+          </div>
+      </div>
 
-    <div id="ui-bottom">
-        <button type="button" id="undo"><span>Undo</span></button>
-        <div id="login-overlay" class="palette-overlay">
-            You are not signed in.&nbsp;<a href="#">Sign in with...</a>
-        </div>
-        <div id="user-message" class="palette-overlay"></div>
-        <div id="palette">
-            <div id="cd-timer-overlay" class="palette-overlay"></div>
-        </div>
-    </div>
-</div>
+      <div id="ui-bottom">
+          <button type="button" id="undo"><span>Undo</span></button>
+          <div id="login-overlay" class="palette-overlay">
+              You are not signed in.&nbsp;<a href="#">Sign in with...</a>
+          </div>
+          <div id="user-message" class="palette-overlay"></div>
+          <div id="palette">
+              <div id="cd-timer-overlay" class="palette-overlay"></div>
+          </div>
+      </div>
+  </div>
+</main>
 
 
 <div id="lookup" class="floating-panel"></div>

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -193,10 +193,10 @@
     <div class="panel-body">
         <article class="no-p-margin">
             <header>
-                <h2>Keybinds</h2>
+                <h3>Keybinds</h3>
             </header>
             <div class="pad-wrapper">
-                <h3>General</h3>
+                <h4>General</h4>
                 <div class="indent-1">
                     <p>Mouse/arrows/wasd to pan</p>
                     <p>Scroll/pinch to zoom</p>
@@ -216,7 +216,7 @@
                     <p><kbd>ESC</kbd> to deselect current pixel</p>
                     <p><kbd>R</kbd> to center the board on the current template</p>
                 </div>
-                <h3>Template</h3>
+                <h4>Template</h4>
                 <div class="indent-1">
                     <p><kbd>Page Up</kbd> to increase opacity</p>
                     <p><kbd>Page Down</kbd> to decrease opacity</p>
@@ -226,7 +226,7 @@
         </article>
         <article>
             <header>
-                <h2>General Settings</h2>
+                <h3>General Settings</h3>
             </header>
             <div class="pad-wrapper">
                 <div class="settingToggles">
@@ -341,7 +341,7 @@
         </article>
         <article>
             <header>
-                <h2>Template</h2>
+                <h3>Template</h3>
             </header>
             <div class="pad-wrapper">
                 <div>
@@ -372,7 +372,7 @@
         </article>
         <article>
             <header>
-                <h2>Pixel Ready Alert Settings</h2>
+                <h3>Pixel Ready Alert Settings</h3>
             </header>
             <div class="pad-wrapper">
                 <p><label for="txtAlertLocation">Alert URL:</label><input class="fullwidth" type="text" placeholder="notify.wav" id="txtAlertLocation"></p>
@@ -391,7 +391,7 @@
         </article>
         <article>
             <header>
-                <h2>Account Settings</h2>
+                <h3>Account Settings</h3>
             </header>
             <div class="pad-wrapper">
                 <p><label for="txtDiscordName">Public Discord Name:</label><input class="fullwidth" type="text" placeholder="pxlslover#1337" id="txtDiscordName"></p>
@@ -407,7 +407,7 @@
 <aside id="faq" data-panel="faq" class="panel left half-width">
     <header class="panel-header">
         <div class="left"></div>
-        <h2><i class="fas fa-question-circle fa-is-left"></i>Help</h2>
+        <h3><i class="fas fa-question-circle fa-is-left"></i>Help</h3>
         <div class="right">
             <button type="button" class="panel-closer" title="Close Panel"><i class="fas fa-times"></i></button>
         </div>
@@ -420,7 +420,7 @@
 <aside id="notifications" data-panel="notifications" class="panel left">
     <header class="panel-header">
         <div class="left"></div>
-        <h2><i class="fas fa-bell fa-is-left"></i>Notifications</h2>
+        <h3><i class="fas fa-bell fa-is-left"></i>Notifications</h3>
         <div class="right">
             <button type="button" class="panel-closer" title="Close Panel"><i class="fas fa-times"></i></button>
         </div>

--- a/resources/public/info.html
+++ b/resources/public/info.html
@@ -70,22 +70,24 @@
 	<header>
 		<h3>Links</h3>
 	</header>
-	<ul>
-		<li><a href="https://pxls.space/discord" target="_blank">Discord (main hub)</a></li>
-		<li><a href="https://reddit.com/r/pxlsspace" target="_blank">Subreddit</a></li>
-		<li><a href="https://twitter.com/pxls_space" target="_blank">Twitter</a></li>
-		<li><a href="https://facebook.com/pxls.space/" target="_blank">Facebook</a></li>
-		<li><a href="https://pxls-space.tumblr.com/" target="_blank">Tumblr</a></li>
-		<li><a href="https://vk.com/pxls.official" target="_blank">VK</a></li>
-		<li><a href="https://play.google.com/store/apps/details?id=space.pxls.android" target="_blank">Android app</a></li>
-		<li><a href="https://github.com/xSke/Pxls" target="_blank">GitHub</a></li>
-		<li><a href="https://github.com/xSke/PxlsApp" target="_blank">GitHub (App)</a></li>
-		<li><a href="http://www.piskelapp.com/p/create" target="_blank">Single-player mode</a></li>
-	</ul>
-	<ul>
-		<li><a href="https://pxls.space/stats" target="_blank">Statistics</a></li>
-		<li><a href="https://pxlsfiddle.com/" target="_blank" title="Template generator, archives, timelapses, and other utilities">PxlsFiddle (templates, archives, etc.)</a></li>
-	</ul>
+	<div class="pad-wrapper">
+		<ul>
+			<li><a href="https://pxls.space/discord" target="_blank">Discord (main hub)</a></li>
+			<li><a href="https://reddit.com/r/pxlsspace" target="_blank">Subreddit</a></li>
+			<li><a href="https://twitter.com/pxls_space" target="_blank">Twitter</a></li>
+			<li><a href="https://facebook.com/pxls.space/" target="_blank">Facebook</a></li>
+			<li><a href="https://pxls-space.tumblr.com/" target="_blank">Tumblr</a></li>
+			<li><a href="https://vk.com/pxls.official" target="_blank">VK</a></li>
+			<li><a href="https://play.google.com/store/apps/details?id=space.pxls.android" target="_blank">Android app</a></li>
+			<li><a href="https://github.com/xSke/Pxls" target="_blank">GitHub</a></li>
+			<li><a href="https://github.com/xSke/PxlsApp" target="_blank">GitHub (App)</a></li>
+			<li><a href="http://www.piskelapp.com/p/create" target="_blank">Single-player mode</a></li>
+		</ul>
+		<ul>
+			<li><a href="https://pxls.space/stats" target="_blank">Statistics</a></li>
+			<li><a href="https://pxlsfiddle.com/" target="_blank" title="Template generator, archives, timelapses, and other utilities">PxlsFiddle (templates, archives, etc.)</a></li>
+		</ul>
+	</div>
 </article>
 <article>
 	<header>

--- a/resources/public/info.html
+++ b/resources/public/info.html
@@ -1,6 +1,6 @@
 <article>
 	<header>
-		<h2>Welcome!</h2>
+		<h3>Welcome!</h3>
 	</header>
 	<div class="pad-wrapper">
 		<p>Welcome to pxls.space! Pxls is a multiplayer online collaborative canvas that allows you to create anything you can imagine, one pixel at a time. Join hundreds of other players in the Pxls community and create amazing works of art together as a team, or solo.</p>
@@ -10,7 +10,7 @@
 </article>
 <article id="canvas-rules">
 	<header>
-		<h2 class="text-red">Canvas Rules</h2>
+		<h3 class="text-red">Canvas Rules</h3>
 	</header>
 	<div class="pad-wrapper" id="rules-content">
 		<p>We pride ourselves on trying to keep an open canvas for all free from outside interference on our end, and especially censorship. However, for the good of the community and on accounts of our own beliefs, please acknowledge and obey the following guidelines:</p>
@@ -40,7 +40,7 @@
 </article>
 <article id="chat-rules">
 	<header>
-		<h2 class="text-red">Chat Rules</h2>
+		<h3 class="text-red">Chat Rules</h3>
 	</header>
 	<div class="pad-wrapper">
 		<ol>
@@ -68,7 +68,7 @@
 </article>
 <article>
 	<header>
-		<h2>Links</h2>
+		<h3>Links</h3>
 	</header>
 	<ul>
 		<li><a href="https://pxls.space/discord" target="_blank">Discord (main hub)</a></li>
@@ -89,7 +89,7 @@
 </article>
 <article>
 	<header>
-		<h2>Donate</h2>
+		<h3>Donate</h3>
 	</header>
 	<div class="pad-wrapper">
 		<p>Donations are not accepted at this time, but this panel will be updated when they're open again!</p>

--- a/resources/public/info.html
+++ b/resources/public/info.html
@@ -70,21 +70,22 @@
 	<header>
 		<h2>Links</h2>
 	</header>
-	<div class="pad-wrapper">
-		<a href="https://pxls.space/discord" target="_blank">Discord (main hub)</a>
-		<a href="https://reddit.com/r/pxlsspace" target="_blank">Subreddit</a>
-		<a href="https://twitter.com/pxls_space" target="_blank">Twitter</a>
-		<a href="https://facebook.com/pxls.space/" target="_blank">Facebook</a>
-		<a href="https://pxls-space.tumblr.com/" target="_blank">Tumblr</a>
-		<a href="https://vk.com/pxls.official" target="_blank">VK</a>
-		<a href="https://play.google.com/store/apps/details?id=space.pxls.android" target="_blank">Android app</a>
-		<a href="https://github.com/xSke/Pxls" target="_blank">GitHub</a>
-		<a href="https://github.com/xSke/PxlsApp" target="_blank">GitHub (App)</a>
-		<a href="http://www.piskelapp.com/p/create" target="_blank">Single-player mode</a>
-		<br>
-		<a href="https://pxls.space/stats" target="_blank">Statistics</a>
-		<a href="https://pxlsfiddle.com/" target="_blank" title="Template generator, archives, timelapses, and other utilities">PxlsFiddle (templates, archives, etc.)</a>
-	</div>
+	<ul>
+		<li><a href="https://pxls.space/discord" target="_blank">Discord (main hub)</a></li>
+		<li><a href="https://reddit.com/r/pxlsspace" target="_blank">Subreddit</a></li>
+		<li><a href="https://twitter.com/pxls_space" target="_blank">Twitter</a></li>
+		<li><a href="https://facebook.com/pxls.space/" target="_blank">Facebook</a></li>
+		<li><a href="https://pxls-space.tumblr.com/" target="_blank">Tumblr</a></li>
+		<li><a href="https://vk.com/pxls.official" target="_blank">VK</a></li>
+		<li><a href="https://play.google.com/store/apps/details?id=space.pxls.android" target="_blank">Android app</a></li>
+		<li><a href="https://github.com/xSke/Pxls" target="_blank">GitHub</a></li>
+		<li><a href="https://github.com/xSke/PxlsApp" target="_blank">GitHub (App)</a></li>
+		<li><a href="http://www.piskelapp.com/p/create" target="_blank">Single-player mode</a></li>
+	</ul>
+	<ul>
+		<li><a href="https://pxls.space/stats" target="_blank">Statistics</a></li>
+		<li><a href="https://pxlsfiddle.com/" target="_blank" title="Template generator, archives, timelapses, and other utilities">PxlsFiddle (templates, archives, etc.)</a></li>
+	</ul>
 </article>
 <article>
 	<header>


### PR DESCRIPTION
The "Links" section of the info side panel put each link on a separate line before #324. This PR returns that layout by use of formal lists rather than styling.

Also included are some minor HTML semantics changes which should have no visual impact but improve the underlying semantic structure of the document. The most contentious of these is probably the grouping of the board and it's primary ui under a single parent element - `<main>`.