### PR TITLE
Fix rendering of emojis with Variant Selectors.

### DIFF
--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -4041,7 +4041,7 @@ window.App = (function() {
             alt: node.emojiName,
             title: `:${node.emojiName}:`,
             draggable: false,
-            src: `${twemoji.base}${twemoji.size}/${twemoji.convert.toCodePoint(node.value)}${twemoji.ext}`
+            src: `${twemoji.base}${twemoji.size}/${twemoji.convert.toCodePoint(node.value.replace(/[\uFE00-\uFE0F]$/, ''))}${twemoji.ext}`
           });
 
           this.Compiler.prototype.visitors.link = (node, next) => {


### PR DESCRIPTION
Removes https://codepoints.net/variation_selectors from the emoji node value before converting them emoji to code points, as twemoji's CDN endpoint doesn't include these characters.

This should fix emojis like ™, which works both as a normal unicode character and an emoji (when the variant selector character is included).