### PR TITLE
Redact factions in chat and lookups, and usernames in chat purges, during Snip mode

### DIFF
--- a/src/main/java/space/pxls/App.java
+++ b/src/main/java/space/pxls/App.java
@@ -936,6 +936,10 @@ public class App {
         return virginmap[x + y * width];
     }
 
+    public static boolean getSnipMode() {
+        return getConfig().getBoolean("oauth.snipMode");
+    }
+
     public static boolean getRegistrationEnabled() {
         return getConfig().getBoolean("oauth.enableRegistration");
     }

--- a/src/main/java/space/pxls/server/PacketHandler.java
+++ b/src/main/java/space/pxls/server/PacketHandler.java
@@ -434,7 +434,7 @@ public class PacketHandler {
     public void sendChatPurge(User target, User initiator, int amount, String reason) {
         var obj = new ServerChatPurge(target.getName(), initiator == null ? "CONSOLE" : initiator.getName(), amount, reason);
         server.broadcastToStaff(obj);
-        if (App.getConfig().getBoolean("oauth.snipMode")) {
+        if (App.getSnipMode()) {
             obj.initiator = "-snip-";
             obj.target = "-snip-";
         }
@@ -448,7 +448,7 @@ public class PacketHandler {
     public void sendSpecificPurge(User target, User initiator, List<Integer> cmids, String reason) {
         var obj = new ServerChatSpecificPurge(target.getName(), initiator == null ? "CONSOLE" : initiator.getName(), cmids, reason);
         server.broadcastToStaff(obj);
-        if (App.getConfig().getBoolean("oauth.snipMode")) {
+        if (App.getSnipMode()) {
             obj.initiator = "-snip-";
             obj.target = "-snip-";
         }

--- a/src/main/java/space/pxls/server/PacketHandler.java
+++ b/src/main/java/space/pxls/server/PacketHandler.java
@@ -432,7 +432,13 @@ public class PacketHandler {
     }
 
     public void sendChatPurge(User target, User initiator, int amount, String reason) {
-        server.broadcast(new ServerChatPurge(target.getName(), initiator == null ? "CONSOLE" : initiator.getName(), amount, reason));
+        var obj = new ServerChatPurge(target.getName(), initiator == null ? "CONSOLE" : initiator.getName(), amount, reason);
+        server.broadcastToStaff(obj);
+        if (App.getConfig().getBoolean("oauth.snipMode")) {
+            obj.initiator = "-snip-";
+            obj.target = "-snip-";
+        }
+        server.broadcastToNonStaff(obj);
     }
 
     public void sendSpecificPurge(User target, User initiator, Integer cmid, String reason) {
@@ -440,7 +446,13 @@ public class PacketHandler {
     }
 
     public void sendSpecificPurge(User target, User initiator, List<Integer> cmids, String reason) {
-        server.broadcast(new ServerChatSpecificPurge(target.getName(), initiator == null ? "CONSOLE" : initiator.getName(), cmids, reason));
+        var obj = new ServerChatSpecificPurge(target.getName(), initiator == null ? "CONSOLE" : initiator.getName(), cmids, reason);
+        server.broadcastToStaff(obj);
+        if (App.getConfig().getBoolean("oauth.snipMode")) {
+            obj.initiator = "-snip-";
+            obj.target = "-snip-";
+        }
+        server.broadcastToNonStaff(obj);
     }
 
     public void updateUserData() {

--- a/src/main/java/space/pxls/server/UndertowServer.java
+++ b/src/main/java/space/pxls/server/UndertowServer.java
@@ -207,6 +207,10 @@ public class UndertowServer {
         broadcastToUserPredicate(obj, user -> user.hasPermission("user.receivestaffbroadcasts"));
     }
 
+    public void broadcastToNonStaff(Object obj) {
+        broadcastToUserPredicate(obj, user -> !user.hasPermission("user.receivestaffbroadcasts"));
+    }
+
     public void broadcastToUserPredicate(Object obj, Predicate<User> predicate) {
         String json = App.getGson().toJson(obj);
         getAuthedUsers()

--- a/src/main/java/space/pxls/server/WebHandler.java
+++ b/src/main/java/space/pxls/server/WebHandler.java
@@ -1064,7 +1064,7 @@ public class WebHandler {
                     return;
                 }
 
-                user.setChatNameColor(t, true, !App.getConfig().getBoolean("oauth.snipMode"));
+                user.setChatNameColor(t, true, !App.getSnipMode());
 
                 exchange.setStatusCode(200);
                 exchange.getResponseSender().send("{}");
@@ -1749,7 +1749,7 @@ public class WebHandler {
             Math.min(App.getConfig().getInt("chat.characterLimit"), 2048),
             App.getConfig().getBoolean("chat.canvasBanRespected"),
             App.getConfig().getStringList("chat.bannerText"),
-            App.getConfig().getBoolean("oauth.snipMode"),
+            App.getSnipMode(),
             App.getConfig().getList("chat.customEmoji").unwrapped()
         )));
     }

--- a/src/main/java/space/pxls/server/packets/chat/ChatMessage.java
+++ b/src/main/java/space/pxls/server/packets/chat/ChatMessage.java
@@ -18,15 +18,16 @@ public class ChatMessage {
     public StrippedFaction strippedFaction;
 
     public ChatMessage(int id, String author, Long date, String message_raw, Purge purge, List<Badge> badges, List<String> authorNameClass, Number authorNameColor, Faction faction) {
+        boolean isSnip = App.getConfig().getBoolean("oauth.snipMode");
         this.id = id;
-        this.author = App.getConfig().getBoolean("oauth.snipMode") ? "-snip-" : author;
+        this.author = isSnip ? "-snip-" : author;
         this.date = date;
         this.message_raw = message_raw;
         this.purge = purge;
         this.badges = badges;
         this.authorNameClass = authorNameClass;
         this.authorNameColor = authorNameColor;
-        this.strippedFaction = faction != null ? new StrippedFaction(faction) : null;
+        this.strippedFaction = !isSnip && faction != null ? new StrippedFaction(faction) : null;
     }
 
     public int getId() {

--- a/src/main/java/space/pxls/server/packets/chat/ChatMessage.java
+++ b/src/main/java/space/pxls/server/packets/chat/ChatMessage.java
@@ -18,7 +18,7 @@ public class ChatMessage {
     public StrippedFaction strippedFaction;
 
     public ChatMessage(int id, String author, Long date, String message_raw, Purge purge, List<Badge> badges, List<String> authorNameClass, Number authorNameColor, Faction faction) {
-        boolean isSnip = App.getConfig().getBoolean("oauth.snipMode");
+        boolean isSnip = App.getSnipMode();
         this.id = id;
         this.author = isSnip ? "-snip-" : author;
         this.date = date;

--- a/src/main/java/space/pxls/server/packets/chat/ServerChatPurge.java
+++ b/src/main/java/space/pxls/server/packets/chat/ServerChatPurge.java
@@ -1,7 +1,5 @@
 package space.pxls.server.packets.chat;
 
-import space.pxls.App;
-
 public class ServerChatPurge {
     public String type = "chat_purge";
     public String target;
@@ -10,7 +8,7 @@ public class ServerChatPurge {
     public String reason;
 
     public ServerChatPurge(String target, String initiator, Integer amount, String reason) {
-        this.target = App.getConfig().getBoolean("oauth.snipMode") ? "-snip-" : target;
+        this.target = target;
         this.initiator = initiator;
         this.amount = amount;
         this.reason = reason;

--- a/src/main/java/space/pxls/server/packets/http/ExtendedLookup.java
+++ b/src/main/java/space/pxls/server/packets/http/ExtendedLookup.java
@@ -16,6 +16,7 @@ public class ExtendedLookup extends Lookup {
         this.discordName = discordName;
         this.pixelCount = username != null ? pixelCount : null;
         this.pixelCountAlltime = username != null ? pixelCountAlltime : null;
+        this.faction = username != null ? faction : null;
     }
 
     public static ExtendedLookup fromDB(DBPixelPlacementFull pixelPlacement) {

--- a/src/main/java/space/pxls/server/packets/http/Lookup.java
+++ b/src/main/java/space/pxls/server/packets/http/Lookup.java
@@ -19,7 +19,7 @@ public class Lookup {
     public String faction;
 
     public Lookup(int id, int x, int y, String origin, int pixelCount, int pixelCountAlltime, long time, String username, String discordName, String faction) {
-        boolean isSnip = App.getConfig().getBoolean("oauth.snipMode");
+        boolean isSnip = App.getSnipMode();
         this.id = id;
         this.x = x;
         this.y = y;

--- a/src/main/java/space/pxls/server/packets/http/Lookup.java
+++ b/src/main/java/space/pxls/server/packets/http/Lookup.java
@@ -29,7 +29,7 @@ public class Lookup {
         this.time = time;
         this.username = isSnip ? "-snip-" : username;
         this.discordName = isSnip ? (discordName != null ? "-snip-" : null) : discordName; // if we're in snip mode, we want to filter the name, otherwise we'll just accept whatever was thrown at us. original serialization utilized nulls.
-        this.faction = faction;
+        this.faction = isSnip ? null : faction;
     }
 
     public static String originFromPixel(DBPixelPlacement pixelPlacement) {

--- a/src/main/java/space/pxls/user/User.java
+++ b/src/main/java/space/pxls/user/User.java
@@ -329,7 +329,7 @@ public class User {
 
         getRoles().forEach(role -> toReturn.addAll(role.getBadges()));
 
-        if (!App.getConfig().getBoolean("oauth.snipMode")) {
+        if (!App.getSnipMode()) {
             if (this.pixelCountAllTime >= 1000000) {
                 toReturn.add(new Badge("1M+", "1M+ Pixels Placed", "text", null));
             } else if (this.pixelCountAllTime >= 900000) {


### PR DESCRIPTION
- Don't send Faction on lookups requested by non-staff users
- Don't send Faction on chat messages during snip mode
- Replace initiator and target usernames with -snip- when sending purges to non-staff users