### PR TITLE
personal info rule and profile link

### DIFF
--- a/resources/public/info.html
+++ b/resources/public/info.html
@@ -58,11 +58,7 @@
 			<li>No "copy pasta"s</li>
 			<li>No links to sites that actively break the canvas or chat rules (e.g. porn sites)</li>
 			<li>No symbology which break the canvas or chat rules (e.g. NSFW ASCII art)</li>
-     			<li>No personal info
-				<ul>
-					<li>This includes ip's/adresses or any other revealing info. Some info such as names and age is allowed </li>
-				</ul>
-			</li>
+     			<li>No personal information</li>
 			<li>Staff have final say in any rule disputes
 				<ul>
 					<li>If you feel a moderator has acted inappropriately, please report it to an administrator.</li>

--- a/resources/public/info.html
+++ b/resources/public/info.html
@@ -58,6 +58,11 @@
 			<li>No "copy pasta"s</li>
 			<li>No links to sites that actively break the canvas or chat rules (e.g. porn sites)</li>
 			<li>No symbology which break the canvas or chat rules (e.g. NSFW ASCII art)</li>
+     			<li>No personal info
+				<ul>
+					<li>This includes ip's/adresses or any other revealing info. Some info such as names and age is allowed </li>
+				</ul>
+			</li>
 			<li>Staff have final say in any rule disputes
 				<ul>
 					<li>If you feel a moderator has acted inappropriately, please report it to an administrator.</li>
@@ -85,6 +90,7 @@
 		</ul>
 		<ul>
 			<li><a href="https://pxls.space/stats" target="_blank">Statistics</a></li>
+     			<li><a href="https://pxls.space/profile" target="_blank">Profile (user info, factions, etc.)</a></li>
 			<li><a href="https://pxlsfiddle.com/" target="_blank" title="Template generator, archives, timelapses, and other utilities">PxlsFiddle (templates, archives, etc.)</a></li>
 		</ul>
 	</div>
@@ -97,9 +103,3 @@
 		<p>Donations are not accepted at this time, but this panel will be updated when they're open again!</p>
 	</div>
 </article>
-
-
-
-
-
-


### PR DESCRIPTION
In separate pr per flying's request. Deleted some extra white space as well. Noticed that profile link wasn't in there so I added it too.