### PR TITLE
Fix borders showing on focused buttons in Firefox

### DIFF
--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -286,7 +286,7 @@ button {
 }
 
  button::-moz-focus-inner {
-    outline: none;
+    border: 0;
 }
 
 button.text-button {


### PR DESCRIPTION
This fixes a minor mistake made when removing user-agent focus indicators from buttons. The mistake resulted in Firefox still displaying a dotted outline around a focused button.