### PR TITLE
Fix templates appearing blurry at 1-to-1 scales.

### DIFF
--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -1677,9 +1677,9 @@ window.App = (function() {
         }
 
         self.elements.board.toggleClass('pixelate', scale > 1);
-        overlays.heatmap.setPixelated(scale > 1);
-        overlays.virginmap.setPixelated(scale > 1);
-        template.setPixelated(scale > template.getWidthRatio());
+        overlays.heatmap.setPixelated(scale >= 1);
+        overlays.virginmap.setPixelated(scale >= 1);
+        template.setPixelated(scale >= template.getWidthRatio());
 
         if (ignoreCanvasLock || self.allowDrag || (!self.allowDrag && self.pannedWithKeys)) {
           self.elements.mover.css({
@@ -2392,7 +2392,7 @@ window.App = (function() {
         }
         document.title = uiHelper.getTitle();
 
-        self.setPixelated(query.get('scale') > self.getWidthRatio());
+        self.setPixelated(query.get('scale') >= self.getWidthRatio());
       },
       disableTemplate: function() {
         self._update({ url: null });


### PR DESCRIPTION
While some browsers had no issue rendering this properly as a non-blurry perfect image, others apparently struggled. This should coerce them into rendering it more appealingly and shouldn't affect browsers that already rendered correctly.