### PR TITLE
template url autocomplete=off to fix parameter reset

### DIFF
--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -592,7 +592,7 @@
                     <div data-keywords="template location;template source;template=">
                         <label class="input-group">
                             <span class="label-text">URL:</span>
-                            <input class="fullwidth" type="text" id="template-url">
+                            <input class="fullwidth" type="text" id="template-url" autocomplete="off">
                         </label>
                         <label id="template-image-error-warning" for="template-url" class="text-red extra-label"></label>
                     </div>


### PR DESCRIPTION
https://discord.com/channels/298948748317294592/455255880888483840/847514120453619722

tl;dr: Chrome's form autofill when re-opening a tab triggers the change event on the template url input, which triggers an update function call, which in turn resets all the other parameters (ox, oy, tw, title) as those haven't been initialized at that point. Disabling autocomplete prevents this from happening, native code still sets that value from the URL anyway.

pros of this change: prevents the parameters from resetting, yay

cons of this change: may not be the best solution; instead, the inputs shouldn't be set up to trigger until after values have been initialized, which would make any autofill not be an issue. The code jumps around a lot, so figuring out where to change the order of code might be of interest to someone else. I did also notice at least one bit of code - the queue system which relies on setTimeout - which might throw a wrench into the works with that as well.