### PR TITLE
Make emote/custom emoji size dependant on the width and not the height.

### DIFF
--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -4181,7 +4181,7 @@ window.App = (function() {
             } else {
               el = document.createElement('img');
               el.draggable = false;
-              el.className = 'customEmoji';
+              el.className = 'emoji emoji--custom';
               el.alt = node.emojiName;
               el.src = node.value;
               el.title = `:${node.emojiName}:`;
@@ -4759,7 +4759,7 @@ window.App = (function() {
       },
       initTypeahead() {
         // init DBs
-        const dbEmojis = new TH.Database('emoji', {}, false, false, (x) => (twemoji.test(x.value)) ? x.value : ':' + x.key + ':', (x) => (twemoji.test(x.value)) ? `${twemoji.parse(x.value)} :${x.key}:` : `${'<img class="customEmoji" draggable="false" alt="' + x.key + '" src="' + x.value + '"/>'} :${x.key}:`);
+        const dbEmojis = new TH.Database('emoji', {}, false, false, (x) => (twemoji.test(x.value)) ? x.value : ':' + x.key + ':', (x) => (twemoji.test(x.value)) ? `${twemoji.parse(x.value)} :${x.key}:` : `${'<img class="emoji emoji--custom" draggable="false" alt="' + x.key + '" src="' + x.value + '"/>'} :${x.key}:`);
         const dbUsers = new TH.Database('users', {}, false, false, (x) => `@${x.value} `, (x) => `@${x.value}`);
 
         // add emoji to emoji DB

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -237,10 +237,9 @@ img.emoji {
     vertical-align: -0.1em;
 }
 
-img.customEmoji {
-    height: auto;
-    width: 1.5em;
-    margin: 0 .05em 0 .1em;
+img.emoji.emoji--custom {
+    height: 1.5em;
+    width: auto;
     vertical-align: middle;
 }
 


### PR DESCRIPTION
Allows for wide emotes to span more of the chat horizontally, instead of long emotes spanning more of the chat diagonally.

#### Before / After
![image](https://user-images.githubusercontent.com/6181929/102792484-56276380-4387-11eb-847b-4f5805197609.png)


Also, makes emotes/custom emoji a subclass of emoji.