### PR TITLE
Fix ban element showing multiple close buttons.

### DIFF
--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -6393,7 +6393,7 @@ window.App = (function() {
             modal.show(modal.buildDom(
               crel('h2', 'Banned'),
               banelem
-            ), { escapeClose: false, clickClose: false, showClose: true });
+            ), { escapeClose: false, clickClose: false });
             if (window.deInitAdmin) {
               window.deInitAdmin();
             }


### PR DESCRIPTION
Commit cedc46ec44de4bc328f6750ed2dbbb63e81fc007 changed modal defaults
and opts to always show a close button regardless of passed options. As
a side effect, the modals which do opt to show the stock close button
now display two anchors.
I've removed the ban modal's overriding boolean, but work is required in
the future to actually honor modal options. This commit is essentially a
bandaid in preparation for reset.