### PR TITLE
Fix some issues with admin logging

### DIFF
--- a/src/main/java/space/pxls/App.java
+++ b/src/main/java/space/pxls/App.java
@@ -493,6 +493,7 @@ public class App {
                     if (toFlag != null) {
                         System.out.printf("Flagging %s as %s%n", toFlag.getName(), flagState);
                         toFlag.setRenameRequested(flagState);
+                        App.getDatabase().insertServerAdminLog(String.format("%s %s (%d) for name change", flagState ? "Flagged" : "Unflagged", toFlag.getName(), toFlag.getId()));
                     } else {
                         System.out.println("User doesn't exist");
                     }
@@ -507,6 +508,7 @@ public class App {
                         toRename.setRenameRequested(false);
                         if (toRename.updateUsername(token[2], true)) {
                             App.getServer().send(toRename, new ServerRenameSuccess(toRename.getName()));
+                            App.getDatabase().insertServerAdminLog(String.format("Changed %s's name to %s (uid: %d)", token[1], token[2], toRename.getId()));
                             System.out.println("Name updated");
                         } else {
                             System.out.println("Failed to update name (function returned false. name taken or an error occurred)");

--- a/src/main/java/space/pxls/App.java
+++ b/src/main/java/space/pxls/App.java
@@ -252,6 +252,7 @@ public class App {
                 String message = String.join(" ", rest);
                 App.getDatabase().insertServerAdminLog(String.format("Sent a server-wide broadcast with the content: %s", message));
                 server.broadcast(new ServerAlert("console", message));
+                System.out.println("Alert sent");
             } else if (token[0].equalsIgnoreCase("ban")) {
                 if (token.length < 2) {
                     System.out.println("Usage: ban <username> [reason]");

--- a/src/main/java/space/pxls/data/Database.java
+++ b/src/main/java/space/pxls/data/Database.java
@@ -1356,7 +1356,7 @@ public class Database {
                 .execute());
         String initiatorName = initiator == null ? "CONSOLE" : initiator.getName();
         int initiatorID = initiator == null ? 0 : initiator.getId();
-        String logReason = reason != null && reason.length() > 0 ? " because: " + reason : "";
+        String logReason = reason != null && reason.length() > 0 ? " with reason: " + reason : "";
         String logMessage = String.format("<%s, %s> purged %s messages from <%s, %s>%s.", initiatorName, initiatorID, amount, target.getName(), target.getId(), logReason);
         if (initiator == null) {
             insertServerAdminLog(logMessage);
@@ -1383,7 +1383,7 @@ public class Database {
                 .execute());
         String initiatorName = initiator == null ? "CONSOLE" : initiator.getName();
         int initiatorID = initiator == null ? 0 : initiator.getId();
-        String logReason = reason != null && reason.length() > 0 ? " because: " + reason : "";
+        String logReason = reason != null && reason.length() > 0 ? " with reason: " + reason : "";
         String logMessage = String.format("<%s, %s> purged message with id %d from <%s, %s>%s.", initiatorName, initiatorID, id, target.getName(), target.getId(), logReason);
         if (initiator == null) {
             insertServerAdminLog(logMessage);

--- a/src/main/java/space/pxls/data/Database.java
+++ b/src/main/java/space/pxls/data/Database.java
@@ -1357,7 +1357,12 @@ public class Database {
         String initiatorName = initiator == null ? "CONSOLE" : initiator.getName();
         int initiatorID = initiator == null ? 0 : initiator.getId();
         String logReason = reason != null && reason.length() > 0 ? " because: " + reason : "";
-        insertServerAdminLog(String.format("<%s, %s> purged %s messages from <%s, %s>%s.", initiatorName, initiatorID, amount, target.getName(), target.getId(), logReason));
+        String logMessage = String.format("<%s, %s> purged %s messages from <%s, %s>%s.", initiatorName, initiatorID, amount, target.getName(), target.getId(), logReason);
+        if (initiator == null) {
+            insertServerAdminLog(logMessage);
+        } else {
+            insertAdminLog(initiatorID, logMessage);
+        }
         if (broadcast) {
             App.getServer().getPacketHandler().sendChatPurge(target, initiator, amount, reason);
         }
@@ -1379,7 +1384,12 @@ public class Database {
         String initiatorName = initiator == null ? "CONSOLE" : initiator.getName();
         int initiatorID = initiator == null ? 0 : initiator.getId();
         String logReason = reason != null && reason.length() > 0 ? " because: " + reason : "";
-        insertServerAdminLog(String.format("<%s, %s> purged message with id %d from <%s, %s>%s.", initiatorName, initiatorID, id, target.getName(), target.getId(), logReason));
+        String logMessage = String.format("<%s, %s> purged message with id %d from <%s, %s>%s.", initiatorName, initiatorID, id, target.getName(), target.getId(), logReason);
+        if (initiator == null) {
+            insertServerAdminLog(logMessage);
+        } else {
+            insertAdminLog(initiatorID, logMessage);
+        }
         if (broadcast) {
             App.getServer().getPacketHandler().sendSpecificPurge(target, initiator, id, reason);
         }

--- a/src/main/java/space/pxls/server/WebHandler.java
+++ b/src/main/java/space/pxls/server/WebHandler.java
@@ -1118,7 +1118,7 @@ public class WebHandler {
         }
 
         toFlag.setRenameRequested(isRequested);
-        App.getDatabase().insertAdminLog(user.getId(), String.format("Flagged %s (%d) for name change", toFlag.getName(), toFlag.getId()));
+        App.getDatabase().insertAdminLog(user.getId(), String.format("%s %s (%d) for name change", isRequested ? "Flagged" : "Unflagged", toFlag.getName(), toFlag.getId()));
 
         exchange.setStatusCode(200);
         exchange.getResponseSender().send("{}");


### PR DESCRIPTION
It is advised to merge and deploy this PR along with pxlsspace/PxlsAdmin#17.

- Insert chat purge admin logs with an user ID, so that they appear on the "user" column of the admin panel
- Change "because: ..." with "with reason: ..." on chat purge logs
- Specify if the user was flagged or unflagged for a rename when admin logging
- Insert server admin logs when flagging or forcing renames through commands

Also:
- Send a confirmation message when an alert is sent through commands.