### PR TITLE
Fix pixel counter sometimes being one higher than expected

### DIFF
--- a/resources/public/include/timer.js
+++ b/resources/public/include/timer.js
@@ -12,15 +12,17 @@ module.exports.timer = (function() {
       timer_countdown: $('#cooldown-timer'),
       timer_chat: $('#txtMobileChatCooldown')
     },
+    hasCooledDown: false,
     hasFiredNotification: true,
     cooldown: 0,
     runningTimer: false,
     audio: new Audio('notify.wav'),
     title: '',
     cooledDown: function() {
-      return self.cooldown < (new Date()).getTime();
+      return self.hasCooledDown;
     },
     update: function(die) {
+      self.hasCooledDown = false;
       // subtract one extra millisecond to prevent the first displaying to be derped
       let delta = (self.cooldown - (new Date()).getTime() - 1) / 1000;
 
@@ -40,6 +42,7 @@ module.exports.timer = (function() {
           notif = nativeNotifications.maybeShow(`Your next pixel will be available in ${Math.abs(alertDelay)} seconds!`);
         }
         setTimeout(() => {
+          self.hasCooledDown = true;
           uiHelper.setPlaceableText(1);
           if (notif) {
             $(window).one('pxls:ack:place', () => notif.close());
@@ -85,6 +88,7 @@ module.exports.timer = (function() {
               $(window).one('pxls:ack:place', () => notif.close());
             }
           }
+          self.hasCooledDown = true;
           uiHelper.setPlaceableText(1);
           self.hasFiredNotification = true;
         }, alertDelay * 1000);
@@ -99,6 +103,7 @@ module.exports.timer = (function() {
             $(window).one('pxls:ack:place', () => notif.close());
           }
         }
+        self.hasCooledDown = true;
         uiHelper.setPlaceableText(1);
         self.hasFiredNotification = true;
       }
@@ -109,7 +114,8 @@ module.exports.timer = (function() {
       self.elements.timer_chat.text('');
 
       setTimeout(function() {
-        if (self.cooledDown() && uiHelper.getAvailable() === 0) {
+        if (self.cooldown < (new Date()).getTime() && uiHelper.getAvailable() === 0) {
+          self.hasCooledDown = true;
           uiHelper.setPlaceableText(1);
         }
       }, 250);


### PR DESCRIPTION
This should fix the longstanding bug where the count would be one higher than it should. This is probably one of the simpler ways to do this, but reworking the entirety of the timer is probably a better solution.

My reasoning for this fixing the bug is that the bug occurs when:
- The current time is after the locally stored cooldown.
- The client timeout for updating the final timer tick is pending.
- The server responds to a placement before the timeout happens.

By waiting for the UI update rather than the cooldown in the first of these assumptions, the bug should disappear 🤞