### PR TITLE
Allow for globally disabling chat

### DIFF
--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -4095,27 +4095,47 @@ window.App = (function() {
           self._setOpenState('info', true);
         }
       },
+      _getPanelElement: (panel) => panel instanceof HTMLElement ? panel : document.querySelector(`.panel[data-panel="${panel}"]`),
+      _getPanelTriggerElement: (panel) => {
+        panel = self._getPanelElement(panel);
+        if (!panel) {
+          return null;
+        }
+        return document.querySelector(`.panel-trigger[data-panel="${panel.dataset.panel}"]`);
+      },
+      setEnabled: (panel, enabled) => {
+        panel = self._getPanelElement(panel);
+        if (enabled) {
+          delete panel.dataset.disabled;
+        } else {
+          panel.dataset.disabled = '';
+        }
+
+        const panelTrigger = self._getPanelTriggerElement(panel);
+        if (panelTrigger) {
+          panelTrigger.style.display = enabled ? '' : 'none';
+        }
+      },
+      isEnabled: (panel) => {
+        panel = self._getPanelElement(panel);
+        return panel && panel.dataset.disabled == null;
+      },
       isOpen: panel => {
-        if (!(panel instanceof HTMLElement)) panel = document.querySelector(`.panel[data-panel="${panel}"]`);
-        return panel && panel.classList.contains('open');
+        panel = self._getPanelElement(panel);
+        return panel && self.isEnabled(panel) && panel.classList.contains('open');
       },
       _toggleOpenState: (panel, exclusive = true) => {
-        if (!(panel instanceof HTMLElement)) panel = document.querySelector(`.panel[data-panel="${panel}"]`);
-        if (panel) {
+        panel = self._getPanelElement(panel);
+        if (panel && self.isEnabled(panel)) {
           self._setOpenState(panel, !panel.classList.contains('open'), exclusive);
         }
       },
       _setOpenState: (panel, state, exclusive = true) => {
         state = !!state;
 
-        let panelDescriptor = panel;
-        if (panel instanceof HTMLElement) {
-          panelDescriptor = panel.dataset.panel;
-        } else {
-          panel = document.querySelector(`.panel[data-panel="${panel}"]`);
-        }
-
+        panel = self._getPanelElement(panel);
         if (panel) {
+          const panelDescriptor = panel.dataset.panel;
           const panelPosition = panel.classList.contains('right') ? 'right' : 'left';
 
           if (state) {
@@ -4145,7 +4165,9 @@ window.App = (function() {
       open: panel => self._setOpenState(panel, true),
       close: panel => self._setOpenState(panel, false),
       toggle: (panel, exclusive = true) => self._toggleOpenState(panel, exclusive),
-      isOpen: self.isOpen
+      isOpen: self.isOpen,
+      setEnabled: self.setEnabled,
+      isEnabled: self.isEnabled
     };
   })();
   const chat = (function() {
@@ -4731,6 +4753,10 @@ window.App = (function() {
           }
         });
       },
+      disable: () => {
+        panels.setEnabled('chat', false);
+        self.elements.username_color_select.attr('disabled', '');
+      },
       _handleChatbanVisualState(canChat) {
         if (canChat) {
           self.elements.input.prop('disabled', false);
@@ -4746,9 +4772,6 @@ window.App = (function() {
       webinit(data) {
         self.setCharLimit(data.chatCharacterLimit);
         self.canvasBanRespected = data.chatRespectsCanvasBan;
-        self.customEmoji = data.customEmoji.map(({ name, emoji }) => ({ name, emoji: `./emoji/${emoji}` }));
-        self.initEmojiPicker();
-        self.initTypeahead();
         self._populateUsernameColor();
         self.elements.username_color_select.value = user.getChatNameColor();
         self.elements.username_color_select.on('change', function() {
@@ -4780,6 +4803,14 @@ window.App = (function() {
             }
           });
         });
+
+        if (data.chatEnabled) {
+          self.customEmoji = data.customEmoji.map(({ name, emoji }) => ({ name, emoji: `./emoji/${emoji}` }));
+          self.initEmojiPicker();
+          self.initTypeahead();
+        } else {
+          self.disable();
+        }
       },
       initTypeahead() {
         // init DBs

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -1165,6 +1165,10 @@ aside.panel {
     cursor: initial !important;
 }
 
+aside.panel[data-disabled] {
+    display: none;
+}
+
 aside.panel.left {
     right: initial;
     transition: left ease-in-out .25s;

--- a/resources/reference.conf
+++ b/resources/reference.conf
@@ -202,6 +202,7 @@ textFilter {
 }
 
 chat {
+    enabled: true
     trimInput: true
     defaultColorIndex: 5
     characterLimit: 256

--- a/src/main/java/space/pxls/App.java
+++ b/src/main/java/space/pxls/App.java
@@ -944,6 +944,10 @@ public class App {
         return getConfig().getBoolean("oauth.enableRegistration");
     }
 
+    public static boolean isChatEnabled() {
+        return getConfig().getBoolean("chat.enabled");
+    }
+
     public static void putPixel(int x, int y, int color, User user, boolean mod_action, String ip, boolean updateDatabase, String action) {
         if (x < 0 || x >= width || y < 0 || y >= height || (color >= getPalette().getColors().size() && !(color == 0xFF || color == -1))) return;
         String userName = user != null ? user.getName() : "<server>";

--- a/src/main/java/space/pxls/server/PacketHandler.java
+++ b/src/main/java/space/pxls/server/PacketHandler.java
@@ -111,10 +111,12 @@ public class PacketHandler {
         if (obj instanceof ClientCaptcha) handleCaptcha(channel, user, ((ClientCaptcha) obj));
         if (obj instanceof ClientShadowBanMe) handleShadowBanMe(channel, user, ((ClientShadowBanMe) obj));
         if (obj instanceof ClientBanMe) handleBanMe(channel, user, ((ClientBanMe) obj));
-        if (obj instanceof ClientChatHistory && user.hasPermission("chat.history")) handleChatHistory(channel, user, ((ClientChatHistory) obj));
-        if (obj instanceof ClientChatbanState) handleChatbanState(channel, user, ((ClientChatbanState) obj));
-        if (obj instanceof ClientChatMessage && user.hasPermission("chat.send")) handleChatMessage(channel, user, ((ClientChatMessage) obj));
-        if (obj instanceof ClientChatLookup && user.hasPermission("chat.lookup")) handleChatLookup(channel, user, ((ClientChatLookup) obj));
+        if (App.isChatEnabled()) {
+            if (obj instanceof ClientChatHistory && user.hasPermission("chat.history")) handleChatHistory(channel, user, ((ClientChatHistory) obj));
+            if (obj instanceof ClientChatbanState) handleChatbanState(channel, user, ((ClientChatbanState) obj));
+            if (obj instanceof ClientChatMessage && user.hasPermission("chat.send")) handleChatMessage(channel, user, ((ClientChatMessage) obj));
+            if (obj instanceof ClientChatLookup && user.hasPermission("chat.lookup")) handleChatLookup(channel, user, ((ClientChatLookup) obj));
+        }
         if (obj instanceof ClientAdminPlacementOverrides && user.hasPermission("user.admin")) handlePlacementOverrides(channel, user, ((ClientAdminPlacementOverrides) obj));
         if (obj instanceof ClientAdminMessage && user.hasPermission("user.alert")) handleAdminMessage(channel, user, ((ClientAdminMessage) obj));
     }

--- a/src/main/java/space/pxls/server/WebHandler.java
+++ b/src/main/java/space/pxls/server/WebHandler.java
@@ -767,6 +767,11 @@ public class WebHandler {
     public void chatReport(HttpServerExchange exchange) {
         exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "application/json");
 
+        if (!App.isChatEnabled()) {
+            sendForbidden(exchange, "Chatting and chat actions are disabled");
+            return;
+        }
+
         User user = exchange.getAttachment(AuthReader.USER);
         if (user == null) {
             sendUnauthorized(exchange, "User must be logged in to report chat messages");
@@ -819,6 +824,13 @@ public class WebHandler {
     }
 
     public void chatban(HttpServerExchange exchange) {
+        exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "application/json");
+
+        if (!App.isChatEnabled()) {
+            sendForbidden(exchange, "Chatting and chat actions are disabled");
+            return;
+        }
+
         User user = exchange.getAttachment(AuthReader.USER);
         if (user == null) {
             sendBadRequest(exchange);
@@ -915,7 +927,6 @@ public class WebHandler {
 
         chatban.commit();
 
-        exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "application/json");
         exchange.setStatusCode(200);
         exchange.getResponseSender().send("{}");
         exchange.endExchange();
@@ -923,6 +934,11 @@ public class WebHandler {
 
     public void deleteChatMessage(HttpServerExchange exchange) {
         exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "application/json");
+
+        if (!App.isChatEnabled()) {
+            sendForbidden(exchange, "Chatting and chat actions are disabled");
+            return;
+        }
 
         User user = exchange.getAttachment(AuthReader.USER);
         if (user == null) {
@@ -986,6 +1002,11 @@ public class WebHandler {
     public void chatPurge(HttpServerExchange exchange) {
         exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "application/json");
 
+        if (!App.isChatEnabled()) {
+            sendForbidden(exchange, "Chatting and chat actions are disabled");
+            return;
+        }
+
         User user = exchange.getAttachment(AuthReader.USER);
         if (user == null) {
             sendBadRequest(exchange);
@@ -1034,6 +1055,11 @@ public class WebHandler {
 
     public void chatColorChange(HttpServerExchange exchange) {
         exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "application/json");
+
+        if (!App.isChatEnabled()) {
+            sendForbidden(exchange, "Chatting and chat actions are disabled");
+            return;
+        }
 
         User user = exchange.getAttachment(AuthReader.USER);
         if (user == null) {
@@ -1746,6 +1772,7 @@ public class WebHandler {
             (int) App.getConfig().getInt("stacking.maxStacked"),
             services,
             App.getRegistrationEnabled(),
+            App.isChatEnabled(),
             Math.min(App.getConfig().getInt("chat.characterLimit"), 2048),
             App.getConfig().getBoolean("chat.canvasBanRespected"),
             App.getConfig().getStringList("chat.bannerText"),

--- a/src/main/java/space/pxls/server/packets/http/CanvasInfo.java
+++ b/src/main/java/space/pxls/server/packets/http/CanvasInfo.java
@@ -1,6 +1,5 @@
 package space.pxls.server.packets.http;
 
-import com.typesafe.config.ConfigList;
 import space.pxls.auth.AuthService;
 import space.pxls.palette.Color;
 
@@ -17,13 +16,14 @@ public class CanvasInfo {
     public Integer maxStacked;
     public Map<String, AuthService> authServices;
     public Boolean registrationEnabled;
+    public Boolean chatEnabled;
     public Boolean chatRespectsCanvasBan;
     public Integer chatCharacterLimit;
     public List<String> chatBannerText;
     public Boolean snipMode;
     public List<Object> customEmoji;
 
-    public CanvasInfo(String canvasCode, Integer width, Integer height, List<Color> palette, String captchaKey, Integer heatmapCooldown, Integer maxStacked, Map<String, AuthService> authServices, Boolean registrationEnabled, Integer chatCharacterLimit, boolean chatRespectsCanvasBan, List<String> chatBannerText, boolean snipMode, List<Object> customEmoji) {
+    public CanvasInfo(String canvasCode, Integer width, Integer height, List<Color> palette, String captchaKey, Integer heatmapCooldown, Integer maxStacked, Map<String, AuthService> authServices, Boolean registrationEnabled, Boolean chatEnabled, Integer chatCharacterLimit, boolean chatRespectsCanvasBan, List<String> chatBannerText, boolean snipMode, List<Object> customEmoji) {
         this.canvasCode = canvasCode;
         this.width = width;
         this.height = height;
@@ -33,6 +33,7 @@ public class CanvasInfo {
         this.maxStacked = maxStacked;
         this.authServices = authServices;
         this.registrationEnabled = registrationEnabled;
+        this.chatEnabled = chatEnabled;
         this.chatCharacterLimit = chatCharacterLimit;
         this.chatRespectsCanvasBan = chatRespectsCanvasBan;
         this.chatBannerText = chatBannerText;
@@ -74,6 +75,10 @@ public class CanvasInfo {
 
     public Boolean getRegistrationEnabled() {
         return registrationEnabled;
+    }
+
+    public Boolean getChatEnabled() {
+        return chatEnabled;
     }
 
     public Integer getChatCharacterLimit() {


### PR DESCRIPTION
Adds the `chat.enabled` setting which turns off all chat functionality on the server and disables the chat panel on the client.

This is more of a quick hack. I'm only making a PR to have the ability in hand if needed.
There is also no guarantee we'll use this anytime soon.
