### PR TITLE
Improve semantic structure of settings inputs

### DIFF
--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -474,11 +474,11 @@
                         <span class="label-text">Alert URL:</span>
                         <input class="fullwidth" type="text" placeholder="notify.wav" id="setting-audio-alert-src">
                     </label>
-                    <ul class="button-bar">
-                        <li><button class="text-button" id="btnForceAudioUpdate">Update</button></li>
-                        <li><button class="text-button" id="btnAlertAudioTest">Test</button></li>
-                        <li><button class="text-button" id="btnAlertReset">Reset</button></li>
-                    </ul>
+                    <div class="button-bar">
+                        <button class="text-button" id="btnForceAudioUpdate">Update</button>
+                        <button class="text-button" id="btnAlertAudioTest">Test</button>
+                        <button class="text-button" id="btnAlertReset">Reset</button>
+                    </div>
                 </div>
                 <div>
                     <label class="input-group">
@@ -505,10 +505,10 @@
                         <span class="label-text">Public Discord Name:<span>
                         <input class="fullwidth" type="text" placeholder="pxlslover#1337" id="txtDiscordName">
                     </label>
-                    <ul class="button-bar">
-                        <li><button class="text-button" id="btnDiscordNameSet">Set</button></li>
-                        <li><button class="text-button" id="btnDiscordNameRemove">Remove</button></li>
-                    </ul>
+                    <div class="button-bar">
+                        <button class="text-button" id="btnDiscordNameSet">Set</button>
+                        <button class="text-button" id="btnDiscordNameRemove">Remove</button>
+                    </div>
                 </div>
             </div>
         </article>

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -231,147 +231,147 @@
                 <p><kbd>V</kbd> to toggle visibility</p>
             </div>
         </article>
-        <article class="no-p-margin">
+        <article>
             <header>
                 <h3>General Settings</h3>
             </header>
             <div class="pad-wrapper">
-                <p>
+                <div>
                     <label class="input-group">
                         <span class="label-text">Theme:</span>
                         <select id="setting-ui-theme-index">
                             <option value="-1" selected>Default</option>
                         </select>
                     </label>
-                </p>
-                <p>
+                </div>
+                <div>
                     <label class="input-group">
                         <input id="setting-audio-enable" type="checkbox"/>
                         <span class="label-text">Enable sound</span>
                     </label>
-                </p>
-                <p>
+                </div>
+                <div>
                     <label class="input-group">
                         <input id="setting-board-heatmap-enable" type="checkbox"/>
                         <span class="label-text">Turn on heatmap</span>
                     </label>
                     <label for="setting-board-heatmap-enable">(toggle with <kbd>H</kbd>)</label>
-                </p>
-                <p>
+                </div>
+                <div>
                     <label class="input-group">
                         <input id="setting-board-virginmap-enable" type="checkbox"/>
                         <span class="label-text">Turn on virginmap</span>
                     </label>
                     <label for="setting-board-virginmap-enable">(toggle with <kbd>X</kbd>)</label>
-                </p>
-                <p>
+                </div>
+                <div>
                     <button class="text-button" id="hvmapClear">Clear heatmap and virginmap</button>
                     <label for="hvmapClear">(hotkey: <kbd>O</kbd>)</label>
-                </p>
-                <p>
+                </div>
+                <div>
                     <label class="input-group">
                         <input id="setting-board-grid-enable" type="checkbox"/>
                         <span class="label-text">Turn on grid</span>
                     </label>
                     <label for="setting-board-grid-enable">(toggle with <kbd>G</kbd>)</label>
-                </p>
-                <p>
+                </div>
+                <div>
                     <label class="input-group">
                         <input type="checkbox" id="setting-board-lock-enable">
                         <span class="label-text">Lock the canvas (disallow canvas drag/zoom with mouse/fingers)</span>
                     </label>
-                </p>
-                <p>
+                </div>
+                <div>
                     <label class="input-group">
                         <input id="setting-place-notification-enable" type="checkbox"/>
                         <span class="label-text">Enable pixel available notification</span>
                     </label>
-                </p>
-                <p>
+                </div>
+                <div>
                     <label class="input-group">
                         <input id="setting-place-deselectonplace-enable" type="checkbox"/>
                         <span class="label-text">Deselect color after placing</span>
                     </label>
-                </p>
-                <p>
+                </div>
+                <div>
                     <label class="input-group">
                         <input id="setting-lookup-monospace-enable" type="checkbox"/>
                         <span class="label-text">Toggle monospace font for lookups</span>
                     </label>
-                </p>
-                <p>
+                </div>
+                <div>
                     <label class="input-group">
                         <span class="label-text">Zoom Sensitivity:</span>
                         <input id="setting-board-zoom-sensitivity" type="range" min="1.01" max="3" step="0.01"/>
                     </label>
-                </p>
-                <p>
+                </div>
+                <div>
                     <label class="input-group">
                         <input id="setting-board-zoom-limit-enable" type="checkbox"/>
                         <span class="label-text">Limit zoom to 50x</span>
                     </label>
-                </p>
-                <p>
+                </div>
+                <div>
                     <label class="input-group">
                         <input id="setting-board-zoom-rounding-enable" type="checkbox"/>
                         <span class="label-text">Round zoom values to nearest whole number</span>
                     </label>
-                </p>
-                <p>
+                </div>
+                <div>
                     <label class="input-group">
                         <input id="setting-place-palette-scrolling-enable" type="checkbox"/>
                         <span class="label-text">Enable scrolling on the palette to switch colors</span>
                     </label>
-                </p>
-                <p>
+                </div>
+                <div>
                     <label class="input-group">
                       <input id="setting-place-palette-scrolling-invert" type="checkbox"/>
                       <span class="label-text">Invert scroll direction</span>
                     </label>
-                </p>
-                <p>
+                </div>
+                <div>
                     <label class="input-group">
                         <input id="setting-ui-reticule-enable" type="checkbox"/>
                         <span class="label-text">Show Reticule</span>
                     </label>
-                </p>
-                <p>
+                </div>
+                <div>
                     <label class="input-group">
                         <input id="setting-ui-cursor-enable" type="checkbox"/>
                         <span class="label-text">Show Cursor</span>
                     </label>
-                </p>
-                <p>
+                </div>
+                <div>
                     <label class="input-group">
                         <input id="setting-board-template-beneathoverlays" type="checkbox"/>
                         <span class="label-text">Layer Template Underneath Heatmap</span>
                     </label>
-                </p>
-                <p>
+                </div>
+                <div>
                     <label class="input-group">
                         <input id="setting-place-picker-enable" type="checkbox">
                         <span class="label-text">Enable middle mouse button selecting color from board</span>
                     </label>
-                </p>
-                <p>
+                </div>
+                <div>
                     <label class="input-group">
                         <input id="setting-ui-palette-numbers-enable" type="checkbox">
                         <span class="label-text">Add numbers to palette entries</span>
                     </label>
