### PR TITLE
Re-apply fix for template parameter reset

### DIFF
--- a/resources/public/pebble_templates/index.html
+++ b/resources/public/pebble_templates/index.html
@@ -596,7 +596,7 @@
                     <div data-keywords="{{i18n('Localization', 'template location;template source;template=') | raw}}">
                         <label class="input-group">
                             <span class="label-text">{{i18n('Localization', 'URL:') | raw}}</span>
-                            <input class="fullwidth" type="text" id="template-url">
+                            <input class="fullwidth" type="text" id="template-url" autocomplete="off">
                         </label>
                         <label id="template-image-error-warning" for="template-url" class="text-red extra-label"></label>
                     </div>


### PR DESCRIPTION
This was originally fixed in #504, then broken again when #475 was merged.