### PR TITLE
Fix zoom hotkeys being inverted

### DIFF
--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -943,7 +943,7 @@ window.App = (function() {
           if (!self.allowDrag) return;
           const oldScale = self.scale;
 
-          let delta = evt.deltaY;
+          let delta = -evt.deltaY;
 
           switch (evt.deltaMode) {
             case WheelEvent.DOM_DELTA_PIXEL:
@@ -1334,7 +1334,7 @@ window.App = (function() {
         const minimumValue = maxUnlocked ? 0 : 0.5;
         const zoomBase = self.getZoomBase();
 
-        self.scale = Math.max(minimumValue, Math.min(maximumValue, self.scale * zoomBase ** -adj));
+        self.scale = Math.max(minimumValue, Math.min(maximumValue, self.scale * zoomBase ** adj));
         self.update();
       },
       getPixel: function(x, y) {


### PR DESCRIPTION
The behaviour of the `nugdeScale` function was changed in #325 such that the main parameter function inversely to how it previously did. This was done to ensure that scrolling via a mousewheel would retain the expected behaviour. This broke hotkeys whose arguments to the function did not change.

This changes the function to use a behaviour more similar to the prior one, inverting the scroll value sooner so that wheel scrolling still works as intended.