-                </p>
-                <p>
+                </div>
+                <div>
                     <label class="input-group">
                         <span class="label-text">Heatmap Background Opacity:</span>
                         <input type="range" min="0" max="1" step="0.01" id="setting-board-heatmap-opacity">
                     </label>
-                </p>
-                <p>
+                </div>
+                <div>
                     <label class="input-group">
                         <span class="label-text">Virginmap Background Opacity:</span>
                         <input type="range" min="0" max="1" step="0.01" id="setting-board-virginmap-opacity">
                     </label>
-                </p>
-                <p>
+                </div>
+                <div>
                     <label class="input-group">
                         <span class="label-text">Snapshot image format:</span>
                         <select id="setting-board-snapshot-format">
@@ -380,8 +380,8 @@
                             <option value="image/webp">WEBP (Chrome only)</option>
                         </select>
                     </label>
-                </p>
-                <p>
+                </div>
+                <div>
                     <label class="input-group">
                         <span class="label-text">Bubble position:</span>
                         <select id="setting-ui-bubble-position">
@@ -391,8 +391,8 @@
                             <option value="bottom right">Bottom right</option>
                         </select>
                     </label>
-                </p>
-                <p>
+                </div>
+                <div>
                     <label class="input-group">
                         <input type="checkbox" id="setting-ui-brightness-enable">
                         <span class="label-text">Enable Color Brightness</span>
@@ -404,41 +404,41 @@
                         <span class="label-text">Color Brightness:</span>
                         <input type="range" min="0" max="1" step="0.01" value="1" id="setting-ui-brightness-value">
                     </label>
-                </p>
-                <p>
+                </div>
+                <div>
                     <label class="input-group" id="chrome-canvas-offset-setting">
                         <input id="setting-fix-chrome-offset-enable" type="checkbox"/>
                         <span class="label-text">Attempt to fix Canvas displacement bug in Chrome 78+</span>
                     </label>
-                </p>
+                </div>
             </div>
         </article>
-        <article class="no-p-margin">
+        <article>
             <header>
                 <h3>Template</h3>
             </header>
             <div class="pad-wrapper">
-                <p>
+                <div>
                     <label class="input-group">
                         <input type="checkbox" id="template-use">
                         <span class="label-text">Use template</span>
                     </label>
-                </p>
+                </div>
                 <p>Hold down <kbd>Ctrl</kbd> (or <kbd>Option</kbd> on mac) to drag the template around</p>
-                <p>
+                <div>
                     <label class="input-group">
                         <span class="label-text">Title:</span>
                         <input class="fullwidth" type="text" id="template-title">
                     </label>
-                </p>
-                <p>
+                </div>
+                <div>
                     <label class="input-group">
                         <span class="label-text">URL:</span>
                         <input class="fullwidth" type="text" id="template-url">
                     </label>
                     <label id="template-image-error-warning" for="template-url" class="text-red extra-label">There was an error getting the image</label>
-                </p>
-                <p>
+                </div>
+                <div>
                     <label class="input-group">
                         <span class="label-text">Horizontal position:</span>
                         <input type="number" min="0" class="template-coords small-input" id="template-coords-x">
@@ -447,29 +447,29 @@
                         <span class="label-text">Vertical position:</span>
                         <input type="number" min="0" class="template-coords small-input" id="template-coords-y">
                     </label>
-                </p>
-                <p>
+                </div>
+                <div>
                     <label class="input-group">
                         <span class="label-text">Opacity:</span>
                         <input type="range" id="template-opacity" min="0" max="1" step="0.01" value="0.5">
                         <span class="range-text-value" id="template-opacity-percentage">50%</span>
                     </label>
-                </p>
-                <p>
+                </div>
+                <div>
                     <label class="input-group">
                         <span class="label-text">Width:</span>
                         <input type="number" id="template-width" class="small-input" min="0">
                     </label>
                     <button class="text-button" id="template-width-reset">Reset</button>
-                </p>
+                </div>
             </div>
         </article>
-        <article class="no-p-margin">
+        <article>
             <header>
                 <h3>Pixel Ready Alert Settings</h3>
             </header>
             <div class="pad-wrapper">
-                <p>
+                <div>
                     <label class="input-group">
                         <span class="label-text">Alert URL:</span>
                         <input class="fullwidth" type="text" placeholder="notify.wav" id="setting-audio-alert-src">
@@ -479,28 +479,28 @@
                         <li><button class="text-button" id="btnAlertAudioTest">Test</button></li>
                         <li><button class="text-button" id="btnAlertReset">Reset</button></li>
                     </ul>
-                </p>
-                <p>
+                </div>
+                <div>
                     <label class="input-group">
                         <span class="label-text">Volume:</span>
                         <input type="range" id="setting-audio-alert-volume" min=0 max=1 step=".01" value="1">
                         <span class="range-text-value" id="lblAlertVolume">100%</span>
                     </label>
-                </p>
-                <p>
+                </div>
+                <div>
                     <label class="input-group">
                         <span class="label-text">Delay (Seconds):</span>
                         <input type="number" width="30px" value="0" id="setting-place-alert-delay">
                     </label>
-                <p>
+                </div>
             </div>
         </article>
-        <article class="no-p-margin">
+        <article>
             <header>
                 <h3>Account Settings</h3>
             </header>
             <div class="pad-wrapper">
-                <p>
+                <div>
                     <label class="input-group">
                         <span class="label-text">Public Discord Name:<span>
                         <input class="fullwidth" type="text" placeholder="pxlslover#1337" id="txtDiscordName">
@@ -509,7 +509,7 @@
                         <li><button class="text-button" id="btnDiscordNameSet">Set</button></li>
                         <li><button class="text-button" id="btnDiscordNameRemove">Remove</button></li>
                     </ul>
-                </p>
+                </div>
             </div>
         </article>
     </div>

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -122,8 +122,12 @@
     <div class="content">
       <h1>Sign up</h1>
       <h4>Pick a username</h4>
-
-      <label>Username: <input type="text" maxlength="32"></label>
+      <p>
+          <label class="input-group">
+              <span class="label-text">Username:</span>
+              <input id="signup-username-input" type="text" maxlength="32">
+          </label>
+      </p>
       <div class="error" id="error"></div>
     </div>
     <button id="signup-button" class="float-right text-button">Sign up</button>
@@ -203,211 +207,309 @@
             </header>
             <div class="pad-wrapper">
                 <h4>General</h4>
