### PR TITLE
UI palette tweaks

### DIFF
--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -318,6 +318,12 @@
                             <span class="label-text">Enable thin scrollbar</span>
                         </label>
                     </div>
+                    <div data-keywords="scrollbar;palette scrolling;palette stack">
+                        <label class="input-group">
+                            <input id="setting-ui-palette-stacking-enable" type="checkbox">
+                            <span class="label-text">Enable palette stacking</span>
+                        </label>
+                    </div>
                     <div data-keywords="enable monospace;disable monospace">
                         <label class="input-group">
                             <input id="setting-lookup-monospace-enable" type="checkbox"/>

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -54,7 +54,7 @@
 
 <div id="reconnecting">Lost connection to server, reconnecting...</div>
 
-</main>
+<main>
     <div id="board-container" style="touch-action: none">
         <div id="grid"></div>
         <div id="board-zoomer">

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -312,6 +312,12 @@
                             <span class="label-text">Add numbers to palette entries</span>
                         </label>
                     </div>
+                    <div data-keywords="scrollbar;palette scrolling">
+                        <label class="input-group">
+                            <input id="setting-ui-palette-scrollbar-thin-enable" type="checkbox">
+                            <span class="label-text">Enable thin scrollbar</span>
+                        </label>
+                    </div>
                     <div data-keywords="enable monospace;disable monospace">
                         <label class="input-group">
                             <input id="setting-lookup-monospace-enable" type="checkbox"/>

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -709,6 +709,9 @@ window.App = (function() {
             thin: {
               enable: setting('ui.palette.scrollbar.thin.enable', SettingType.TOGGLE, true, $('#setting-ui-palette-scrollbar-thin-enable'))
             }
+          },
+          stacking: {
+            enable: setting('ui.palette.stacking.enable', SettingType.TOGGLE, false, $('#setting-ui-palette-stacking-enable'))
           }
         },
         chat: {
@@ -3536,6 +3539,10 @@ window.App = (function() {
 
         settings.ui.palette.scrollbar.thin.enable.listen(function(value) {
           document.querySelector('#palette').classList.toggle('thin-scrollbar', value);
+        });
+
+        settings.ui.palette.stacking.enable.listen(function(value) {
+          document.querySelector('#palette').classList.toggle('palette-stacking', value);
         });
 
         settings.board.lock.enable.listen((value) => board.setAllowDrag(!value));

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -704,6 +704,11 @@ window.App = (function() {
         palette: {
           numbers: {
             enable: setting('ui.palette.numbers.enable', SettingType.TOGGLE, false, $('#setting-ui-palette-numbers-enable'))
+          },
+          scrollbar: {
+            thin: {
+              enable: setting('ui.palette.scrollbar.thin.enable', SettingType.TOGGLE, true, $('#setting-ui-palette-scrollbar-thin-enable'))
+            }
           }
         },
         chat: {
@@ -3527,6 +3532,10 @@ window.App = (function() {
 
         settings.ui.palette.numbers.enable.listen(function(value) {
           place.setNumberedPaletteEnabled(value);
+        });
+
+        settings.ui.palette.scrollbar.thin.enable.listen(function(value) {
+          document.querySelector('#palette').classList.toggle('thin-scrollbar', value);
         });
 
         settings.board.lock.enable.listen((value) => board.setAllowDrag(!value));

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -723,7 +723,7 @@ body .message {
 #palette {
     position: relative;
     z-index: 6;
-    padding: 15px 0;
+    padding: 10px 0;
     margin: 0 auto;
 
     overflow-x: auto;
@@ -736,6 +736,10 @@ body .message {
 .thin-scrollbar {
     scrollbar-width: thin;
     scrollbar-color: #aaa transparent;
+}
+
+.palette-stacking {
+    white-space: normal !important;
 }
 
 /* Scrollbar, Chrome only */
@@ -760,7 +764,7 @@ body .message {
     min-height: 32px;
     border: 2px solid var(--palette-item-border-color);
     border-radius: 3px;
-    margin-right: 10px;
+    margin: 5px;
     cursor: pointer;
     bottom: 0;
     /* the default of `baseline` causes the deselect button to be raised on Firefox */

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -730,8 +730,10 @@ body .message {
     text-align: center;
     white-space: nowrap;
     background: var(--palette-background);
+}
 
-    /* Scrollbar, Firefox only */
+/* Scrollbar, Firefox only */
+.thin-scrollbar {
     scrollbar-width: thin;
     scrollbar-color: #aaa transparent;
 }


### PR DESCRIPTION
This pull request adds two settings under the **UI Settings** group:
- The ability to toggle the thin scrollbar width on the palette bar
- The ability to override the `white-space` property to allow for stacking

To accomplish the first option, a separate CSS class was made with the following properties:
```css
.thin-scrollbar {
    scrollbar-width: thin;
    scrollbar-color: #aaa transparent;
}
```
The class will be toggled onto the `palette` element.

To accomplish the second option, another CSS class was made with the following property:
```css
.palette-stacking {
    white-space: normal !important;
}
```
When toggled, the palette buttons will overflow onto the next row with no extra limitations for how many rows it can take up. To make the rows look nicer, the top and bottom padding on `#palette` was reduced to `10px` from `15px` and an all-round margin of `5px` was added to the `.palette-color` class.

Demonstration:
![ui-palette-tweaks](https://user-images.githubusercontent.com/19217244/106363826-37739f80-632b-11eb-8cd7-157ef62bf488.gif)
