### PR TITLE
Center undo button

### DIFF
--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -772,6 +772,7 @@ body:not(.show-placeable-bubble) #placeableInfoBubble {
     height: 0px;
     flex-flow: column;
     justify-content: center;
+    align-items: center;
     cursor: pointer;
     display: flex;
     color: #000;


### PR DESCRIPTION
This solves a problem where the undo button text was aligned to the left on Chrome rather than being centered.