-                <div class="indent-1">
-                    <p>Mouse/arrows/wasd to pan</p>
-                    <p>Scroll/pinch to zoom</p>
-                    <p><kbd>+</kbd>/<kbd>-</kbd> or <kbd>Q</kbd>/<kbd>E</kbd> to zoom</p>
-                    <p><kbd>Shift</kbd> + Click/Hold touch to lookup pixel</p>
-                    <p><kbd>G</kbd> to toggle grid</p>
-                    <p><kbd>I</kbd> to open info</p>
-                    <p><kbd>T</kbd> to open settings</p>
-                    <p><kbd>B</kbd> to open chat</p>
-                    <p><kbd>L</kbd> to toggle locking panning of the canvas</p>
-                    <p><kbd>P</kbd> to take a snapshot</p>
-                    <p><kbd>H</kbd> to toggle heatmap</p>
-                    <p><kbd>X</kbd> to toggle virginmap</p>
-                    <p><kbd>O</kbd> to clear heatmap and virginmap (if either is enabled)</p>
-                    <p><kbd>J</kbd>/<kbd>K</kbd> to cycle through palette colors</p>
-                    <p><kbd>C</kbd> to copy link of moused-over coordinates</p>
-                    <p><kbd>ESC</kbd> to deselect current pixel</p>
-                    <p><kbd>R</kbd> to center the board on the current template</p>
-                </div>
+                <p>Mouse/arrows/wasd to pan</p>
+                <p>Scroll/pinch to zoom</p>
+                <p><kbd>+</kbd>/<kbd>-</kbd> or <kbd>Q</kbd>/<kbd>E</kbd> to zoom</p>
+                <p><kbd>Shift</kbd> + Click/Hold touch to lookup pixel</p>
+                <p><kbd>G</kbd> to toggle grid</p>
+                <p><kbd>I</kbd> to open info</p>
+                <p><kbd>T</kbd> to open settings</p>
+                <p><kbd>B</kbd> to open chat</p>
+                <p><kbd>L</kbd> to toggle locking panning of the canvas</p>
+                <p><kbd>P</kbd> to take a snapshot</p>
+                <p><kbd>H</kbd> to toggle heatmap</p>
+                <p><kbd>X</kbd> to toggle virginmap</p>
+                <p><kbd>O</kbd> to clear heatmap and virginmap (if either is enabled)</p>
+                <p><kbd>J</kbd>/<kbd>K</kbd> to cycle through palette colors</p>
+                <p><kbd>C</kbd> to copy link of moused-over coordinates</p>
+                <p><kbd>ESC</kbd> to deselect current pixel</p>
+                <p><kbd>R</kbd> to center the board on the current template</p>
+
                 <h4>Template</h4>
-                <div class="indent-1">
-                    <p><kbd>Page Up</kbd> to increase opacity</p>
-                    <p><kbd>Page Down</kbd> to decrease opacity</p>
-                    <p><kbd>V</kbd> to toggle visibility</p>
-                </div>
+                <p><kbd>Page Up</kbd> to increase opacity</p>
+                <p><kbd>Page Down</kbd> to decrease opacity</p>
+                <p><kbd>V</kbd> to toggle visibility</p>
             </div>
         </article>
-        <article>
+        <article class="no-p-margin">
             <header>
                 <h3>General Settings</h3>
             </header>
             <div class="pad-wrapper">
