### PR TITLE
Ensure `serviceWorkerHelper.isInit` is set before we start using the service worker.

### DIFF
--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -3342,13 +3342,17 @@ window.App = (function() {
           return;
         }
 
-        navigator.serviceWorker.register('/serviceWorker.js')
-          .then(() => {
-            self.isInit = true;
-          })
-          .catch((err) => {
-            console.error('Failed to register Service Worker:', err);
-          });
+        if (navigator.serviceWorker.controller == null) {
+          navigator.serviceWorker.register('/serviceWorker.js')
+            .then(() => {
+              self.isInit = true;
+            })
+            .catch((err) => {
+              console.error('Failed to register Service Worker:', err);
+            });
+        } else {
+          self.isInit = true;
+        }
 
         navigator.serviceWorker.addEventListener('message', (ev) => {
           if (typeof ev.data !== 'object' || !('type' in ev.data)) {
@@ -3406,7 +3410,11 @@ window.App = (function() {
         return self.hasSupport;
       },
       get readyPromise() {
-        return navigator.serviceWorker.ready;
+        return navigator.serviceWorker.ready.then((v) => {
+          // fail safe
+          self.isInit = true;
+          return v;
+        });
       },
       init: self.init,
       addMessageListener: self.addMessageListener,


### PR DESCRIPTION
With this PR, `serviceWorkerHelper.isInit` is set automatically if `navigator.serviceWorker.controller` is set (if the service worker is in the active state) or, as a fail safe, on our wrapper for `navigator.serviceWorker.ready`.

This fixes a bug with multi-tabs where `App.uiHelper.tabId` would never be set because the client was preventing itself from sending the 'request-id' message to the service worker. This was caused due to a race condition between the fullfilment of the service worker registration promise (`navigator.serviceWorker.register(...).then(...)`, the one originally setting `serviceWorkerHelper.isInit`) and the fullfilment of the ready promise (`navigator.serviceWorker.ready.then(...)`, the one used by the multi-tabs logic to trigger the 'request-id' message).
I was able to reproduce this bug locally by opening Dev Tools, going to the Network tab, toggling Disable Cache on, reloading the page and inmediately going to another tab. Once the page had finished loading, going back to the tab and running `App.uiHelper.tabId` on the console would return null.