### PR TITLE
Fix faction canvasCode only accepting integers.

### DIFF
--- a/src/main/java/space/pxls/data/DBFaction.java
+++ b/src/main/java/space/pxls/data/DBFaction.java
@@ -13,10 +13,10 @@ public class DBFaction {
     public final String tag;
     public final int color;
     public final int owner;
-    public final int canvasCode;
+    public final String canvasCode;
     public final Timestamp created;
 
-    public DBFaction(int id, String name, String tag, int color, int owner, Timestamp created, int canvasCode) {
+    public DBFaction(int id, String name, String tag, int color, int owner, Timestamp created, String canvasCode) {
         this.id = id;
         this.name = name;
         this.tag = tag;
@@ -36,7 +36,7 @@ public class DBFaction {
                 rs.getInt("color"),
                 rs.getInt("owner"),
                 rs.getTimestamp("created"),
-                rs.getInt("canvasCode")
+                rs.getString("canvasCode")
             );
         }
     }

--- a/src/main/java/space/pxls/data/DBFactionSearch.java
+++ b/src/main/java/space/pxls/data/DBFactionSearch.java
@@ -13,12 +13,12 @@ public class DBFactionSearch {
     public final String tag;
     public final int color;
     public final int owner;
-    public final int canvasCode;
+    public final String canvasCode;
     public final int memberCount;
     public final Timestamp created;
     public final boolean userJoined;
 
-    public DBFactionSearch(int id, String name, String tag, int color, int owner, Timestamp created, int canvasCode, int memberCount, boolean memberJoined) {
+    public DBFactionSearch(int id, String name, String tag, int color, int owner, Timestamp created, String canvasCode, int memberCount, boolean memberJoined) {
         this.id = id;
         this.name = name;
         this.tag = tag;
@@ -40,7 +40,7 @@ public class DBFactionSearch {
                 rs.getInt("color"),
                 rs.getInt("owner"),
                 rs.getTimestamp("created"),
-                rs.getInt("canvasCode"),
+                rs.getString("canvasCode"),
                 rs.getInt("memberCount"),
                 rs.getBoolean("userJoined")
             );

--- a/src/main/java/space/pxls/data/Database.java
+++ b/src/main/java/space/pxls/data/Database.java
@@ -211,7 +211,7 @@ public class Database {
                 "  color INT NOT NULL DEFAULT 0," +
                 "  owner INT NOT NULL REFERENCES users(id)," +
                 "  created TIMESTAMP NOT NULL DEFAULT NOW()," +
-                "  \"canvasCode\" INT NOT NULL DEFAULT 0" +
+                "  \"canvasCode\" VARCHAR(256) NOT NULL DEFAULT 0" +
                 ");" +
                 "CREATE INDEX IF NOT EXISTS _faction_name ON faction (\"name\");" +
                 "CREATE INDEX IF NOT EXISTS _faction_tag ON faction (tag);" +
@@ -1528,7 +1528,7 @@ public class Database {
                 .bind("tag", factionTag)
                 .bind("owner", owner_uid)
                 .bind("color", _color)
-                .bind("canvasCode", App.getConfig().getInt("canvascode"))
+                .bind("canvasCode", App.getConfig().getString("canvascode"))
                 .map(new DBFaction.Mapper())
                 .findFirst()
                 .orElse(null);

--- a/src/main/java/space/pxls/server/packets/http/UserFaction.java
+++ b/src/main/java/space/pxls/server/packets/http/UserFaction.java
@@ -10,7 +10,7 @@ public class UserFaction {
     public String name;
     public String tag;
     public String owner;
-    public int canvasCode;
+    public String canvasCode;
     public long creation_ms;
     public Integer memberCount;
     public Boolean userJoined;

--- a/src/main/java/space/pxls/user/Faction.java
+++ b/src/main/java/space/pxls/user/Faction.java
@@ -1,6 +1,5 @@
 package space.pxls.user;
 
-import com.typesafe.config.Config;
 import com.typesafe.config.ConfigList;
 import com.typesafe.config.ConfigValueType;
 
@@ -10,7 +9,6 @@ import space.pxls.data.DBFactionSearch;
 import space.pxls.util.TextFilter;
 
 import java.sql.Timestamp;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -22,14 +20,14 @@ public class Faction {
     private String tag;
     private int color;
     private int owner;
-    private int canvasCode;
+    private String canvasCode;
     private Timestamp created;
     private transient List<User> _cachedMembers = null;
     private transient List<User> _cachedBans = null;
     private transient User _cachedOwner = null;
     private transient AtomicBoolean dirty = new AtomicBoolean(false);
 
-    public Faction(int id, String name, String tag, int color, int owner, Timestamp created, int canvasCode) {
+    public Faction(int id, String name, String tag, int color, int owner, Timestamp created, String canvasCode) {
         this.id = id;
         this.name = name;
         this.tag = tag;
@@ -194,7 +192,7 @@ public class Faction {
         this.color = color;
     }
 
-    public int getCanvasCode() {
+    public String getCanvasCode() {
         return canvasCode;
     }
 
@@ -206,8 +204,8 @@ public class Faction {
      *
      * @param canvasCode The canvas code
      */
-    public void setCanvasCode(int canvasCode) {
-        if (canvasCode != this.canvasCode) dirty.set(true);
+    public void setCanvasCode(String canvasCode) {
+        if (!canvasCode.equals(this.canvasCode)) dirty.set(true);
         this.canvasCode = canvasCode;
     }
 
@@ -237,7 +235,7 @@ public class Faction {
               .map(value -> value.valueType() == ConfigValueType.STRING ? (Number) Integer.decode((String) value.unwrapped()) : (Number) value.unwrapped())
               .collect(Collectors.toList())
           ).collect(Collectors.toList());
-        
+
         return input.codePoints().allMatch(i -> codePoints.stream()
             .anyMatch(pair -> (pair.size() == 1)
                 ? (i == pair.get(0).intValue())


### PR DESCRIPTION
This changes a faction's canvas code to be an string of characters instead of just a number, allowing e.g. for making factions during gimmick canvases.

Changes to the database:
```sql
ALTER TABLE faction ALTER COLUMN "canvasCode" SET DATA TYPE VARCHAR(256);
```