### PR TITLE
Add option to replace usernames with hashes in log sanitization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .gradle/
 target/
 run/
+/logs
 *.log
 backups/
 .settings/


### PR DESCRIPTION
These hashes are generated based on keys unique to each user. The idea is that each log entry can be verified to pertain to a user if that user's key is known.

The hashes are computed using the other outputted data in the log entry as follows:

`sha256('{date},{x},{y},{color_index},{key}')`

with the input to `sha256` being a utf-8 string and the output being bytes represented by a hexidecimal string.