### PR TITLE
Expose default board as /initialboarddata

### DIFF
--- a/src/main/java/space/pxls/App.java
+++ b/src/main/java/space/pxls/App.java
@@ -751,6 +751,10 @@ public class App {
         return board;
     }
 
+    public static byte[] getDefaultBoardData() {
+        return defaultBoard;
+    }
+
     public static boolean getHavePlacemap() {
         return havePlacemap;
     }

--- a/src/main/java/space/pxls/server/UndertowServer.java
+++ b/src/main/java/space/pxls/server/UndertowServer.java
@@ -56,6 +56,7 @@ public class UndertowServer {
                 .addPermGatedPrefixPath("/heatmap", "board.data", webHandler::heatmap)
                 .addPermGatedPrefixPath("/virginmap", "board.data", webHandler::virginmap)
                 .addPermGatedPrefixPath("/placemap", "board.data", webHandler::placemap)
+                .addPermGatedPrefixPath("/initialboarddata", "board.data", webHandler::initialdata)
                 .addPermGatedPrefixPath("/auth", "user.auth", new RateLimitingHandler(webHandler::auth, "http:auth", (int) App.getConfig().getDuration("server.limits.auth.time", TimeUnit.SECONDS), App.getConfig().getInt("server.limits.auth.count")))
                 .addPermGatedPrefixPath("/signin", "user.auth", webHandler::signIn)
                 .addPermGatedPrefixPath("/signup", "user.auth", new RateLimitingHandler(webHandler::signUp, "http:signUp", (int) App.getConfig().getDuration("server.limits.signup.time", TimeUnit.SECONDS), App.getConfig().getInt("server.limits.signup.count")))

--- a/src/main/java/space/pxls/server/WebHandler.java
+++ b/src/main/java/space/pxls/server/WebHandler.java
@@ -1679,6 +1679,14 @@ public class WebHandler {
         exchange.getResponseSender().send(ByteBuffer.wrap(App.getBoardData()));
     }
 
+    public void initialdata(HttpServerExchange exchange) {
+        exchange.getResponseHeaders()
+                .put(Headers.CONTENT_TYPE, "application/binary")
+                .put(HttpString.tryFromString("Access-Control-Allow-Origin"), "*");
+
+        exchange.getResponseSender().send(ByteBuffer.wrap(App.getDefaultBoardData()));
+    }
+
     public void heatmap(HttpServerExchange exchange) {
         exchange.getResponseHeaders()
                 .put(Headers.CONTENT_TYPE, "application/binary")


### PR DESCRIPTION
Exposes the default_board.dat file as an endpoint on the server. This allows third party developers to retrieve this information at any time on the canvas and use it for their own applications.

For example, https://pxlsfiddle.com can benefit from this by automating the default_board.dat retrieval process, since as far as I know the initial state is uploaded manually every new canvas from the image posted on our Discord.