### PR TITLE
Fix Chrome Offset Workaround not updating the board size on load.

### DIFF
--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -6887,7 +6887,6 @@ window.App = (function() {
     // by a pixel when the window size is odd.
   const chromeOffsetWorkaround = (function() {
     const self = {
-      isEnabled: false,
       elements: {
         boardContainer: board.getContainer(),
         setting: $('#chrome-canvas-offset-setting')
@@ -6926,7 +6925,7 @@ window.App = (function() {
     return {
       init: self.init,
       update: () => {
-        if (self.isEnabled) {
+        if (settings.fix.chrome.offset.enable.get()) {
           self.updateContainer();
         }
       }


### PR DESCRIPTION
Replaces `chromeOffsetWorkaround.isEnabled`, which was always false, with `settings.fix.chrome.offset.enable.get()`. `chromeOffsetWorkaround.isEnabled` was used on `chromeOffsetWorkaround.update()` to determine whether to update the board size or not.