-                <div class="settingToggles">
-                    <div class="lblwrap">
-                        <label>Theme:
-                            <select id="setting-ui-theme-index">
-                                <option value="-1" selected>Default</option>
-                            </select>
-                        </label>
-                    </div>
-                    <div>
-                        <label><input id="setting-audio-enable" type="checkbox"/>Enable sound</label>
-                    </div>
-                    <div>
-                        <label><input id="setting-board-heatmap-enable" type="checkbox"/>Turn on heatmap (toggle with <kbd>H</kbd>)</label>
-                    </div>
-                    <div>
-                        <label><input id="setting-board-virginmap-enable" type="checkbox"/>Turn on virginmap (toggle with <kbd>X</kbd>)</label>
-                    </div>
-                    <div>
-                        <button class="text-button" id="hvmapClear">Clear heatmap and virginmap</button> (hotkey: <kbd>O</kbd>)
-                    </div>
-                    <div>
-                        <label><input id="setting-board-grid-enable" type="checkbox"/>Turn on grid (toggle with <kbd>G</kbd>)</label>
-                    </div>
-                    <div>
-                        <label><input type="checkbox" id="setting-board-lock-enable">Lock the canvas (disallow canvas drag/zoom with mouse/fingers)</label>
-                    </div>
-                    <div>
-                        <label><input id="setting-place-notification-enable" type="checkbox"/>Enable pixel available notification</label>
-                    </div>
-                    <div>
-                        <label><input id="setting-place-deselectonplace-enable" type="checkbox"/>Deselect color after placing</label>
-                    </div>
-                    <div>
-                        <label><input id="setting-lookup-monospace-enable" type="checkbox"/>Toggle monospace font for lookups</label>
-                    </div>
-                    <div>
-                      <label>Zoom Sensitivity: <input id="setting-board-zoom-sensitivity" type="range" min="1.01" max="3" step="0.01"/></label>
-                    </div>
-                    <div>
-                        <label><input id="setting-board-zoom-limit-enable" type="checkbox"/>Limit zoom to 50x</label>
-                    </div>
-                    <div>
-                        <label><input id="setting-board-zoom-rounding-enable" type="checkbox"/>Round zoom values to nearest whole number</label>
-                    </div>
-                    <div>
-                        <label><input id="setting-place-palette-scrolling-enable" type="checkbox"/>Enable scrolling on the palette to switch colors</label>
-                    </div>
-                    <div>
-                        <label style="text-indent:1em"><input id="setting-place-palette-scrolling-invert" type="checkbox"/>Invert scroll direction</label>
-                    </div>
-                    <div>
-                        <label><input id="setting-ui-reticule-enable" type="checkbox"/>Show Reticule</label>
-                    </div>
-                    <div>
-                        <label><input id="setting-ui-cursor-enable" type="checkbox"/>Show Cursor</label>
-                    </div>
-                    <div>
-                        <label><input id="setting-board-template-beneathoverlays" type="checkbox"/>Layer Template Underneath Heatmap</label>
-                    </div>
-                    <div>
-                        <label><input id="setting-place-picker-enable" type="checkbox">Enable middle mouse button selecting color from board</label>
-                    </div>
-                    <div>
-                        <label><input id="setting-ui-palette-numbers-enable" type="checkbox"> Add numbers to palette entries</label>
-                    </div>
-                    <div>
-                        <label>Heatmap Background Opacity: <input type="range" min="0" max="1" step="0.01" id="setting-board-heatmap-opacity"></label>
-                    </div>
-                    <div>
-                        <label>Virginmap Background Opacity: <input type="range" min="0" max="1" step="0.01" id="setting-board-virginmap-opacity"></label>
-                    </div>
-                    <div>
-                        <label>
-                            Snapshot (hotkey: <kbd>P</kbd>) image format
-                            <select id="setting-board-snapshot-format">
-                                <option value="image/png" selected>PNG</option>
-                                <option value="image/jpeg">JPEG</option>
-                                <option value="image/webp">WEBP (Chrome only)</option>
-                            </select>
-                        </label>
-                    </div>
-                    <div>
-                        Bubble position
-                        <div id="bubble-position">
-                            <label>
-                                <input type="radio" name="setting-ui-bubble-position" value="top left" />
-                                <div></div>
-                            </label>
-                            <label>
-                                <input type="radio" name="setting-ui-bubble-position" value="top right" />
-                                <div></div>
-                            </label>
-                            <label>
-                                <input type="radio" name="setting-ui-bubble-position" value="bottom left" />
-                                <div></div>
-                            </label>
-                            <label>
-                                <input type="radio" name="setting-ui-bubble-position" value="bottom right" />
-                                <div></div>
-                            </label>
-                        </div>
-                    </div>
-
-
-                </div>
-                <div>
-                    <p><label class="vertical-spacing"><input type="checkbox" id="setting-ui-brightness-enable"> Enable Color Brightness</label></p>
-                    <p><label class="text-orange fake-indent"><i class="fas fa-exclamation-triangle"></i> Warning: Known to cause fuzziness in Chrome on some Mac/Linux installs</label></p>
-                    <p><label class="fake-indent">Color Brightness: <input type="range" min="0" max="1" step="0.01" value="1" id="setting-ui-brightness-value"></label></p>
-                </div>
-                <label id="chrome-canvas-offset-setting"><input id="setting-fix-chrome-offset-enable" type="checkbox"/>Attempt to fix Canvas displacement bug in Chrome 78+</label>
+                <p>
+                    <label class="input-group">
+                        <span class="label-text">Theme:</span>
+                        <select id="setting-ui-theme-index">
+                            <option value="-1" selected>Default</option>
+                        </select>
+                    </label>
+                </p>
+                <p>
+                    <label class="input-group">
+                        <input id="setting-audio-enable" type="checkbox"/>
+                        <span class="label-text">Enable sound</span>
+                    </label>
+                </p>
+                <p>
+                    <label class="input-group">
+                        <input id="setting-board-heatmap-enable" type="checkbox"/>
+                        <span class="label-text">Turn on heatmap</span>
+                    </label>
+                    <label for="setting-board-heatmap-enable">(toggle with <kbd>H</kbd>)</label>
+                </p>
+                <p>
+                    <label class="input-group">
+                        <input id="setting-board-virginmap-enable" type="checkbox"/>
+                        <span class="label-text">Turn on virginmap</span>
+                    </label>
+                    <label for="setting-board-virginmap-enable">(toggle with <kbd>X</kbd>)</label>
+                </p>
+                <p>
+                    <button class="text-button" id="hvmapClear">Clear heatmap and virginmap</button>
+                    <label for="hvmapClear">(hotkey: <kbd>O</kbd>)</label>
+                </p>
+                <p>
+                    <label class="input-group">
+                        <input id="setting-board-grid-enable" type="checkbox"/>
+                        <span class="label-text">Turn on grid</span>
+                    </label>
+                    <label for="setting-board-grid-enable">(toggle with <kbd>G</kbd>)</label>
+                </p>
+                <p>
+                    <label class="input-group">
+                        <input type="checkbox" id="setting-board-lock-enable">
+                        <span class="label-text">Lock the canvas (disallow canvas drag/zoom with mouse/fingers)</span>
+                    </label>
+                </p>
+                <p>
+                    <label class="input-group">
+                        <input id="setting-place-notification-enable" type="checkbox"/>
+                        <span class="label-text">Enable pixel available notification</span>
+                    </label>
+                </p>
+                <p>
+                    <label class="input-group">
+                        <input id="setting-place-deselectonplace-enable" type="checkbox"/>
+                        <span class="label-text">Deselect color after placing</span>
+                    </label>
+                </p>
+                <p>
+                    <label class="input-group">
+                        <input id="setting-lookup-monospace-enable" type="checkbox"/>
+                        <span class="label-text">Toggle monospace font for lookups</span>
+                    </label>
+                </p>
+                <p>
+                    <label class="input-group">
+                        <span class="label-text">Zoom Sensitivity:</span>
+                        <input id="setting-board-zoom-sensitivity" type="range" min="1.01" max="3" step="0.01"/>
+                    </label>
+                </p>
+                <p>
+                    <label class="input-group">
+                        <input id="setting-board-zoom-limit-enable" type="checkbox"/>
+                        <span class="label-text">Limit zoom to 50x</span>
+                    </label>
+                </p>
+                <p>
+                    <label class="input-group">
+                        <input id="setting-board-zoom-rounding-enable" type="checkbox"/>
+                        <span class="label-text">Round zoom values to nearest whole number</span>
+                    </label>
+                </p>
+                <p>
+                    <label class="input-group">
+                        <input id="setting-place-palette-scrolling-enable" type="checkbox"/>
+                        <span class="label-text">Enable scrolling on the palette to switch colors</span>
+                    </label>
+                </p>
+                <p>
+                    <label class="input-group">
+                      <input id="setting-place-palette-scrolling-invert" type="checkbox"/>
+                      <span class="label-text">Invert scroll direction</span>
+                    </label>
+                </p>
+                <p>
+                    <label class="input-group">
+                        <input id="setting-ui-reticule-enable" type="checkbox"/>
+                        <span class="label-text">Show Reticule</span>
+                    </label>
+                </p>
+                <p>
+                    <label class="input-group">
+                        <input id="setting-ui-cursor-enable" type="checkbox"/>
+                        <span class="label-text">Show Cursor</span>
+                    </label>
+                </p>
+                <p>
+                    <label class="input-group">
+                        <input id="setting-board-template-beneathoverlays" type="checkbox"/>
+                        <span class="label-text">Layer Template Underneath Heatmap</span>
+                    </label>
+                </p>
+                <p>
+                    <label class="input-group">
+                        <input id="setting-place-picker-enable" type="checkbox">
+                        <span class="label-text">Enable middle mouse button selecting color from board</span>
+                    </label>
+                </p>
+                <p>
+                    <label class="input-group">
+                        <input id="setting-ui-palette-numbers-enable" type="checkbox">
+                        <span class="label-text">Add numbers to palette entries</span>
+                    </label>
+                </p>
+                <p>
+                    <label class="input-group">
+                        <span class="label-text">Heatmap Background Opacity:</span>
+                        <input type="range" min="0" max="1" step="0.01" id="setting-board-heatmap-opacity">
+                    </label>
+                </p>
+                <p>
+                    <label class="input-group">
+                        <span class="label-text">Virginmap Background Opacity:</span>
+                        <input type="range" min="0" max="1" step="0.01" id="setting-board-virginmap-opacity">
+                    </label>
+                </p>
+                <p>
+                    <label class="input-group">
+                        <span class="label-text">Snapshot image format:</span>
+                        <select id="setting-board-snapshot-format">
+                            <option value="image/png" selected>PNG</option>
+                            <option value="image/jpeg">JPEG</option>
+                            <option value="image/webp">WEBP (Chrome only)</option>
+                        </select>
+                    </label>
+                </p>
+                <p>
+                    <label class="input-group">
+                        <span class="label-text">Bubble position:</span>
+                        <select id="setting-ui-bubble-position">
+                            <option value="top left">Top left</option>
+                            <option value="top right">Top right</option>
+                            <option value="bottom left" selected>Bottom left</option>
+                            <option value="bottom right">Bottom right</option>
+                        </select>
+                    </label>
+                </p>
+                <p>
+                    <label class="input-group">
+                        <input type="checkbox" id="setting-ui-brightness-enable">
+                        <span class="label-text">Enable Color Brightness</span>
+                    </label>
+                    <label for="setting-ui-brightness-enable" class="text-orange extra-label">
+                        <i class="fas fa-exclamation-triangle"></i> Warning: Known to cause fuzziness in Chrome on some Mac/Linux installs
+                    </label>
+                    <label class="input-group fake-indent">
+                        <span class="label-text">Color Brightness:</span>
+                        <input type="range" min="0" max="1" step="0.01" value="1" id="setting-ui-brightness-value">
+                    </label>
+                </p>
+                <p>
+                    <label class="input-group" id="chrome-canvas-offset-setting">
+                        <input id="setting-fix-chrome-offset-enable" type="checkbox"/>
+                        <span class="label-text">Attempt to fix Canvas displacement bug in Chrome 78+</span>
+                    </label>
+                </p>
             </div>
         </article>
