### PR TITLE
Handle console command scanner erroring on shutdown

### DIFF
--- a/src/main/java/space/pxls/App.java
+++ b/src/main/java/space/pxls/App.java
@@ -98,8 +98,13 @@ public class App {
 
         new Thread(() -> {
             Scanner s = new Scanner(System.in);
-            while (true) {
-                handleCommand(s.nextLine());
+            try {
+                while (true) {
+                    handleCommand(s.nextLine());
+                }
+            } catch (NoSuchElementException ex) {
+                // System.in closed, program is shutting down.
+                s.close();
             }
         }).start();
 
@@ -111,6 +116,7 @@ public class App {
         new Timer().schedule(new HeatmapTimer(), 0, heatmap_timer_cd * 1000 / 256);
 
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            System.out.println("Saving map before shutdown...");
             saveMapBackup();
             saveMapForce();
         }));


### PR DESCRIPTION
The exception was preventing the shutdown hook from firing on certain cases, potentially losing board progress.