### PR TITLE
Unpixelate various elements when scale is less than 1

### DIFF
--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -1683,6 +1683,8 @@ window.App = (function() {
         }
 
         self.elements.board.toggleClass('pixelate', scale > 1);
+        overlays.heatmap.setPixelated(scale > 1);
+        overlays.virginmap.setPixelated(scale > 1);
         template.setPixelated(scale > template.getWidthRatio());
 
         if (ignoreCanvasLock || self.allowDrag || (!self.allowDrag && self.pannedWithKeys)) {
@@ -2011,7 +2013,10 @@ window.App = (function() {
         },
         setShown: self.setShown,
         remove: self.remove,
-        reload: self.reload
+        reload: self.reload,
+        setPixelated: function(pixelate = true) {
+          $(self.elements.overlay).toggleClass('pixelate', pixelate);
+        }
       };
     };
 

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -1681,11 +1681,10 @@ window.App = (function() {
         if (optional) {
           return false;
         }
-        if (scale < 1) {
-          self.elements.board.removeClass('pixelate');
-        } else {
-          self.elements.board.addClass('pixelate');
-        }
+
+        self.elements.board.toggleClass('pixelate', scale > 1);
+        template.setPixelated(scale > template.getWidthRatio());
+
         if (ignoreCanvasLock || self.allowDrag || (!self.allowDrag && self.pannedWithKeys)) {
           self.elements.mover.css({
             width: self.width,
@@ -2218,7 +2217,7 @@ window.App = (function() {
           x: 0,
           y: 0
         };
-        self.elements.template = $('<img>').addClass('noselect pixelate').attr({
+        self.elements.template = $('<img>').addClass('noselect').attr({
           id: 'board-template',
           src: self.options.url,
           alt: 'template'
@@ -2263,6 +2262,7 @@ window.App = (function() {
           if (self.options.width < 0) {
             self.elements.widthInput.val(self.elements.template.width());
           }
+          self.elements.template.toggleClass('pixelate', query.get('scale') > self.getWidthRatio());
         }).on('error', () => {
           self.elements.imageErrorWarning.show();
           self.elements.template.remove();
@@ -2392,6 +2392,8 @@ window.App = (function() {
           self.updateSettings();
         }
         document.title = uiHelper.getTitle();
+
+        self.setPixelated(query.get('scale') > self.getWidthRatio());
       },
       disableTemplate: function() {
         self._update({ url: null });
@@ -2478,6 +2480,18 @@ window.App = (function() {
         if (self.options.use) {
           self.elements.template.css('pointer-events', 'none').data('dragging', false);
         }
+      },
+      setPixelated: function(pixelate = true) {
+        if (self.elements.template !== null) {
+          self.elements.template.toggleClass('pixelate', pixelate);
+        }
+      },
+      getWidthRatio: function() {
+        if (self.elements.template === null || self.options.width === -1) {
+          return 1;
+        }
+
+        return self.elements.template[0].naturalWidth / self.options.width;
       }
     };
     return {
@@ -2486,7 +2500,9 @@ window.App = (function() {
       draw: self.draw,
       init: self.init,
       queueUpdate: self.queueUpdate,
-      getOptions: () => self.options
+      getOptions: () => self.options,
+      setPixelated: self.setPixelated,
+      getWidthRatio: self.getWidthRatio
     };
   })();
     // here all the grid stuff happens


### PR DESCRIPTION
This gives parity to template, heatmap, and virginmap when compared to the canvas which already behaved like this. This applies to templates when there is theoretically less than 1 actual pixel per template pixel. This allows softer and less artifacted templates when working at lower scales.

One notable implication of this is that templates will appear transparent at scales around 1 rather than appearing fully solid as before. This is technically a more accurate representation of what the template should look like at that zoom level, but many users abuse this rendering quirk as a feature and may be confused by this change.