### PR TITLE
Shadow-Banned Chat Messages

### DIFF
--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -54,7 +54,7 @@
 
 <div id="reconnecting">Lost connection to server, reconnecting...</div>
 
-</main>
+<main>
     <div id="board-container" style="touch-action: none">
         <div id="grid"></div>
         <div id="board-zoomer">

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -5358,6 +5358,9 @@ window.App = (function() {
         if (packet.purge) {
           self._markMessagePurged(chatLine, packet.purge);
         }
+        if (packet.authorIsShadowBanned) {
+          self._markMessageShadowBanned(chatLine);
+        }
 
         if (hasPing) {
           self.pingsList.push(packet);
@@ -5395,6 +5398,10 @@ window.App = (function() {
         elem.classList.add('purged');
         elem.setAttribute('title', `Purged by ${purge.initiator} with reason: ${purge.reason || 'none provided'}`);
         elem.dataset.purgedBy = purge.initiator;
+      },
+      _markMessageShadowBanned: (elem) => {
+        elem.classList.add('shadow-banned');
+        elem.dataset.shadowBanned = 'true';
       },
       _makeCoordinatesElement: (raw, x, y, scale, template, title) => {
         let text = `(${x}, ${y}${scale != null ? `, ${scale}x` : ''})`;

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -132,6 +132,7 @@ html {
     --chat-server-action-text-color: #555;
     --chat-user-text-shadow-color: #ccc;
     --chat-purged-text-color: #888;
+    --chat-shadowbanned-text-color: #F44;
 
     --chat-tobottom-text-color: #fff;
     --chat-tobottom-background: #66a;
@@ -1573,6 +1574,11 @@ li.chat-line .actions [data-action]:not(:last-of-type):not(:only-child) {
     font-size: .9em;
     color: var(--chat-purged-text-color);
     text-decoration: line-through;
+}
+
+.chat-line.shadow-banned {
+    font-size: .9em;
+    color: var(--chat-shadowbanned-text-color);
 }
 
 #jump-to-bottom {

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -132,7 +132,7 @@ html {
     --chat-server-action-text-color: #555;
     --chat-user-text-shadow-color: #ccc;
     --chat-purged-text-color: #888;
-    --chat-shadowbanned-text-color: #F44;
+    --chat-shadowbanned-text-color: #F66;
 
     --chat-tobottom-text-color: #fff;
     --chat-tobottom-background: #66a;

--- a/resources/reference.conf
+++ b/resources/reference.conf
@@ -209,6 +209,7 @@ chat {
     defaultColorIndex: 5
     characterLimit: 256
     canvasBanRespected: false
+    showShadowBannedMessagesToStaff: true
     chatLookupScrollbackAmount: 500
     customEmoji: [
       // Emoji only support a-z, A-Z, _, and -.

--- a/resources/roles-reference.conf
+++ b/resources/roles-reference.conf
@@ -77,6 +77,7 @@ staff {
     board.check
     chat.lookup
     chat.history.purged
+    chat.history.shadowbanned
     chat.usercolor.rainbow
     user.admin
     user.alert

--- a/roles.md
+++ b/roles.md
@@ -64,6 +64,7 @@ roleID {
 | `chat.delete` | `/admin/delete` | Delete chat messages | staff |
 | `chat.history` | | Retrieve chat history | user |
 | `chat.history.purged` | | Show purged messages in chat and chat history | staff |
+| `chat.history.shadowbanned` | | Show shadow-banned messages in chat and chat history | staff |
 | `chat.lookup` | | Chat message lookups | staff |
 | `chat.purge` | `/admin/chatPurge` | Purge (multiple) chat messages | staff |
 | `chat.report` | `/reportChat` | Report chat messages | user |

--- a/src/main/java/space/pxls/App.java
+++ b/src/main/java/space/pxls/App.java
@@ -1,9 +1,6 @@
 package space.pxls;
 
-import com.google.gson.ExclusionStrategy;
-import com.google.gson.FieldAttributes;
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.typesafe.config.*;
 import org.apache.commons.jcs.JCS;
 import org.apache.logging.log4j.Level;
@@ -24,9 +21,7 @@ import space.pxls.palette.*;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.RandomAccessFile;
 import java.nio.file.Files;
-import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;

--- a/src/main/java/space/pxls/App.java
+++ b/src/main/java/space/pxls/App.java
@@ -1,6 +1,9 @@
 package space.pxls;
 
+import com.google.gson.ExclusionStrategy;
+import com.google.gson.FieldAttributes;
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.typesafe.config.*;
 import org.apache.commons.jcs.JCS;
 import org.apache.logging.log4j.Level;

--- a/src/main/java/space/pxls/data/Database.java
+++ b/src/main/java/space/pxls/data/Database.java
@@ -1236,7 +1236,7 @@ public class Database {
      * @param includeShadowBanned Whether or not to include shadow-banned messages.
      * @return The retrieved {@link DBChatMessage}s. The length is determined by the {@link ResultSet} size.
      */
-    public List<ChatMessage> getlastXMessagesForSocket(int x, boolean includePurged, boolean includeShadowBanned, boolean ignoreFilter) {
+    public List<ChatMessage> getLastXMessagesForSocket(int x, boolean includePurged, boolean includeShadowBanned, boolean ignoreFilter) {
         DBChatMessage[] fromDB = getLastXMessages(x, includePurged, includeShadowBanned);
         List<ChatMessage> toReturn = new ArrayList<>();
         for (DBChatMessage dbChatMessage : fromDB) {

--- a/src/main/java/space/pxls/data/Database.java
+++ b/src/main/java/space/pxls/data/Database.java
@@ -1173,11 +1173,10 @@ public class Database {
      * @param sent The chat message's creation epoch.
      * @param content The chat contents.
      * @param filtered The filtered chat contents.
-     * @param shadowBanned Whether or not the user sending the message is shadow-banned.
      * @return The new chat message's ID.
      */
-    public Integer createChatMessage(User author, long sent, String content, String filtered, boolean shadowBanned) {
-        return createChatMessage(author == null ? -1 : author.getId(), sent / 1000L, content, filtered, shadowBanned);
+    public Integer createChatMessage(User author, long sent, String content, String filtered) {
+        return createChatMessage(author == null ? -1 : author.getId(), sent / 1000L, content, filtered, author != null && author.isShadowBanned());
     }
 
     /**

--- a/src/main/java/space/pxls/data/Database.java
+++ b/src/main/java/space/pxls/data/Database.java
@@ -1234,6 +1234,7 @@ public class Database {
      * @param x The amount of chat messages to retrieve.
      * @param includePurged Whether or not to include purged messages.
      * @param ignoreFilter Whether or not the chat filter should apply to messages being returned.
+     * @param includeShadowBanned Whether or not to include shadow-banned messages.
      * @return The retrieved {@link DBChatMessage}s. The length is determined by the {@link ResultSet} size.
      */
     public List<ChatMessage> getlastXMessagesForSocket(int x, boolean includePurged, boolean includeShadowBanned, boolean ignoreFilter) {
@@ -1245,7 +1246,7 @@ public class Database {
             int nameColor = 0;
             Faction faction = null;
             List<String> nameClass = null;
-            Boolean isAuthorShadowBanned = false;
+            boolean isAuthorShadowBanned = false;
             if (dbChatMessage.author_uid > 0) {
                 author = "$Unknown";
                 User temp = App.getUserManager().getByID(dbChatMessage.author_uid);
@@ -1258,12 +1259,13 @@ public class Database {
                     isAuthorShadowBanned = temp.isShadowBanned();
                 }
             }
+            if (isAuthorShadowBanned && !includeShadowBanned) continue;
             var message = new ChatMessage(
                 dbChatMessage.id,
                 author,
                 dbChatMessage.sent,
                 App.getConfig().getBoolean("textFilter.enabled") && !ignoreFilter && dbChatMessage.filtered_content.length() > 0 ? dbChatMessage.filtered_content : dbChatMessage.content,
-                isAuthorShadowBanned,
+                isAuthorShadowBanned ? true : null,
                 dbChatMessage.purged ? new ChatMessage.Purge(dbChatMessage.purged_by_uid, dbChatMessage.purge_reason) : null,
                 badges,
                 nameClass,

--- a/src/main/java/space/pxls/server/PacketHandler.java
+++ b/src/main/java/space/pxls/server/PacketHandler.java
@@ -434,7 +434,10 @@ public class PacketHandler {
                     // To staff, if enabled in the config, they will be the only ones to also get the message.
                     staffPacket = App.getConfig().getBoolean("chat.showShadowBannedMessagesToStaff") ? staffPacket : null;
                 }
-                server.broadcastSeparateForStaff(userPacket, staffPacket);
+                //noinspection ConstantConditions
+                if (userPacket != null && staffPacket != null) {
+                    server.broadcastSeparateForStaff(userPacket, staffPacket);
+                }
             } catch (UnableToExecuteStatementException utese) {
                 utese.printStackTrace();
                 System.err.println("Failed to execute the ChatMessage insert statement.");

--- a/src/main/java/space/pxls/server/PacketHandler.java
+++ b/src/main/java/space/pxls/server/PacketHandler.java
@@ -393,6 +393,7 @@ public class PacketHandler {
                     // sent messages normally.
                     if (user.isShadowBanned() && message.authorIsShadowBanned) message.authorIsShadowBanned = null;
                 })
+                .filter(message -> !(message.authorIsShadowBanned != null && message.authorIsShadowBanned && !user.hasPermission("chat.history.shadowbanned")))
                 .collect(Collectors.toList());
         server.send(channel, new ServerChatHistory(filtered));
     }

--- a/src/main/java/space/pxls/server/PacketHandler.java
+++ b/src/main/java/space/pxls/server/PacketHandler.java
@@ -384,7 +384,7 @@ public class PacketHandler {
     }
 
     public void handleChatHistory(WebSocketChannel channel, User user, ClientChatHistory clientChatHistory) {
-        server.send(channel, new ServerChatHistory(App.getDatabase().getlastXMessagesForSocket(100, user.hasPermission("chat.history.purged"), user.hasPermission("chat.history.shadowbanned"), false)));
+        server.send(channel, new ServerChatHistory(App.getDatabase().getLastXMessagesForSocket(100, user.hasPermission("chat.history.purged"), user.hasPermission("chat.history.shadowbanned"), false)));
     }
 
     public void handleChatMessage(WebSocketChannel channel, User user, ClientChatMessage clientChatMessage) {

--- a/src/main/java/space/pxls/server/PacketHandler.java
+++ b/src/main/java/space/pxls/server/PacketHandler.java
@@ -424,9 +424,17 @@ public class PacketHandler {
                 var chatMessage = new ChatMessage(cmid, user.getName(), nowMS / 1000L, toSend, user.isShadowBanned(), null, user.getChatBadges(), user.getChatNameClasses(), user.getChatNameColor(), usersFaction);
 
                 var barePacket = new ServerChatMessage(chatMessage);
-                var redactedPacket = App.getSnipMode() ? barePacket.asSnipRedacted() : barePacket;
-                redactedPacket = user.isShadowBanned() ? redactedPacket.asShadowBanned() : redactedPacket;
-                server.broadcastSeparateForStaff(redactedPacket, barePacket);
+                var staffPacket = App.getSnipMode() ? barePacket.asSnipRedacted() : barePacket;
+                staffPacket = user.isShadowBanned() ? staffPacket.asShadowBanned() : staffPacket;
+                if (user.isShadowBanned()) {
+                    // If the message author is shadow-banned, it should be visible to staff only.
+                    staffPacket = staffPacket.asShadowBanned();
+                    barePacket = null;
+                    if (!App.getConfig().getBoolean("chat.showShadowBannedMessagesToStaff")) {
+                        staffPacket = null;
+                    }
+                }
+                server.broadcastSeparateForStaff(staffPacket, barePacket);
             } catch (UnableToExecuteStatementException utese) {
                 utese.printStackTrace();
                 System.err.println("Failed to execute the ChatMessage insert statement.");

--- a/src/main/java/space/pxls/server/UndertowServer.java
+++ b/src/main/java/space/pxls/server/UndertowServer.java
@@ -233,8 +233,8 @@ public class UndertowServer {
     }
 
     public void broadcastSeparateForStaff(Object nonStaffObj, Object staffObj) {
-        String nonStaffJSON = App.getGson().toJson(nonStaffObj);
-        String staffJSON = App.getGson().toJson(staffObj);
+        String nonStaffJSON = nonStaffObj != null ? App.getGson().toJson(nonStaffObj) : null;
+        String staffJSON = staffObj != null ? App.getGson().toJson(staffObj) : null;
         broadcastMapped(con -> {
             boolean sendStaffObject = con.getUser().isPresent() && userCanReceiveStaffBroadcasts.test(con.getUser().get());
             return sendStaffObject ? staffJSON : nonStaffJSON;

--- a/src/main/java/space/pxls/server/packets/chat/ChatMessage.java
+++ b/src/main/java/space/pxls/server/packets/chat/ChatMessage.java
@@ -11,17 +11,19 @@ public class ChatMessage {
     public String author;
     public Long date;
     public String message_raw;
+    public Boolean authorIsShadowBanned;
     public Purge purge;
     public List<Badge> badges;
     public List<String> authorNameClass;
     public Number authorNameColor;
     public StrippedFaction strippedFaction;
 
-    public ChatMessage(int id, String author, Long date, String message_raw, Purge purge, List<Badge> badges, List<String> authorNameClass, Number authorNameColor, Faction faction) {
+    public ChatMessage(int id, String author, Long date, String message_raw, Boolean authorIsShadowBanned, Purge purge, List<Badge> badges, List<String> authorNameClass, Number authorNameColor, Faction faction) {
         this.id = id;
         this.author = author;
         this.date = date;
         this.message_raw = message_raw;
+        this.authorIsShadowBanned = authorIsShadowBanned;
         this.purge = purge;
         this.badges = badges;
         this.authorNameClass = authorNameClass;
@@ -62,7 +64,12 @@ public class ChatMessage {
     }
 
     public ChatMessage asSnipRedacted() {
-        return new ChatMessage(id, "-snip-", date, message_raw, purge, badges, authorNameClass, authorNameColor, null);
+        return new ChatMessage(id, "-snip-", date, message_raw, authorIsShadowBanned, purge, badges, authorNameClass, authorNameColor, null);
+    }
+
+    public ChatMessage asShadowBanned() {
+        // If authorIsShadowBanned is null, it is automatically skipped by Gson
+        return new ChatMessage(id, author, date, message_raw, null, purge, badges, authorNameClass, authorNameColor, null);
     }
 
     public static class StrippedFaction {

--- a/src/main/java/space/pxls/server/packets/chat/ServerChatMessage.java
+++ b/src/main/java/space/pxls/server/packets/chat/ServerChatMessage.java
@@ -19,4 +19,8 @@ public class ServerChatMessage {
     public ServerChatMessage asSnipRedacted() {
         return new ServerChatMessage(message.asSnipRedacted());
     }
+
+    public ServerChatMessage asShadowBanned() {
+        return new ServerChatMessage(message.asShadowBanned());
+    }
 }


### PR DESCRIPTION
### Database Changes

```sql
ALTER TABLE chat_messages ADD COLUMN shadow_banned BOOL NOT NULL DEFAULT false;
```

### Configuration Changes

```
chat {
    ...
    showShadowBannedMessagesToStaff: true
    ...
}
```

### Goals

This pull request aims to hide new and historical chat messages by shadow-banned users from users without the `chat.history.shadowbanned` and `user.receivestaffbroadcasts` permissions, for history and new messages respectively.  Users with said permissions will see those messages as `.9em`-sized `#F66`-colored text.

### Specifics

- For shadow-banned users, their messages will be processed but not be re-broadcast.  It will be sent back to give the illusion that the message was handled like normal.
- For users without the permissions, no packets will be received regarding new messages from shadow-banned users.
- For users with the permission, messages will have the `data-shadow-banned` element attribute and appear as `.9em`-sized `#F66`-colored text.

### Screenshots

Perspective of a shadow-banned user:

<img src="https://files.f66.dev/uploads/firefox_JAr4fgAb9Y.png">

Perspective of a user with the necessary permissions:

<img src="https://files.f66.dev/uploads/firefox_1K9bE84nyk.png">