### PR TITLE
Right Click Actions

### DIFF
--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -536,6 +536,18 @@
                             <span class="label-text">Enable middle mouse button selecting color from board</span>
                         </label>
                     </div>
+                    <div data-keywords="right click action">
+                        <label class="input-group">
+                            <span class="label-text">Right-click action:</span>
+                            <select id="setting-ui-right-click-action">
+                                <option value="nothing">Nothing</option>
+                                <option value="clear">Clear color</option>
+                                <option value="copy">Copy color</option>
+                                <option value="lookup">Lookup</option>
+                                <option value="clearlookup">Clear color + Lookup</option>
+                            </select>
+                        </label>
+                    </div>
                 </section>
             </div>
         </article>

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -54,7 +54,7 @@
 
 <div id="reconnecting">Lost connection to server, reconnecting...</div>
 
-</main>
+<main>
     <div id="board-container" style="touch-action: none">
         <div id="grid"></div>
         <div id="board-zoomer">

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -778,6 +778,9 @@ window.App = (function() {
         picker: {
           enable: setting('place.picker.enable', SettingType.TOGGLE, true, $('#setting-place-picker-enable'))
         },
+        rightclick: {
+          action: setting('ui.rightclick.action', SettingType.SELECT, 'nothing', $('#setting-ui-right-click-action'))
+        },
         alert: {
           delay: setting('place.alert.delay', SettingType.NUMBER, 0, $('#setting-place-alert-delay'))
         }
@@ -1482,7 +1485,24 @@ window.App = (function() {
           .on('pointerup mouseup touchend', handleInputUp)
           .contextmenu(function(evt) {
             evt.preventDefault();
-            place.switch(-1);
+            switch (settings.place.rightclick.action.get()) {
+              case 'clear':
+                place.switch(-1);
+                break;
+              case 'copy': {
+                const coordinates = board.fromScreen(evt.clientX, evt.clientY, true);
+                const index = board.getPixelIndex(coordinates.x, coordinates.y);
+                place.switch(index);
+                break;
+              }
+              case 'lookup':
+                lookup.runLookup(evt.clientX, evt.clientY);
+                break;
+              case 'clearlookup':
+                place.switch(-1);
+                lookup.runLookup(evt.clientX, evt.clientY);
+                break;
+            }
           });
 
         // Separated some of these events from jQuery to deal with chrome's complaints about passive event violations.


### PR DESCRIPTION
### Goals

This pull request aims to add five possible actions to choose from when the user performs a right-click on the canvas:

- Nothing
- Clear color
- Copy color
- Lookup
- Clear color + Lookup

I was also getting tired of accidentally right-clicking a second before a pixel became available, so instead of removing that functionality altogether, expand upon it!

### Specifics

- A "Right-click action" drop-down box (`select`) is added to the bottom of the _Control Settings_ category with the five options listed above:
- If "Nothing" is selected, nothing will occur when the user right-clicks the canvas.
- If "Clear color" is selected, the user's palette selection will clear, as with current functionality.
- If "Copy color" is selected, the user's palette selection will change to the highlighted pixel's color. Transparent pixels will count as deselecting by existing design. Toggling the "Ignore placemap" option makes no difference.
- If "Lookup" is selected, the user will perform an instant lookup on the highlighted pixel.
- If "Clear color + Lookup" is selected, their palette selection will be cleared and they will perform a lookup.
- The default action is to do nothing.

### Screenshots / Videos

<img src="https://files.f66.dev/uploads/firefox_fwhvA7X0lc.png">