### PR TITLE
Send place ACK when a shadow banned user places a pixel.

### DIFF
--- a/src/main/java/space/pxls/server/PacketHandler.java
+++ b/src/main/java/space/pxls/server/PacketHandler.java
@@ -285,6 +285,7 @@ public class PacketHandler {
                                 for (WebSocketChannel ch : user.getConnections()) {
                                     server.send(ch, msg);
                                 }
+                                ackPlace(user, cp.getX(), cp.getY());
                                 if (user.canUndo(false)) {
                                     server.send(channel, new ServerCanUndo(App.getConfig().getDuration("undo.window", TimeUnit.SECONDS)));
                                 }


### PR DESCRIPTION
Fixes shadow banned users not hearing the place sound.