### PR TITLE
Fix profiles of permabanned users showing epoch time as the ban expiry

### DIFF
--- a/src/main/java/space/pxls/user/User.java
+++ b/src/main/java/space/pxls/user/User.java
@@ -346,6 +346,10 @@ public class User {
         return banExpiryTime;
     }
 
+    public boolean isPermaBanned() {
+        return banExpiryTime == 0;
+    }
+
     private void setBanExpiryTime(Integer timeFromNowSeconds) {
         setBanExpiryTime(timeFromNowSeconds, false);
     }
@@ -618,13 +622,13 @@ public class User {
     public boolean hasRainbowChatNameColor() {
         return hasPermission("chat.usercolor.rainbow")
                 && this.chatNameColor == -1;
-        
+
     }
-    
+
      public boolean hasDonatorChatNameColor() {
         return hasPermission("chat.usercolor.donator")
                 && this.chatNameColor == -2;
-        
+
     }
 
     public int getChatNameColor() {


### PR DESCRIPTION
Readds user.isPermaBanned(), which returns true if the ban expiry of the user is exactly 0 (epoch).

Apparently Pebble doesn't throw an error when a method is not found, and instead returns false (?)