### PR TITLE
Add UNIQUE constraint to usernames on the database

### DIFF
--- a/src/main/java/space/pxls/data/Database.java
+++ b/src/main/java/space/pxls/data/Database.java
@@ -71,7 +71,7 @@ public class Database {
             // users
             handle.createUpdate("CREATE TABLE IF NOT EXISTS users (" +
                     "id SERIAL NOT NULL PRIMARY KEY," +
-                    "username VARCHAR(32) NOT NULL," +
+                    "username VARCHAR(32) UNIQUE NOT NULL," +
                     "login VARCHAR(64) NOT NULL," +
                     "signup_time TIMESTAMP NOT NULL DEFAULT NOW()," +
                     "cooldown_expiry TIMESTAMP," +


### PR DESCRIPTION
This will aid on debugging a bug where an user is inserted twice in the database with the same username.

### Get a list of users with the same username before running the migration
```sql
SELECT id, username FROM users u1 WHERE (SELECT count(id) FROM users u2 WHERE u2.username = u1.username) > 1 AND login != 'staff:overwrite';
```

Then set the username of each unused user (usually the one with the highest id) to something unique (e.g. "staff_overwrite.{old username}_{id}"), and remove all sessions from those users and restart Pxls.

### Migration steps (optional but preferred) (not tested)
```sql
ALTER TABLE users ADD CONSTRAINT users_unique_name UNIQUE (username);
```