### PR TITLE
Allow for configuring multiple origins which can fetch the authenticated user's name and ID from the /whoami endpoint.

### DIFF
--- a/resources/reference.conf
+++ b/resources/reference.conf
@@ -141,7 +141,9 @@ stacking {
   maxStacked: 5
 }
 
-whoamiAllowedOrigin: "https://pxls.space"
+whoamiAllowedOrigins: [
+  "https://pxls.space"
+]
 
 oauth {
   useIp: false

--- a/src/main/java/space/pxls/App.java
+++ b/src/main/java/space/pxls/App.java
@@ -919,9 +919,8 @@ public class App {
         return !config.getString("captcha.key").isEmpty() && !config.getString("captcha.secret").isEmpty();
     }
 
-    public static String getWhoamiAllowedOrigin() {
-        if (cachedWhoamiOrigin == null) cachedWhoamiOrigin = config.getString("whoamiAllowedOrigin");
-        return cachedWhoamiOrigin;
+    public static List<String> getWhoamiAllowedOrigins() {
+        return config.getStringList("whoamiAllowedOrigins");
     }
 
     public static int getPixel(int x, int y) {

--- a/src/main/java/space/pxls/server/WebHandler.java
+++ b/src/main/java/space/pxls/server/WebHandler.java
@@ -29,6 +29,7 @@ import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 public class WebHandler {
@@ -1911,8 +1912,14 @@ public class WebHandler {
     public void whoami(HttpServerExchange exchange) {
         exchange.getResponseHeaders()
                 .put(Headers.CONTENT_TYPE, "application/json")
-                .put(HttpString.tryFromString("Access-Control-Allow-Origin"), App.getWhoamiAllowedOrigin())
                 .put(HttpString.tryFromString("Access-Control-Allow-Credentials"), "true");
+
+        String origin = exchange.getRequestHeaders().getFirst(HttpString.tryFromString("Origin"));
+        if (origin != null && App.getWhoamiAllowedOrigins().stream().anyMatch(Predicate.isEqual(origin))) {
+            exchange.getResponseHeaders()
+                    .put(HttpString.tryFromString("Access-Control-Allow-Origin"), origin);
+        }
+
         User user = exchange.getAttachment(AuthReader.USER);
         if (user != null) {
             exchange.getResponseSender().send(App.getGson().toJson(new WhoAmI(user.getName(), user.getId())));


### PR DESCRIPTION
[Since the `Access-Control-Allow-Origin` header doesn't allow for multiple values](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin#directives), we check that the  `Origin` header on the request matches one of the configured origins and if so, echoes it back.

This should be useful for sites like https://pxlsfiddle.com to authenticate users more easily.
In the future we'll probably want to implement some Application Authorization process the user has to go through instead, so that the user can choose if and what to share with registered third-parties.

### Breaking change
In pxls.conf
```diff
- whoamiAllowedOrigin: "https://pxls.space"
+ whoamiAllowedOrigins: [
+   "https://pxls.space"
+ ]
```