### PR TITLE
Only update query once the board is fully loaded

### DIFF
--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -1708,14 +1708,16 @@ window.App = (function() {
         });
       },
       update: function(optional, ignoreCanvasLock = false) {
-        self.pan.x = Math.min(self.width / 2, Math.max(-self.width / 2, self.pan.x));
-        self.pan.y = Math.min(self.height / 2, Math.max(-self.height / 2, self.pan.y));
         const scale = self.getScale();
-        query.set({
-          x: Math.round((self.width / 2) - self.pan.x),
-          y: Math.round((self.height / 2) - self.pan.y),
-          scale: Math.round(scale * 100) / 100
-        }, true);
+        if (self.loaded) {
+          self.pan.x = Math.min(self.width / 2, Math.max(-self.width / 2, self.pan.x));
+          self.pan.y = Math.min(self.height / 2, Math.max(-self.height / 2, self.pan.y));
+          query.set({
+            x: Math.round((self.width / 2) - self.pan.x),
+            y: Math.round((self.height / 2) - self.pan.y),
+            scale: Math.round(scale * 100) / 100
+          }, true);
+        }
         if (self.use_js_render) {
           const ctx2 = self.elements.board_render[0].getContext('2d');
           let pxlX = -self.pan.x + ((self.width - (window.innerWidth / scale)) / 2);


### PR DESCRIPTION
Previously, any call to `board.update()` before the board was fully loaded would result in the view being centered on (0, 0) instead of the center of the board. This PR removes this delicacy by adding a check for whenever the board has been loaded or not (`board.draw()` was ever called) and only performing the update once it has.