-        <article>
+        <article class="no-p-margin">
             <header>
                 <h3>Template</h3>
             </header>
             <div class="pad-wrapper">
-                <div>
-                    <label><input type="checkbox" id="template-use"> Use template</label>
-                </div>
+                <p>
+                    <label class="input-group">
+                        <input type="checkbox" id="template-use">
+                        <span class="label-text">Use template</span>
+                    </label>
+                </p>
                 <p>Hold down <kbd>Ctrl</kbd> (or <kbd>Option</kbd> on mac) to drag the template around</p>
                 <p>
-                    <label>Title:</label>
-                    <input class="fullwidth" type="text" id="template-title">
+                    <label class="input-group">
+                        <span class="label-text">Title:</span>
+                        <input class="fullwidth" type="text" id="template-title">
+                    </label>
                 </p>
                 <p>
-                    <label>URL:</label>
-                    <input class="fullwidth" type="text" id="template-url">
-                    <span id="template-image-error-warning" class="text-red">There was an error getting the image</span>
+                    <label class="input-group">
+                        <span class="label-text">URL:</span>
+                        <input class="fullwidth" type="text" id="template-url">
+                    </label>
+                    <label id="template-image-error-warning" for="template-url" class="text-red extra-label">There was an error getting the image</label>
                 </p>
-                <div>
-                    <label>Position: <input type="number" min="0" class="template-coords small-input" id="template-coords-x">, <input type="number" min="0" class="template-coords small-input" id="template-coords-y"></label>
-                </div>
-                <div>
-                    <label>Opacity: <input type="range" id="template-opacity" min="0" max="1" step="0.01"></label>
-                    <span id="template-opacity-percentage">100%</span>
-                </div>
-                <div>
-                    <label>Width: <input type="number" id="template-width" class="small-input" min="0"></label>
+                <p>
+                    <label class="input-group">
+                        <span class="label-text">Horizontal position:</span>
+                        <input type="number" min="0" class="template-coords small-input" id="template-coords-x">
+                    </label>
+                    <label class="input-group">
+                        <span class="label-text">Vertical position:</span>
+                        <input type="number" min="0" class="template-coords small-input" id="template-coords-y">
+                    </label>
+                </p>
+                <p>
+                    <label class="input-group">
+                        <span class="label-text">Opacity:</span>
+                        <input type="range" id="template-opacity" min="0" max="1" step="0.01" value="0.5">
+                        <span class="range-text-value" id="template-opacity-percentage">50%</span>
+                    </label>
+                </p>
+                <p>
+                    <label class="input-group">
+                        <span class="label-text">Width:</span>
+                        <input type="number" id="template-width" class="small-input" min="0">
+                    </label>
                     <button class="text-button" id="template-width-reset">Reset</button>
-                </div>
+                </p>
             </div>
         </article>
-        <article>
+        <article class="no-p-margin">
             <header>
                 <h3>Pixel Ready Alert Settings</h3>
             </header>
             <div class="pad-wrapper">
-                <p><label for="setting-audio-alert-src">Alert URL:</label><input class="fullwidth" type="text" placeholder="notify.wav" id="setting-audio-alert-src"></p>
-                <div class="button-bar">
-                    <button class="text-button" id="btnForceAudioUpdate">Update</button>
-                    <button class="text-button" id="btnAlertAudioTest">Test</button>
-                    <button class="text-button" id="btnAlertReset">Reset</button>
-                </div>
-                <div>
-                    <label for="setting-audio-alert-volume">Volume:</label>
-                    <input type="range" id="setting-audio-alert-volume" min=0 max=1 step=".01" value=1>
-                    <span id="lblAlertVolume"></span>
-                </div>
-                <label style="display: block;">Delay (Seconds): <input type="number" width="30px" value="0" id="setting-place-alert-delay"></label>
+                <p>
+                    <label class="input-group">
+                        <span class="label-text">Alert URL:</span>
+                        <input class="fullwidth" type="text" placeholder="notify.wav" id="setting-audio-alert-src">
+                    </label>
+                    <ul class="button-bar">
+                        <li><button class="text-button" id="btnForceAudioUpdate">Update</button></li>
+                        <li><button class="text-button" id="btnAlertAudioTest">Test</button></li>
+                        <li><button class="text-button" id="btnAlertReset">Reset</button></li>
+                    </ul>
+                </p>
+                <p>
+                    <label class="input-group">
+                        <span class="label-text">Volume:</span>
+                        <input type="range" id="setting-audio-alert-volume" min=0 max=1 step=".01" value="1">
+                        <span class="range-text-value" id="lblAlertVolume">100%</span>
+                    </label>
+                </p>
+                <p>
+                    <label class="input-group">
+                        <span class="label-text">Delay (Seconds):</span>
+                        <input type="number" width="30px" value="0" id="setting-place-alert-delay">
+                    </label>
+                <p>
             </div>
         </article>
-        <article>
+        <article class="no-p-margin">
             <header>
                 <h3>Account Settings</h3>
             </header>
             <div class="pad-wrapper">
