### PR TITLE
Fix phantom button outlines

### DIFF
--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -282,6 +282,11 @@ button {
     margin: 0;
     border: 0;
     line-height: 1.1em;
+    outline: none;
+}
+
+ button::-moz-focus-inner {
+   outline: none;
 }
 
 button.text-button {

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -286,7 +286,7 @@ button {
 }
 
  button::-moz-focus-inner {
-   outline: none;
+    outline: none;
 }
 
 button.text-button {

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -779,6 +779,7 @@ body:not(.show-placeable-bubble) #placeableInfoBubble {
     color: var(--undo-text-color);
     font-weight: bold;
     font-size: 1.25em;
+    overflow: hidden;
 }
 
 #undo.open {


### PR DESCRIPTION
Most notably this removes the in the undo button showing an outline when it was supposed to be hidden, but this also removes the default outline browsers apply to focused buttons in general.