### PR TITLE
Fix grid lines not rendering at non-integer scales

### DIFF
--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -2454,9 +2454,11 @@ window.App = (function() {
       update: function() {
         const a = board.fromScreen(0, 0, false);
         const scale = board.getScale();
+        const roundedScale = Math.max(1, Math.floor(scale));
+        const scaleRoundingErrorMultiplier = scale / roundedScale;
         self.elements.grid.css({
-          backgroundSize: scale + 'px ' + scale + 'px',
-          transform: 'translate(' + Math.floor(-a.x % 1 * scale) + 'px,' + Math.floor(-a.y % 1 * scale) + 'px)',
+          backgroundSize: roundedScale + 'px ' + roundedScale + 'px',
+          transform: 'translate(' + Math.floor(-a.x % 1 * roundedScale) + 'px,' + Math.floor(-a.y % 1 * roundedScale) + 'px) scale(' + scaleRoundingErrorMultiplier + ')',
           opacity: (scale - 2) / 6
         });
       }

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -930,6 +930,7 @@ body:not(.show-placeable-bubble) #placeableInfoBubble {
     height: 110vh;
     pointer-events: none;
     background-image: linear-gradient(to right, #aaa 1px, transparent 1px), linear-gradient(to bottom, #aaa 1px, transparent 1px);
+    transform-origin: top left;
 }
 
 #settings .settingToggles > * {


### PR DESCRIPTION
This is an alternate solution to the one in #348.

This solves the problem by coercing browsers into scaling up rather than down by first flooring the scale for the grid background size and then correcting with CSS scale transforms.

This will instead cause browsers using nearest neighbor scaling here to occasionally render lines one pixel thicker than they should be. It has been decided that this is at least better than them rendering some lines at 0 pixels thickness.