-                <p><label for="txtDiscordName">Public Discord Name:</label><input class="fullwidth" type="text" placeholder="pxlslover#1337" id="txtDiscordName"></p>
-                <div class="button-bar">
-                    <button class="text-button" id="btnDiscordNameSet">Set</button>
-                    <button class="text-button" id="btnDiscordNameRemove">Remove</button>
-                </div>
+                <p>
+                    <label class="input-group">
+                        <span class="label-text">Public Discord Name:<span>
+                        <input class="fullwidth" type="text" placeholder="pxlslover#1337" id="txtDiscordName">
+                    </label>
+                    <ul class="button-bar">
+                        <li><button class="text-button" id="btnDiscordNameSet">Set</button></li>
+                        <li><button class="text-button" id="btnDiscordNameRemove">Remove</button></li>
+                    </ul>
+                </p>
             </div>
         </article>
     </div>

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -4921,7 +4921,7 @@ window.App = (function() {
             lblUsernameColor,
             lblIgnores,
             lblIgnoresFeedback
-          ].map(x => crel('p', x))
+          ].map(x => crel('div', x))
         );
         modal.show(modal.buildDom(
           crel('h2', { class: 'modal-title' }, 'Chat Settings'),

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -4766,21 +4766,10 @@ window.App = (function() {
           return [cb, lbl];
         };
 
-        const a24hTimestamps = genCheckboxGroup('24 Hour Timestamps');
-        const _cb24hTimestamps = a24hTimestamps[0];
-        const lbl24hTimestamps = a24hTimestamps[1];
-
-        const aPixelPlaceBadges = genCheckboxGroup('Show pixel-placed badges');
-        const _cbPixelPlaceBadges = aPixelPlaceBadges[0];
-        const lblPixelPlaceBadges = aPixelPlaceBadges[1];
-
-        const aFactionTagBadges = genCheckboxGroup('Show faction tags');
-        const _cbFactionTagBadges = aFactionTagBadges[0];
-        const lblFactionTagBadges = aFactionTagBadges[1];
-
-        const aPings = genCheckboxGroup('Enable pings');
-        const _cbPings = aPings[0];
-        const lblPings = aPings[1];
+        const [_cb24hTimestamps, lbl24hTimestamps] = genCheckboxGroup('24 Hour Timestamps');
+        const [_cbPixelPlaceBadges, lblPixelPlaceBadges] = genCheckboxGroup('Show pixel-placed badges');
+        const [_cbFactionTagBadges, lblFactionTagBadges] = genCheckboxGroup('Show faction tags');
+        const [_cbPings, lblPings] = genCheckboxGroup('Enable pings');
 
         const _cbPingAudio = crel('select', {},
           crel('option', { value: 'off' }, 'Off'),
@@ -4800,13 +4789,8 @@ window.App = (function() {
           _txtPingAudioVol
         );
 
-        const aBanner = genCheckboxGroup('Enable the rotating banner under chat');
-        const _cbBanner = aBanner[0];
-        const lblBanner = aBanner[1];
-
-        const aTemplateTitles = genCheckboxGroup('Replace template titles with URLs in chat where applicable');
-        const _cbTemplateTitles = aTemplateTitles[0];
-        const lblTemplateTitles = aTemplateTitles[1];
+        const [_cbBanner, lblBanner] = genCheckboxGroup('Enable the rotating banner under chat');
+        const [_cbTemplateTitles, lblTemplateTitles] = genCheckboxGroup('Replace template titles with URLs in chat where applicable');
 
         const _txtFontSize = crel('input', { type: 'number', min: '1', max: '72' });
         const _btnFontSizeConfirm = crel('button', { class: 'text-button' }, crel('i', { class: 'fas fa-check' }));
@@ -4815,9 +4799,7 @@ window.App = (function() {
           _txtFontSize
         );
 
-        const aHorizontal = genCheckboxGroup('Enable horizontal chat');
-        const _cbHorizontal = aHorizontal[0];
-        const lblHorizontal = aHorizontal[1];
+        const [_cbHorizontal, lblHorizontal] = genCheckboxGroup('Enable horizontal chat');
 
         const _selInternalClick = crel('select',
           Object.values(self.TEMPLATE_ACTIONS).map(action =>

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -562,7 +562,7 @@ window.App = (function() {
           enable: setting('ui.cursor.enable', SettingType.TOGGLE, !possiblyMobile, $('#setting-ui-cursor-enable'))
         },
         bubble: {
-          position: setting('ui.bubble.position', SettingType.RADIO, 'bottom left', $('[name=setting-ui-bubble-position]'))
+          position: setting('ui.bubble.position', SettingType.SELECT, 'bottom left', $('#setting-ui-bubble-position'))
         },
         brightness: {
           enable: setting('ui.brightness.enable', SettingType.TOGGLE, false, $('#setting-ui-brightness-enable')),
@@ -4755,57 +4755,79 @@ window.App = (function() {
       getIgnores: () => [].concat(self.ignored || []),
       popChatSettings() {
         // dom generation
-        const body = crel('div', { class: 'chat-settings-wrapper' });
+        const body = crel('div', { class: 'chat-settings-wrapper no-p-margin' });
 
-        const _cb24hTimestamps = crel('input', { type: 'checkbox' });
-        const lbl24hTimestamps = crel('label', _cb24hTimestamps, '24 Hour Timestamps');
+        const genCheckboxGroup = (label) => {
+          const cb = crel('input', { type: 'checkbox' });
+          const lbl = crel('label', { class: 'input-group' },
+            cb,
+            ' ',
+            crel('span', { class: 'label-text' }, label));
+          return [cb, lbl];
+        };
 
-        const _cbPixelPlaceBadges = crel('input', { type: 'checkbox' });
-        const lblPixelPlaceBadges = crel('label', _cbPixelPlaceBadges, 'Show pixel-placed badges');
+        const a24hTimestamps = genCheckboxGroup('24 Hour Timestamps');
+        const _cb24hTimestamps = a24hTimestamps[0];
+        const lbl24hTimestamps = a24hTimestamps[1];
 
-        const _cbFactionTagBadges = crel('input', { type: 'checkbox' });
-        const lblFactionTagBadges = crel('label', _cbFactionTagBadges, 'Show faction tags');
+        const aPixelPlaceBadges = genCheckboxGroup('Show pixel-placed badges');
+        const _cbPixelPlaceBadges = aPixelPlaceBadges[0];
+        const lblPixelPlaceBadges = aPixelPlaceBadges[1];
 
-        const _cbPings = crel('input', { type: 'checkbox' });
-        const lblPings = crel('label', _cbPings, 'Enable pings');
+        const aFactionTagBadges = genCheckboxGroup('Show faction tags');
+        const _cbFactionTagBadges = aFactionTagBadges[0];
+        const lblFactionTagBadges = aFactionTagBadges[1];
+
+        const aPings = genCheckboxGroup('Enable pings');
+        const _cbPings = aPings[0];
+        const lblPings = aPings[1];
 
         const _cbPingAudio = crel('select', {},
           crel('option', { value: 'off' }, 'Off'),
           crel('option', { value: 'discrete' }, 'Only when necessary'),
           crel('option', { value: 'always' }, 'Always')
         );
-        const lblPingAudio = crel('label',
-          'Play sound on ping: ',
+        const lblPingAudio = crel('label', { class: 'input-group' },
+          crel('span', { class: 'label-text' }, 'Play sound on ping: '),
           _cbPingAudio
         );
 
         const _rgPingAudioVol = crel('input', { type: 'range', min: 0, max: 1, step: 0.01 });
-        const _txtPingAudioVol = crel('span');
-        const lblPingAudioVol = crel('label',
-          'Ping sound volume: ',
+        const _txtPingAudioVol = crel('span', { class: 'range-text-value' });
+        const lblPingAudioVol = crel('label', { class: 'input-group' },
+          crel('span', { class: 'label-text' }, 'Ping sound volume: '),
           _rgPingAudioVol,
           _txtPingAudioVol
         );
 
-        const _cbBanner = crel('input', { type: 'checkbox' });
-        const lblBanner = crel('label', _cbBanner, 'Enable the rotating banner under chat');
+        const aBanner = genCheckboxGroup('Enable the rotating banner under chat');
+        const _cbBanner = aBanner[0];
+        const lblBanner = aBanner[1];
 
-        const _cbTemplateTitles = crel('input', { type: 'checkbox' });
-        const lblTemplateTitles = crel('label', _cbTemplateTitles, 'Replace template titles with URLs in chat where applicable');
+        const aTemplateTitles = genCheckboxGroup('Replace template titles with URLs in chat where applicable');
+        const _cbTemplateTitles = aTemplateTitles[0];
+        const lblTemplateTitles = aTemplateTitles[1];
 
         const _txtFontSize = crel('input', { type: 'number', min: '1', max: '72' });
         const _btnFontSizeConfirm = crel('button', { class: 'text-button' }, crel('i', { class: 'fas fa-check' }));
-        const lblFontSize = crel('label', 'Font Size: ', _txtFontSize, _btnFontSizeConfirm);
+        const lblFontSize = crel('label', { class: 'input-group' },
+          crel('span', { class: 'label-text' }, 'Font Size: '),
+          _txtFontSize
+        );
 
-        const _cbHorizontal = crel('input', { type: 'checkbox' });
-        const lblHorizontal = crel('label', _cbHorizontal, 'Enable horizontal chat');
+        const aHorizontal = genCheckboxGroup('Enable horizontal chat');
+        const _cbHorizontal = aHorizontal[0];
+        const lblHorizontal = aHorizontal[1];
 
         const _selInternalClick = crel('select',
           Object.values(self.TEMPLATE_ACTIONS).map(action =>
             crel('option', { value: action.id }, action.pretty)
           )
         );
-        const lblInternalAction = crel('label', 'Default internal link action click: ', _selInternalClick);
+        const lblInternalAction = crel('label', { class: 'input-group' },
+          crel('span', { class: 'label-text' }, 'Default internal link action click: '),
+          _selInternalClick
+        );
 
         const _selUsernameColor = crel('select', { class: 'username-color-picker' },
           user.isStaff() ? crel('option', { value: -1, class: 'rainbow' }, 'rainbow') : null,
@@ -4815,7 +4837,10 @@ window.App = (function() {
             style: `background-color: ${x}`
           }, x))
         );
-        const lblUsernameColor = crel('label', 'Username Color: ', _selUsernameColor);
+        const lblUsernameColor = crel('label', { class: 'input-group' },
+          crel('span', { class: 'label-text' }, 'Username Color: '),
+          _selUsernameColor
+        );
 
         const _selIgnores = crel('select', {
           class: 'user-ignores',
@@ -4825,9 +4850,12 @@ window.App = (function() {
           crel('option', { value: x }, x)
         )
         );
-        const _btnUnignore = crel('button', { class: 'text-button', style: 'margin-left: .5rem' }, 'Unignore');
-        const lblIgnores = crel('label', 'Ignores: ', _selIgnores, _btnUnignore);
-        const lblIgnoresFeedback = crel('label', { style: 'display: none; margin-left: 1rem;' }, '');
+        const _btnUnignore = crel('button', { class: 'text-button' }, 'Unignore');
+        const lblIgnores = crel('label', { class: 'input-group' },
+          crel('span', { class: 'label-text' }, 'Ignores: '),
+          _selIgnores
+        );
+        const lblIgnoresFeedback = crel('label', { for: _selIgnores.id, class: 'extra-label' }, '');
 
         // events/scaffolding
         _selUsernameColor.value = user.getChatNameColor();
@@ -4893,7 +4921,7 @@ window.App = (function() {
             lblUsernameColor,
             lblIgnores,
             lblIgnoresFeedback
-          ].map(x => crel('div', x))
+          ].map(x => crel('p', x))
         );
         modal.show(modal.buildDom(
           crel('h2', { class: 'modal-title' }, 'Chat Settings'),

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -963,37 +963,20 @@ body:not(.show-placeable-bubble) #placeableInfoBubble {
     display: inline-flex !important;
 }
 
-.button-bar > * {
+.button-bar > button {
     flex: 1 0 auto;
-}
-
-ul.button-bar {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-}
-
-ul.button-bar > li {
-    margin: 0;
-    padding: 0;
-}
-
-.button-bar button {
+    padding: 5px;
     margin: 0;
     border-width: 1px;
     border-radius: 0;
 }
 
-ul.button-bar > li > button {
-    width: 100%;
-}
-
-.button-bar > button:first-child, .button-bar > :first-child button {
+.button-bar > button:first-child {
     border-top-left-radius: 5px;
     border-bottom-left-radius: 5px;
 }
 
-.button-bar > button:last-child, .button-bar > :last-child button {
+.button-bar > button:last-child {
     border-top-right-radius: 5px;
     border-bottom-right-radius: 5px;
 }

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -224,15 +224,6 @@ kbd {
     user-select: none;
 }
 
-.indent-1 {
-    text-indent: 0.75em;
-}
-
-.vertical-spacing {
-    margin-top: .5em;
-    margin-bottom: .5em;
-}
-
 .fake-indent {
     margin-left:1.2rem;
 }
@@ -245,8 +236,16 @@ kbd {
   font-family: monospace;
 }
 
+label.extra-label {
+    display: block;
+    margin-top: .25em;
+    margin-bottom: .5em;
+    text-indent: 1em;
+}
+
 input:disabled, button:disabled {
     cursor: not-allowed;
+    opacity: 0.5;
 }
 
 input[type="text"], input[type="number"], textarea, select {
@@ -257,6 +256,14 @@ input[type="text"], input[type="number"], textarea, select {
     background: var(--input-background);
     color: #000;
     color: var(--input-text-color);
+}
+
+input.small-input {
+    width: 6em;
+}
+
+.input-group > * {
+    vertical-align: middle;
 }
 
 /* NOTE (Flying): Does not work grouped together. */
@@ -391,6 +398,10 @@ dt {
 .chat-lookup-side {
     max-height: calc(88vh - 30px);
     overflow: auto;
+}
+
+.no-p-margin p {
+    margin: 0 !important;
 }
 
 /*//////////////////////////*\
@@ -939,21 +950,6 @@ body:not(.show-placeable-bubble) #placeableInfoBubble {
     transform-origin: top left;
 }
 
-#settings .settingToggles > * {
-    margin: 3px 0;
-}
-
-#settings .settingToggles > label {
-    display: block;
-}
-
-#settings input.small-input {
-    width: 6em;
-}
-#settings input[disabled] {
-    opacity: 0.5;
-}
-
 #template-image-error-warning {
     margin-bottom: 0.5em;
     display: inline-block;
@@ -971,20 +967,37 @@ body:not(.show-placeable-bubble) #placeableInfoBubble {
     display: inline-flex !important;
 }
 
-.button-bar > button {
+.button-bar > * {
     flex: 1 0 auto;
-    padding: 5px;
+}
+
+ul.button-bar {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+ul.button-bar > li {
+    margin: 0;
+    padding: 0;
+}
+
+.button-bar button {
     margin: 0;
     border-width: 1px;
     border-radius: 0;
 }
 
-.button-bar > button:first-child {
+ul.button-bar > li > button {
+    width: 100%;
+}
+
+.button-bar > button:first-child, .button-bar > :first-child button {
     border-top-left-radius: 5px;
     border-bottom-left-radius: 5px;
 }
 
-.button-bar > button:last-child {
+.button-bar > button:last-child, .button-bar > :last-child button {
     border-top-right-radius: 5px;
     border-bottom-right-radius: 5px;
 }
@@ -1275,6 +1288,10 @@ aside.panel.horizontal.right {
     margin: .5rem 0;
 }
 
+.panel-body article > header ~ :not(footer) > h4 ~ :not(h4) {
+    text-indent: 0.75em;
+}
+
 .panel-body article > header h1, .panel-body article > header h2, .panel-body article > header h3, .panel-body article > header h4, .panel-body article > header h5, .panel-body article > header h6 {
     font-size: x-large;
     text-align: center;
@@ -1283,14 +1300,6 @@ aside.panel.horizontal.right {
 
 .panel-body article .pad-wrapper {
     padding: .5rem;
-}
-
-.panel-body article input[type="range"] {
-    vertical-align: middle;
-}
-
-.no-p-margin p {
-    margin: 0 !important;
 }
 
 body.panel-open.panel-left #ui {

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -106,10 +106,6 @@ html {
 
     --panel-trigger-outline-color: #AAA;
 
-    --option-bubble-position-border-color-hovered: #6495ED;
-    --option-bubble-position-background-hovered: rgba(0, 0, 0, 0);
-    --option-bubble-position-background-selected: #eee;
-
     --chat-separator-color: #bfbfbf;
     --chat-odd-background: #d5d5d5;
     --chat-abbr-underline-color: #aaa;
@@ -1904,44 +1900,6 @@ body .emoji-picker {
     border-bottom: 1px solid #000;
     border-bottom: 1px solid var(--panel-border-color);
     text-align: center;
-}
-
-/* Settings tweaks */
-#bubble-position {
-    width: 0;
-    grid-template: repeat(2, 1fr) / repeat(2, .5fr);
-    display: grid;
-}
-
-#bubble-position label {
-    position: relative;
-    width: 55px;
-    height: 30px;
-}
-
-#bubble-position label > input {
-    visibility: hidden;
-}
-
-#bubble-position label > div {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: inherit;
-    height: inherit;
-    border: 1px solid #797979;
-}
-
-#bubble-position label:hover > div {
-    border: 2px solid #6495ED;
-    border: 2px solid var(--option-bubble-position-border-color-hovered);
-    background: rgba(0, 0, 0, 0);
-    background: var(--option-bubble-position-background-hovered);
-}
-
-#bubble-position label input:checked ~ div {
-    background: #eee;
-    background: var(--option-bubble-position-background-selected);
 }
 
 /* Chat settings tweaks */

--- a/resources/public/themes/blue.css
+++ b/resources/public/themes/blue.css
@@ -35,8 +35,6 @@ html {
     --panel-background: #043aee;
     --panel-text-color: #eee;
 
-    --option-bubble-position-background-selected: #03f;
-
     --chat-separator-color: #0d47f4;
     --chat-odd-background: #0234d9;
     --chat-server-action-text-color: #dae0ec;

--- a/resources/public/themes/dark.css
+++ b/resources/public/themes/dark.css
@@ -38,7 +38,6 @@ html {
     --panel-footer-background: #2e2e2e;
     --panel-footer-text-color: #666;
     
-    --option-bubble-position-background-selected: #9d9d9d;
     --chat-separator-color: #4f4f4f;
     --chat-odd-background: #3f3f3f;
     --chat-server-action-text-color: #9f9f9f;

--- a/resources/public/themes/darker.css
+++ b/resources/public/themes/darker.css
@@ -43,8 +43,6 @@ html {
     --panel-footer-background: #252525;
     --panel-footer-text-color: #999;
     
-    --option-bubble-position-background-selected: #fff;
-    
     --chat-separator-color:#2f2f2f;
     --chat-odd-background:#111;
     --chat-server-action-text-color:#ccc;

--- a/resources/public/themes/purple.css
+++ b/resources/public/themes/purple.css
@@ -80,10 +80,6 @@ html {
 
     --panel-trigger-outline-color: #AAA;
 
-    --option-bubble-position-border-color-hovered: #797979;
-    --option-bubble-position-background-hovered: #683683;
-    --option-bubble-position-background-selected: #8445a7;
-
     --chat-separator-color: #000;
     --chat-odd-background: rgba(0, 0, 0, 0.1);
     --chat-abbr-underline-color: var(--general-text-color);


### PR DESCRIPTION
This does several things to improve the semantics and structure of input fields used for settings as well as improving consistency.

- Input elements are now wrapped in a label.
- Labels containing an input element have their text content wrapped by an element with the `label-text` class.
- Setting fields are now grouped using paragraph elements.
- Extra text that provide additional information about a field (such as warnings and error messages) is now a label for the input of that field.

In addition to these changes, a couple of specific changes were made to individual setting fields:
- The bubble position setting is now a simple select input.
- The template position label was broken into horizontal and vertical parts.

Finally, `button-bar`s were changed from being generic to using lists. This change was incited by requiring an element allowed inside of paragraph elements be used. `ul` worked for this and also holds some useful semantic meaning given that `button-bar`s are flat, unordered sets of usually two or more buttons.