### PR TITLE
Fix middle-clicking on a template link not doing anything

### DIFF
--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -5421,7 +5421,7 @@ window.App = (function() {
           }
         }
 
-        return crel('span', {
+        return crel('a', {
           class: 'link coordinates',
           dataset: {
             raw,
@@ -5431,6 +5431,7 @@ window.App = (function() {
             template,
             title
           },
+          href: raw,
           onclick: handleClick
         }, text);
       },


### PR DESCRIPTION
Fixes middle-mouse clicking on a template link in chat from not opening the link at all by changing the element to an `a` tag and adding an href attribute.