### PR TITLE
Fix palette number changing with button font size

### DIFF
--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -712,7 +712,7 @@ body .message {
     color: #000;
     background-color: #fff;
     border: 1px solid #000;
-    width: 2rem;
+    width: 1.5rem;
     font-size: .75rem;
     user-select: none;
     -moz-user-select: none;

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -712,8 +712,8 @@ body .message {
     color: #000;
     background-color: #fff;
     border: 1px solid #000;
-    width: 2em;
-    font-size: .75em;
+    width: 2rem;
+    font-size: .75rem;
     user-select: none;
     -moz-user-select: none;
     -ms-user-select: none;


### PR DESCRIPTION
Most user agent buttons have their own size. This sets the palette number based on the root document text size instead of their parent element.