### PR TITLE
Make /profile/ (empty username) return the current user's profile.

### DIFF
--- a/src/main/java/space/pxls/server/WebHandler.java
+++ b/src/main/java/space/pxls/server/WebHandler.java
@@ -139,7 +139,7 @@ public class WebHandler {
             view40x(exchange, 403, null);
         } else {
             PathTemplateMatch match = exchange.getAttachment(PathTemplateMatch.ATTACHMENT_KEY);
-            String requested = match.getParameters().computeIfAbsent("who", s -> user.getName());
+            String requested = match.getParameters().compute("who", (k, s) -> (s == null || s.isEmpty()) ? user.getName() : s);
             boolean requested_self = user.getName().equals(requested); // usernames are case-sensitive, we can use #equals relatively safely.
             User profileUser = requested_self ? user : App.getUserManager().getByName(requested);
 


### PR DESCRIPTION
Before /profile/ would always return a 404 page since there was no user with an empty username. This was specially annoying on Firefox, which autocompletes "https://pxls.space/profile" with a leading `/`.