### PR TITLE
Change 50x Zoom Limit to Min/Max Inputs

### DIFF
--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -508,11 +508,11 @@
                     <div data-keywords="zooming limit;scrolling limit;mousewheel;zooming minimum;zooming maximum">
                         <label class="input-group">
                             <span class="label-text">Minimum scale:</span>
-                            <input type="number" placeholder="0.5" step="any" min="0" max="50" class="template-coords small-input" id="setting-board-zoom-limit-minimum">
+                            <input type="number" placeholder="0.5" step="any" class="template-coords small-input" id="setting-board-zoom-limit-minimum">
                         </label>
                         <label class="input-group">
                             <span class="label-text">Maximum scale:</span>
-                            <input type="number" placeholder="50" step="any" min="0" max="50" class="template-coords small-input" id="setting-board-zoom-limit-maximum">
+                            <input type="number" placeholder="50" step="any" class="template-coords small-input" id="setting-board-zoom-limit-maximum">
                         </label>
                     </div>
                     <div data-keywords="rounding;zooming;scrolling;mousewheel;integer;decimal">

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -505,10 +505,14 @@
                             <input id="setting-board-zoom-sensitivity" type="range" min="1.01" max="3" step="0.01"/>
                         </label>
                     </div>
-                    <div data-keywords="zooming limit;scrolling limit;mousewheel;zooming maximum">
+                    <div data-keywords="zooming limit;scrolling limit;mousewheel;zooming minimum;zooming maximum">
                         <label class="input-group">
-                            <input id="setting-board-zoom-limit-enable" type="checkbox"/>
-                            <span class="label-text">Limit zoom to 50x</span>
+                            <span class="label-text">Minimum scale:</span>
+                            <input type="number" placeholder="0.5" step="0.5" min="0" max="50" class="template-coords small-input" id="setting-board-zoom-limit-minimum">
+                        </label>
+                        <label class="input-group">
+                            <span class="label-text">Maximum scale:</span>
+                            <input type="number" placeholder="50" step="0.5" min="0" max="50" class="template-coords small-input" id="setting-board-zoom-limit-maximum">
                         </label>
                     </div>
                     <div data-keywords="rounding;zooming;scrolling;mousewheel;integer;decimal">

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -54,7 +54,7 @@
 
 <div id="reconnecting">Lost connection to server, reconnecting...</div>
 
-</main>
+<main>
     <div id="board-container" style="touch-action: none">
         <div id="grid"></div>
         <div id="board-zoomer">

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -508,11 +508,11 @@
                     <div data-keywords="zooming limit;scrolling limit;mousewheel;zooming minimum;zooming maximum">
                         <label class="input-group">
                             <span class="label-text">Minimum scale:</span>
-                            <input type="number" placeholder="0.5" step="0.5" min="0" max="50" class="template-coords small-input" id="setting-board-zoom-limit-minimum">
+                            <input type="number" placeholder="0.5" step="any" min="0" max="50" class="template-coords small-input" id="setting-board-zoom-limit-minimum">
                         </label>
                         <label class="input-group">
                             <span class="label-text">Maximum scale:</span>
-                            <input type="number" placeholder="50" step="0.5" min="0" max="50" class="template-coords small-input" id="setting-board-zoom-limit-maximum">
+                            <input type="number" placeholder="50" step="any" min="0" max="50" class="template-coords small-input" id="setting-board-zoom-limit-maximum">
                         </label>
                     </div>
                     <div data-keywords="rounding;zooming;scrolling;mousewheel;integer;decimal">

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -748,7 +748,8 @@ window.App = (function() {
         zoom: {
           sensitivity: setting('board.zoom.sensitivity', SettingType.RANGE, 1.5, $('#setting-board-zoom-sensitivity')),
           limit: {
-            enable: setting('board.zoom.limit.enable', SettingType.TOGGLE, true, $('#setting-board-zoom-limit-enable'))
+            minimum: setting('board.zoom.limit.minimum', SettingType.NUMBER, 0.5, $('#setting-board-zoom-limit-minimum')),
+            maximum: setting('board.zoom.limit.maximum', SettingType.NUMBER, 50, $('#setting-board-zoom-limit-maximum'))
           },
           rounding: {
             enable: setting('board.zoom.rounding.enable', SettingType.TOGGLE, false, $('#setting-board-zoom-rounding-enable'))
@@ -1817,8 +1818,9 @@ window.App = (function() {
         return Math.abs(self.scale);
       },
       setScale: function(scale, doUpdate = true) {
-        if (settings.board.zoom.limit.enable.get() !== false && scale > 50) scale = 50;
-        else if (scale <= 0.01) scale = 0.01; // enforce the [0.01, 50] limit without blindly resetting to 0.01 when the user was trying to zoom in farther than 50x
+        const { minimum, maximum } = settings.board.zoom.limit;
+        if (scale > maximum.get()) scale = maximum.get();
+        else if (scale <= minimum.get()) scale = minimum.get(); // enforce the [x, y] limit without blindly resetting to x when the user was trying to zoom in farther than y
 
         if (settings.board.zoom.rounding.enable.get()) {
           // We round up if zooming in and round down if zooming out to ensure that the level does change


### PR DESCRIPTION
### Goals

This pull request aims to replace the "Limit zoom to 50x" option with a couple of number input boxes for custom minimum and maximum scale limits.

### Specifics

- The default minimum and maximum scales are 0.5 and 50 respectively. These are also the placeholder values.
- Users may enter any numerical input, which allows for greater freedom but may lead to bugs. For example, if the user inputs a maximum value less than the minimum value, the canvas coordinates will turn `NaN` and have unexpected behavior.

### Screenshots / Videos

https://user-images.githubusercontent.com/19217244/107891680-7c4d2800-6f20-11eb-9b06-b009c161074a.mp4

