### PR TITLE
Clamp final rendering scale to integer values

### DIFF
--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -277,6 +277,9 @@
                         <label><input id="setting-board-zoom-limit-enable" type="checkbox"/>Limit zoom to 50x</label>
                     </div>
                     <div>
+                        <label><input id="setting-board-zoom-rounding-enable" type="checkbox"/>Round zoom values to nearest whole number</label>
+                    </div>
+                    <div>
                         <label><input id="setting-place-palette-scrolling-enable" type="checkbox"/>Enable scrolling on the palette to switch colors</label>
                     </div>
                     <div>

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -1494,11 +1494,6 @@ window.App = (function() {
         settings.board.template.beneathoverlays.listen(function(value) {
           self.elements.container.toggleClass('lower-template', value);
         });
-
-        settings.board.zoom.rounding.enable.listen(function(value) {
-          // this rounds the current scale if it needs rounding
-          self.setScale(self.getScale());
-        });
       },
       start: function() {
         $.get('/info', (data) => {
@@ -1579,6 +1574,11 @@ window.App = (function() {
           if (color != null) {
             place.switch(parseInt(color));
           }
+
+          settings.board.zoom.rounding.enable.listen(function(value) {
+            // this rounds the current scale if it needs rounding
+            self.setScale(self.getScale());
+          });
         }).fail(function() {
           socket.reconnect();
         });

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -1694,9 +1694,17 @@ window.App = (function() {
           }
 
           if (scale > 1) {
-            scale = round(scale);
+            if (self.scale < 1) {
+              scale = 1;
+            } else {
+              scale = round(scale);
+            }
           } else {
-            scale = 2 ** round(Math.log(scale) / Math.log(2));
+            if (self.scale > 1) {
+              scale = 1;
+            } else {
+              scale = 2 ** round(Math.log(scale) / Math.log(2));
+            }
           }
         }
 

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -1228,12 +1228,12 @@ window.App = (function() {
       update: function(optional, ignoreCanvasLock = false) {
         self.pan.x = Math.min(self.width / 2, Math.max(-self.width / 2, self.pan.x));
         self.pan.y = Math.min(self.height / 2, Math.max(-self.height / 2, self.pan.y));
+        const scale = self.getScale();
         query.set({
           x: Math.round((self.width / 2) - self.pan.x),
           y: Math.round((self.height / 2) - self.pan.y),
-          scale: Math.round(self.scale * 100) / 100
+          scale: Math.round(scale * 100) / 100
         }, true);
-        const scale = self.getScale();
         if (self.use_js_render) {
           const ctx2 = self.elements.board_render[0].getContext('2d');
           let pxlX = -self.pan.x + ((self.width - (window.innerWidth / scale)) / 2);


### PR DESCRIPTION
This prevents a number of rendering artifacts present when scaling is non-integer. This includes different columns and rows of pixels being different sizes at the same scale and parts of the grid being cut-off.

The downside to this approach is that scrolling is now a lot less smooth - something most readily noticeable when using a pixel-perfect scrolling device such as a trackpad.