### PR TITLE
Use CSS transition for fading overlays

### DIFF
--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -56,7 +56,7 @@
 
 <main>
     <div id="board-container" style="touch-action: none">
-        <div id="grid"></div>
+        <div id="grid" class="overlay transparent"></div>
         <div id="board-zoomer">
             <div id="board-mover">
                 <canvas id="board" class="pixelate noselect" width="100" height="100"></canvas>

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -2049,7 +2049,7 @@ window.App = (function() {
       const self = {
         name: name,
         elements: {
-          overlay: crel('canvas', { id: name, class: 'pixelate noselect' })
+          overlay: crel('canvas', { id: name, class: 'pixelate noselect overlay transparent' })
         },
         ctx: null,
         width: null,
@@ -2102,7 +2102,7 @@ window.App = (function() {
         setOpacity: function(opacity) {
           $(self.elements.overlay).css('opacity', opacity);
         },
-        setShown: function(value = self.isShown, fadeTime = 200) {
+        setShown: function(value = self.isShown) {
           self.isShown = value === true;
 
           if (!self.lazyInitStarted) {
@@ -2114,11 +2114,7 @@ window.App = (function() {
             return;
           }
 
-          if (self.isShown) {
-            $(self.elements.overlay).fadeIn(fadeTime);
-          } else {
-            $(self.elements.overlay).fadeOut(fadeTime);
-          }
+          $(self.elements.overlay).toggleClass('transparent', !self.isShown);
         },
         remove: function() {
           self.elements.overlay.remove();
@@ -2132,7 +2128,6 @@ window.App = (function() {
         }
       };
 
-      $(self.elements.overlay).hide();
       $('#board-mover').prepend(self.elements.overlay);
 
       return {
@@ -2683,13 +2678,8 @@ window.App = (function() {
         grid: $('#grid')
       },
       init: function() {
-        self.elements.grid.hide();
         settings.board.grid.enable.listen(function(value) {
-          if (value) {
-            self.elements.grid.fadeIn({ duration: 100 });
-          } else {
-            self.elements.grid.fadeOut({ duration: 100 });
-          }
+          self.elements.grid.toggleClass('transparent', !value);
         });
         $(document.body).on('keydown', function(evt) {
           if (['INPUT', 'TEXTAREA'].includes(evt.target.nodeName)) {

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -1034,6 +1034,16 @@ body:not(.show-placeable-bubble) #placeableInfoBubble {
     display: inline-block;
 }
 
+.overlay {
+    transition: opacity 200ms;
+}
+
+.overlay.transparent {
+    /* NOTE ([  ]): Since overlays set opacity using the style property directly,
+                    the opacity for invisible overlays needs to be !important. */
+    opacity: 0 !important;
+}
+
 /*//////////////////////////*\
 | Button Bar
 \*\\\\\\\\\\\\\\\\\\\\\\\\\\*/


### PR DESCRIPTION
This allows the overlay to always fade in the correct direction, never falling behind the actual keypress. This is less of an issue since #500 was merged, but just because it's harder to notice doesn't mean it's not still an issue.

There may be some associated performance cost for this, though it could also be more efficient — I haven't looked into it.

