### PR TITLE
Fix rainbow and donator chat colors permission check on the client

### DIFF
--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -4970,8 +4970,8 @@ window.App = (function() {
         );
 
         const _selUsernameColor = crel('select', { class: 'username-color-picker' },
-          user.isStaff() ? crel('option', { value: -1, class: 'rainbow' }, 'rainbow') : null,
-          user.isDonator() ? crel('option', { value: -2, class: 'donator' }, 'donator') : null,
+          user.hasPermission('chat.usercolor.rainbow') ? crel('option', { value: -1, class: 'rainbow' }, 'rainbow') : null,
+          user.hasPermission('chat.usercolor.donator') ? crel('option', { value: -2, class: 'donator' }, 'donator') : null,
           place.getPalette().map((x, i) => crel('option', {
             value: i,
             'data-idx': i,


### PR DESCRIPTION
The options now appear if the user has the individual chat.usercolor.*