### PR TITLE
Use `twemoji.parse` to get the twemoji image element instead of creating one ourselves.

### DIFF
--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -4042,13 +4042,11 @@ window.App = (function() {
           inline: ['coordinate', 'emoji_raw', 'emoji_name', 'mention', 'escape', 'autoLink', 'url', 'underline', 'strong', 'emphasis', 'deletion', 'code']
         })
         .use(function() {
-          this.Compiler.prototype.visitors.emoji = (node, next) => crel('img', {
-            class: 'emoji',
-            alt: node.emojiName,
-            title: `:${node.emojiName}:`,
-            draggable: false,
-            src: `${twemoji.base}${twemoji.size}/${twemoji.convert.toCodePoint(node.value.replace(/[\uFE00-\uFE0F]$/, ''))}${twemoji.ext}`
-          });
+          this.Compiler.prototype.visitors.emoji = (node, next) => {
+            const el = twemoji.parse(crel('span', node.value)).children[0];
+            el.title = `:${node.emojiName}:`;
+            return el;
+          };
 
           this.Compiler.prototype.visitors.link = (node, next) => {
             const url = new URL(node.url, location.href);


### PR DESCRIPTION
While this adds the overhead of Twemoji having to search and parse the emoji itself, it should cover all bases for rendering emojis correctly.