### PR TITLE
Remove double-escaped newline in settings

### DIFF
--- a/po/Localization.po
+++ b/po/Localization.po
@@ -312,8 +312,8 @@ msgid "<kbd>V</kbd> to toggle visibility"
 msgstr "<kbd>V</kbd> to toggle visibility"
 
 #: resources/public/pebble_templates/index.html:252:24
-msgid "Note: These values are based on QWERTY keyboards.\\nFor other layouts, use the keys corresponding to the same position on a QWERTY keyboard."
-msgstr "Note: These values are based on QWERTY keyboards.\\nFor other layouts, use the keys corresponding to the same position on a QWERTY keyboard."
+msgid "Note: These values are based on QWERTY keyboards. For other layouts, use the keys corresponding to the same position on a QWERTY keyboard."
+msgstr "Note: These values are based on QWERTY keyboards. For other layouts, use the keys corresponding to the same position on a QWERTY keyboard."
 
 #: resources/public/pebble_templates/index.html:256:36
 msgid "ui;interface"

--- a/po/Localization.pot
+++ b/po/Localization.pot
@@ -312,7 +312,7 @@ msgid "<kbd>V</kbd> to toggle visibility"
 msgstr ""
 
 #: resources/public/pebble_templates/index.html:252:24
-msgid "Note: These values are based on QWERTY keyboards.\\nFor other layouts, use the keys corresponding to the same position on a QWERTY keyboard."
+msgid "Note: These values are based on QWERTY keyboards. For other layouts, use the keys corresponding to the same position on a QWERTY keyboard."
 msgstr ""
 
 #: resources/public/pebble_templates/index.html:256:36

--- a/po/Localization_fr.po
+++ b/po/Localization_fr.po
@@ -312,8 +312,8 @@ msgid "<kbd>V</kbd> to toggle visibility"
 msgstr "<kbd>V</kbd> pour activer/désactiver la visibilité d'un modèle"
 
 #: resources/public/pebble_templates/index.html:252:24
-msgid "Note: These values are based on QWERTY keyboards.\\nFor other layouts, use the keys corresponding to the same position on a QWERTY keyboard."
-msgstr "Note : Ces touches sont basées sur les claviers QWERTY. \\nPour d'autres claviers, utilise les touches correspondantes aux positions sur un clavier QWERTY."
+msgid "Note: These values are based on QWERTY keyboards. For other layouts, use the keys corresponding to the same position on a QWERTY keyboard."
+msgstr "Note : Ces touches sont basées sur les claviers QWERTY. Pour d'autres claviers, utilise les touches correspondantes aux positions sur un clavier QWERTY."
 
 #: resources/public/pebble_templates/index.html:256:36
 msgid "ui;interface"

--- a/resources/Localization.properties
+++ b/resources/Localization.properties
@@ -236,7 +236,7 @@ hidden;shown;hide;show=hidden;shown;hide;show
 <kbd>V</kbd>\ to\ toggle\ visibility=<kbd>V</kbd> to toggle visibility
 
 #: resources/public/pebble_templates/index.html:252:24
-Note\:\ These\ values\ are\ based\ on\ QWERTY\ keyboards.\\nFor\ other\ layouts,\ use\ the\ keys\ corresponding\ to\ the\ same\ position\ on\ a\ QWERTY\ keyboard.=Note\: These values are based on QWERTY keyboards.\\nFor other layouts, use the keys corresponding to the same position on a QWERTY keyboard.
+Note\:\ These\ values\ are\ based\ on\ QWERTY\ keyboards.\ For\ other\ layouts,\ use\ the\ keys\ corresponding\ to\ the\ same\ position\ on\ a\ QWERTY\ keyboard.=Note\: These values are based on QWERTY keyboards. For other layouts, use the keys corresponding to the same position on a QWERTY keyboard.
 
 #: resources/public/pebble_templates/index.html:256:36
 ui;interface=ui;interface

--- a/resources/Localization_fr.properties
+++ b/resources/Localization_fr.properties
@@ -236,7 +236,7 @@ hidden;shown;hide;show=cach\u00e9;affich\u00e9;cacher;afficher
 <kbd>V</kbd>\ to\ toggle\ visibility=<kbd>V</kbd> pour activer/d\u00e9sactiver la visibilit\u00e9 d'un mod\u00e8le
 
 #: resources/public/pebble_templates/index.html:252:24
-Note\:\ These\ values\ are\ based\ on\ QWERTY\ keyboards.\\nFor\ other\ layouts,\ use\ the\ keys\ corresponding\ to\ the\ same\ position\ on\ a\ QWERTY\ keyboard.=Note \: Ces touches sont bas\u00e9es sur les claviers QWERTY. \\nPour d'autres claviers, utilise les touches correspondantes aux positions sur un clavier QWERTY.
+Note\:\ These\ values\ are\ based\ on\ QWERTY\ keyboards.\ For\ other\ layouts,\ use\ the\ keys\ corresponding\ to\ the\ same\ position\ on\ a\ QWERTY\ keyboard.=Note \: Ces touches sont bas\u00e9es sur les claviers QWERTY. Pour d'autres claviers, utilise les touches correspondantes aux positions sur un clavier QWERTY.
 
 #: resources/public/pebble_templates/index.html:256:36
 ui;interface=interface utilisateur;interface
@@ -515,7 +515,7 @@ scrolling\ sensitivity;zooming\ sensitivity;mousewheel\ sensitivity=sensibilit\u
 Zoom\ sensitivity\:=Sensibilit\u00e9 du zoom \:
 
 #: resources/public/pebble_templates/index.html:512:44
-zooming\ limit;scrolling\ limit;mousewheel;zooming\ minimum;zooming\ maximum=limites du zoom;limites du scroll;roulette de souris;molette de souris;maximum du zoom
+zooming\ limit;scrolling\ limit;mousewheel;zooming\ minimum;zooming\ maximum=limites du zoom;limites du scroll;roulette de souris;molette de souris;minimum du zoom;maximum du zoom
 
 #: resources/public/pebble_templates/index.html:514:57
 Minimum\ scale\:=\u00c9chelle minimale \:

--- a/resources/public/pebble_templates/index.html
+++ b/resources/public/pebble_templates/index.html
@@ -249,7 +249,7 @@
 
                 <br/>
                 <small>
-                    {{i18n('Localization', 'Note: These values are based on QWERTY keyboards.\nFor other layouts, use the keys corresponding to the same position on a QWERTY keyboard.') | raw}}
+                    {{i18n('Localization', 'Note: These values are based on QWERTY keyboards. For other layouts, use the keys corresponding to the same position on a QWERTY keyboard.') | raw}}
                 </small>
             </div>
         </article>


### PR DESCRIPTION
Replacing it with a regular space has the same effect as if it were properly escaped.