### PR TITLE
Add Donator Gray username color to chat

### DIFF
--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -3486,7 +3486,7 @@ window.App = (function() {
           color: '#cf0000'
         }
       ],
-      specialChatColorClasses: ['rainbow', 'donator'],
+      specialChatColorClasses: ['rainbow', ['donator', 'donator--green'], ['donator', 'donator--gray']],
       init: function() {
         self.initTitle = document.title;
         self._initThemes();
@@ -3893,7 +3893,10 @@ window.App = (function() {
         return self._available;
       },
       styleElemWithChatNameColor: (elem, colorIdx, layer = 'bg') => {
-        elem.classList.remove(...self.specialChatColorClasses);
+        elem.classList.remove(...self.specialChatColorClasses.reduce((acc, val) => {
+          acc.push(...(Array.isArray(val) ? val : [val]));
+          return acc;
+        }, []));
         if (colorIdx >= 0) {
           switch (layer) {
             case 'bg':
@@ -3906,7 +3909,8 @@ window.App = (function() {
         } else {
           elem.style.backgroundColor = null;
           elem.style.color = null;
-          elem.classList.add(self.specialChatColorClasses[-colorIdx - 1]);
+          const classes = self.specialChatColorClasses[-colorIdx - 1];
+          elem.classList.add(...(Array.isArray(classes) ? classes : [classes]));
         }
       },
       setLoadingBubbleState: (process, state) => {
@@ -5111,9 +5115,12 @@ window.App = (function() {
         uiHelper.styleElemWithChatNameColor(self.elements.username_color_select[0], colorIdx);
       },
       _populateUsernameColor: () => {
+        const hasPermForColor = (name) => user.hasPermission(`chat.usercolor.${name}`);
+        const hasAllDonatorColors = hasPermForColor('donator') || hasPermForColor('donator.*');
         self.elements.username_color_select.empty().append(
-          user.hasPermission('chat.usercolor.rainbow') ? crel('option', { value: -1, class: 'rainbow' }, '*. Rainbow') : null,
-          user.hasPermission('chat.usercolor.donator') ? crel('option', { value: -2, class: 'donator' }, '*. Donator') : null,
+          hasPermForColor('rainbow') ? crel('option', { value: -1, class: 'rainbow' }, '*. Rainbow') : null,
+          hasAllDonatorColors || hasPermForColor('donator.green') ? crel('option', { value: -2, class: 'donator donator--green' }, '*. Donator Green') : null,
+          hasAllDonatorColors || hasPermForColor('donator.gray') ? crel('option', { value: -3, class: 'donator donator--gray' }, '*. Donator Gray') : null,
           place.palette.map(({ name, value: hex }, i) => crel('option', {
             value: i,
             'data-idx': i,

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -389,7 +389,7 @@ dt {
     background-image: linear-gradient(45deg, violet, #308dff, cyan, green, yellow, orange, red, orange, yellow, green, cyan, #308dff, violet, violet);
     background-size: 500px 100%;
     animation: rainbow-move 4s linear 1ms infinite;
-    transform: rotateZ(360deg); /* force rainbow rendering onto GPU if available */
+    transform: rotateZ(360deg); /* force rendering onto GPU if available */
 }
 
 @keyframes donator-move {
@@ -402,10 +402,15 @@ dt {
 }
 
 .donator {
-    background-image: linear-gradient(45deg, #94E044, #02BE01 25%, #005F00 50%, #02BE01 75%, #94E044 90%);
     background-size: 500px 100%;
     animation: donator-move 4s linear 1ms infinite;
-    transform: rotateZ(360deg); /* force donator rendering onto GPU if available */
+    transform: rotateZ(360deg); /* force rendering onto GPU if available */
+}
+.donator.donator--green {
+    background-image: linear-gradient(45deg, #94E044, #02BE01 25%, #005F00 50%, #02BE01 75%, #94E044 90%);
+}
+.donator.donator--gray {
+    background-image: linear-gradient(45deg, hsl(0, 0%, 42.5%) 0, hsl(0, 0%, 63.5%) 50%, hsl(0, 0%, 42.5%) 100%);
 }
 
 .error {

--- a/resources/roles-reference.conf
+++ b/resources/roles-reference.conf
@@ -40,7 +40,7 @@ donator {
     }
   ]
   permissions: [
-    chat.usercolor.donator
+    "chat.usercolor.donator.*"
     user.donator
   ]
 }

--- a/roles.md
+++ b/roles.md
@@ -69,14 +69,16 @@ roleID {
 | `chat.report` | `/reportChat` | Report chat messages | user |
 | `chat.send` | | Send chat messages | user |
 | `chat.usercolor.rainbow` | | Ability to use rainbow user color | staff |
-| `chat.usercolor.donator` | | Ability to use donator user color | donator |
+| `chat.usercolor.donator`, `chat.usercolor.donator.*` | | Ability to use donator user colors | donator |
+| `chat.usercolor.donator.green` | | Ability to use green donator user color | donator |
+| `chat.usercolor.donator.gray` | | Ability to use green donator user color | donator |
 
 ### User
 
 | Node | Endpoint | Purpose | Default Role |
 | --- | --- | --- | --- |
 | `user.admin` | `/admin/*` | Access to admin client resources | staff |
-| `user.donator` | `/donator/*` | donator role | donator |
+| `user.donator` | `/donator/*` | Mark the role as a donator role | donator |
 | `user.alert` | | Alerts users | staff |
 | `user.auth` | `/auth`, `/signin`, `/signup`, `/logout` | User authentication | guest |
 | `user.auth` | `/whoami` | List own username and ID | guest |

--- a/src/main/java/space/pxls/server/WebHandler.java
+++ b/src/main/java/space/pxls/server/WebHandler.java
@@ -1030,11 +1030,15 @@ public class WebHandler {
 
         try {
             int t = Integer.parseInt(nameColor.getValue());
-            if (t >= -2 && t < App.getPalette().getColors().size()) {
+            if (t >= -3 && t < App.getPalette().getColors().size()) {
+                var hasAllDonatorColors = user.hasPermission("chat.usercolor.donator") || user.hasPermission("chat.usercolor.donator.*");
                 if (t == -1 && !user.hasPermission("chat.usercolor.rainbow")) {
                     sendBadRequest(exchange, "Color reserved for staff members");
                     return;
-                } else if (t == -2 && !user.hasPermission("chat.usercolor.donator")) {
+                } else if (t == -2 && !(hasAllDonatorColors || user.hasPermission("chat.usercolor.donator.green"))) {
+                    sendBadRequest(exchange, "Color reserved for donators");
+                    return;
+                } else if (t == -3 && !(hasAllDonatorColors || user.hasPermission("chat.usercolor.donator.gray"))) {
                     sendBadRequest(exchange, "Color reserved for donators");
                     return;
                 }

--- a/src/main/java/space/pxls/user/User.java
+++ b/src/main/java/space/pxls/user/User.java
@@ -653,15 +653,19 @@ public class User {
         App.getDatabase().setDiscordName(id, discordName);
     }
 
+    public boolean canUseDonatorCharNameColors() {
+        return hasPermission("chat.usercolor.donator") || hasPermission("chat.usercolor.donator.*");
+    }
+
     public boolean hasRainbowChatNameColor() {
         return hasPermission("chat.usercolor.rainbow")
                 && this.chatNameColor == -1;
 
     }
 
-     public boolean hasDonatorChatNameColor() {
-        return hasPermission("chat.usercolor.donator")
-                && this.chatNameColor == -2;
+    public boolean hasDonatorChatNameColor(String name, Integer idx) {
+        return (canUseDonatorCharNameColors() || hasPermission("chat.usercolor.donator." + name))
+                && this.chatNameColor == -idx;
 
     }
 
@@ -673,9 +677,12 @@ public class User {
         List<String> toReturn = new ArrayList<>();
         if (this.hasRainbowChatNameColor()) {
             toReturn.add("rainbow");
-        }
-        if (this.hasDonatorChatNameColor()) {
+        } else if (this.hasDonatorChatNameColor("green", 2)) {
             toReturn.add("donator");
+            toReturn.add("donator--green");
+        } else if (this.hasDonatorChatNameColor("gray", 3)) {
+            toReturn.add("donator");
+            toReturn.add("donator--gray");
         }
         return toReturn.size() != 0 ? toReturn : null;
     }


### PR DESCRIPTION
Adds Donator Gray as an option for donators to select from the username color selector.
![Donator Gray demo](https://user-images.githubusercontent.com/6181929/103034557-e6aaa300-4543-11eb-9902-695afa377510.gif)

This is quickly hacked together just like all the previous special username colors, but does bring some changes to try and standardize special username colors.