### PR TITLE
Fix Chrome blurring background when using brightness setting

### DIFF
--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -2974,10 +2974,22 @@ window.App = (function() {
         const colorBrightnessSlider = $('#color-brightness');
         const colorBrightnessToggle = $('#color-brightness-toggle');
 
+        const brightnessEnabled = ls.get('brightness.enabled') === true;
+        const brightnessFixElement = $('<canvas>').attr('id', 'brightness-fixer').addClass('noselect');
+
+        if (brightnessEnabled) {
+          $('#board-mover').prepend(brightnessFixElement);
+        }
+
         colorBrightnessToggle
-          .prop('checked', ls.get('brightness.enabled') === true)
+          .prop('checked', brightnessEnabled)
           .change(function(e) {
             const isEnabled = !!this.checked;
+            if (isEnabled) {
+              $('#board-mover').prepend(brightnessFixElement);
+            } else {
+              brightnessFixElement.remove();
+            }
             ls.set('brightness.enabled', isEnabled);
             colorBrightnessSlider.prop('disabled', !isEnabled);
             self.adjustColorBrightness(isEnabled ? numOrDefault(parseFloat(ls.get('colorBrightness')), 1) : null);

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -827,6 +827,14 @@ body:not(.show-placeable-bubble) #placeableInfoBubble {
     user-select: none;
 }
 
+#brightness-fixer {
+    position: absolute;
+    pointer-events: none;
+    user-select: none;
+    /* actually just transparent but tricks chrome into thinking it has to render this element */
+    background: linear-gradient(#00000001, #00000000 0%);
+}
+
 #board-container {
     z-index: 0;
     position: fixed;


### PR DESCRIPTION
This involves layering another canvas element on top of the board. For unknown reasons, this has resulted in Chrome correctly using pixelated rendering for the board in tests. While this is ineffective for truely unrendered elements, we can trick chrome into thinking the fix element is being used by giving it a gradient background which starts at a non-transparent value and immediately becomes transparent at 0%.

This fix works for me under Chromium version `81.0.4044.138 (Official Build) Arch Linux (64-bit)` but I don't know if it fixes all cases of this bug. For this reason this PR currently leaves the warning for the brightness setting in.