### PR TITLE
Remove now unused DatabaseTimer thread.

### DIFF
--- a/src/main/java/space/pxls/App.java
+++ b/src/main/java/space/pxls/App.java
@@ -111,8 +111,6 @@ public class App {
 
         new Timer().schedule(new SessionTimer(), 0, 1000 * 3600); // execute once every hour
 
-        new Timer().schedule(new DatabaseTimer(), 0, 1000 * 60 * 2);
-
         int heatmap_timer_cd = (int) App.getConfig().getDuration("board.heatmapCooldown", TimeUnit.SECONDS);
         new Timer().schedule(new HeatmapTimer(), 0, heatmap_timer_cd * 1000 / 256);
 

--- a/src/main/java/space/pxls/util/DatabaseTimer.java
+++ b/src/main/java/space/pxls/util/DatabaseTimer.java
@@ -1,9 +1,0 @@
-package space.pxls.util;
-
-import java.util.TimerTask;
-
-public class DatabaseTimer extends TimerTask {
-	public void run () {
-
-	}
-}


### PR DESCRIPTION
This was used to periodically clean up database connections, but became useless once we switched to Postgres.