### PR TITLE
Render alert contents as markdown

### DIFF
--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -3410,7 +3410,7 @@ window.App = (function() {
         socket.on('alert', (data) => {
           modal.show(modal.buildDom(
             crel('h2', { class: 'modal-title' }, 'Alert'),
-            crel('p', { style: 'padding: 0; margin: 0;' }, data.message),
+            crel('p', { style: 'padding: 0; margin: 0;' }, chat.processMessage(data.message)),
             crel('span', `Sent from ${data.sender || '$Unknown'}`)
           ), { closeExisting: false });
         });


### PR DESCRIPTION
Quick change to allow markdown inside alert popups.

![markdown in alerts](https://user-images.githubusercontent.com/6181929/96351755-e7324380-1093-11eb-8c32-6a539cf3bcb8.png)
