### PR TITLE
Remove autoReset from list of inverted settings

### DIFF
--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -539,7 +539,7 @@ window.App = (function() {
     };
 
     // these are the settings which have gone from being toggle-off to toggle-on
-    const flippedmappings = ['audio_muted', 'increased_zoom', 'autoReset', 'canvas.unlocked'];
+    const flippedmappings = ['audio_muted', 'increased_zoom', 'canvas.unlocked'];
 
     // Convert old settings keys to new keys.
     Object.entries(keymappings).forEach((entry) => {


### PR DESCRIPTION
This was causing the setting to be incorrectly set for anyone updating
from old settings keys.