### PR TITLE
Remove extra opening bracket in report header

### DIFF
--- a/resources/public/pebble_templates/profile.html
+++ b/resources/public/pebble_templates/profile.html
@@ -137,7 +137,7 @@
                                             <div class="card-header">
                                                 <button class="btn btn-sm mr-2 btn-info" data-action="collapse"><i class="fas fa-chevron-down"></i></button>
                                                 <span class="{% if report.closed %}text-success{% else %}text-warning{% endif %}">
-                                                    ({% if report.closed %}
+                                                    {% if report.closed %}
                                                     {# eg "Report on Bob (closed) #}
                                                     {{i18n('Localization', 'Report on {0} (closed)', reportedName) | raw}}
                                                     {% else %}


### PR DESCRIPTION
This was introduced when refactoring this code to be more localization friendly. Previously, the condition was only checked at the end of the text, allowing the brackets around "(closed)" and "(open)" to be outside of the check. When moving this check to encompass the entire output, I failed to delete the opening bracket before the condition check.

The fix is trivial — just remove the opening bracket.