### PR TITLE
Implement localization for script strings

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -21,6 +21,7 @@
     // Pxls-specific
     "App": "writable",
     "SLIDEIN": "readonly",
-    "interact": "readonly"
+    "interact": "readonly",
+    "__": "writable"
   }
 }

--- a/generate-potfile.js
+++ b/generate-potfile.js
@@ -1,7 +1,56 @@
 const fs = require('fs');
 const PO = require('pofile');
+const esprima = require('esprima');
 
-const FILES = [
+const {
+  AssignmentExpression,
+  AssignmentPattern,
+  FunctionExpression,
+  ExpressionStatement,
+  BlockStatement,
+  CallExpression,
+  IfStatement,
+  BinaryExpression,
+  StaticMemberExpression,
+  ComputedMemberExpression,
+  Identifier,
+  ForInStatement,
+  MemberExpression,
+  ClassDeclaration,
+  ClassBody,
+  VariableDeclaration,
+  VariableDeclarator,
+  ThisExpression,
+  ArrowFunctionExpression,
+  LogicalExpression,
+  ReturnStatement,
+  ObjectExpression,
+  Property,
+  SpreadElement,
+  Literal,
+  ArrayExpression,
+  ForStatement,
+  UpdateExpression,
+  NewExpression,
+  UnaryExpression,
+  FunctionDeclaration,
+  TemplateLiteral,
+  ConditionalExpression,
+  SwitchStatement,
+  SwitchCase,
+  TryStatement,
+  CatchClause,
+  RestElement,
+  ObjectPattern,
+  BreakStatement,
+  ForOfStatement,
+  AwaitExpression,
+  WhileStatement,
+  ThrowStatement,
+  ContinueStatement
+} = esprima.Syntax;
+
+const PEBBLE_FILES = [
   'resources/public/pebble_templates/index.html',
   'resources/public/pebble_templates/faq.html',
   'resources/public/pebble_templates/info.html',
@@ -28,7 +77,20 @@ const globalOffsetToLocal = (text, offset) => offset - text.slice(0, offset).las
 
 const itemsByIdByPofile = new Map();
 
-for (const path of FILES) {
+function createPoFile(name) {
+  const poFile = new PO();
+  poFile.headers['Project-Id-Version'] = 'Pxls';
+  poFile.headers['POT-Creation-Date'] = (new Date()).toISOString();
+  // "Better written as…" no it's not - look at the context.
+  /* eslint-disable-next-line dot-notation */
+  poFile.headers['Language'] = '';
+  poFile.headers['Content-Type'] = 'text/plain; charset=UTF-8';
+
+  itemsByIdByPofile.set(name, new Map());
+  poFiles.set(name, poFile);
+}
+
+for (const path of PEBBLE_FILES) {
   const file = fs.readFileSync(path).toString();
 
   const commentsByLine = new Map();
@@ -92,16 +154,7 @@ for (const path of FILES) {
       const [poFileName, id] = params;
 
       if (!poFiles.has(poFileName)) {
-        const poFile = new PO();
-        poFiles.set(poFileName, poFile);
-        poFile.headers['Project-Id-Version'] = 'Pxls';
-        poFile.headers['POT-Creation-Date'] = (new Date()).toISOString();
-        // "Better written as…" no it's not - look at the context.
-        /* eslint-disable-next-line dot-notation */
-        poFile.headers['Language'] = '';
-        poFile.headers['Content-Type'] = 'text/plain; charset=UTF-8';
-
-        itemsByIdByPofile.set(poFileName, new Map());
+        createPoFile(poFileName);
       }
 
       const poFile = poFiles.get(poFileName);
@@ -131,10 +184,264 @@ for (const path of FILES) {
   }
 }
 
+// TODO: maybe just use ttag instead?
+
+const JS_FILES = [
+  'resources/public/pxls.js',
+  'resources/public/include/ban.js',
+  'resources/public/include/board.js',
+  'resources/public/include/chat.js',
+  'resources/public/include/chromeOffsetWorkaround.js',
+  'resources/public/include/coords.js',
+  'resources/public/include/grid.js',
+  'resources/public/include/helpers.js',
+  'resources/public/include/lookup.js',
+  'resources/public/include/modal.js',
+  'resources/public/include/nativeNotifications.js',
+  'resources/public/include/notifications.js',
+  'resources/public/include/overlays.js',
+  'resources/public/include/panels.js',
+  'resources/public/include/place.js',
+  'resources/public/include/query.js',
+  'resources/public/include/serviceworkers.js',
+  'resources/public/include/settings.js',
+  'resources/public/include/socket.js',
+  'resources/public/include/storage.js',
+  'resources/public/include/template.js',
+  'resources/public/include/timer.js',
+  'resources/public/include/typeahead.js',
+  'resources/public/include/uiHelper.js',
+  'resources/public/include/user.js',
+  'resources/public/admin/admin.js'
+];
+
+const GETTEXT_FUNCTION_NAME = '__';
+const JS_POFILE = 'Localization';
+
+function isGettextCall(callExpression) {
+  return callExpression.callee.type === Identifier &&
+    callExpression.callee.name === GETTEXT_FUNCTION_NAME;
+}
+
+const translatableStrings = [];
+
+function addTranslatableStringsFromExpression(expression) {
+  if (expression === null) {
+    return;
+  }
+
+  switch (expression.type) {
+    case ExpressionStatement:
+      addTranslatableStringsFromExpression(expression.expression);
+      break;
+    case VariableDeclaration:
+      for (const declaration of expression.declarations) {
+        addTranslatableStringsFromExpression(declaration);
+      }
+      break;
+    case VariableDeclarator:
+      addTranslatableStringsFromExpression(expression.init);
+      break;
+    case AssignmentPattern:
+    case AssignmentExpression:
+      addTranslatableStringsFromExpression(expression.right);
+      break;
+    case ArrowFunctionExpression:
+    case FunctionDeclaration:
+    case FunctionExpression:
+      for (const parameter of expression.params) {
+        addTranslatableStringsFromExpression(parameter);
+      }
+      addTranslatableStringsFromExpression(expression.body);
+      break;
+    case ClassBody:
+    case BlockStatement:
+      for (const nestedExpression of expression.body) {
+        addTranslatableStringsFromExpression(nestedExpression);
+      }
+      break;
+    case NewExpression:
+      addTranslatableStringsFromExpression(expression.callee);
+      for (const argument of expression.arguments) {
+        addTranslatableStringsFromExpression(argument);
+      }
+      break;
+    case CallExpression:
+      if (isGettextCall(expression)) {
+        if (expression.arguments.length !== 1) {
+          throw new Error(`Invalid call to gettext: expected exactly one argument: ${expression}`);
+        }
+
+        const [argument] = expression.arguments;
+        translatableStrings.push(argument.range);
+      } else {
+        addTranslatableStringsFromExpression(expression.callee);
+        for (const argument of expression.arguments) {
+          addTranslatableStringsFromExpression(argument);
+        }
+      }
+      break;
+    case WhileStatement:
+      addTranslatableStringsFromExpression(expression.test);
+      addTranslatableStringsFromExpression(expression.body);
+      break;
+    case ConditionalExpression:
+    case IfStatement:
+      addTranslatableStringsFromExpression(expression.test);
+      addTranslatableStringsFromExpression(expression.consequent);
+      addTranslatableStringsFromExpression(expression.alternate);
+      break;
+    case ForStatement:
+      addTranslatableStringsFromExpression(expression.init);
+      addTranslatableStringsFromExpression(expression.test);
+      addTranslatableStringsFromExpression(expression.update);
+      addTranslatableStringsFromExpression(expression.body);
+      break;
+    case ForOfStatement:
+    case ForInStatement:
+      addTranslatableStringsFromExpression(expression.right);
+      addTranslatableStringsFromExpression(expression.body);
+      break;
+    case SwitchStatement:
+      addTranslatableStringsFromExpression(expression.discriminant);
+      for (const switchcase of expression.cases) {
+        addTranslatableStringsFromExpression(switchcase);
+      }
+      break;
+    case SwitchCase:
+      for (const nestedExpression of expression.consequent) {
+        addTranslatableStringsFromExpression(nestedExpression);
+      }
+      break;
+    case ClassDeclaration:
+      addTranslatableStringsFromExpression(expression.body);
+      break;
+    case LogicalExpression:
+    case BinaryExpression:
+      addTranslatableStringsFromExpression(expression.left);
+      addTranslatableStringsFromExpression(expression.right);
+      break;
+    case ObjectPattern:
+    case ObjectExpression:
+      for (const property of expression.properties) {
+        addTranslatableStringsFromExpression(property);
+      }
+      break;
+    case Property:
+      addTranslatableStringsFromExpression(expression.value);
+      break;
+    case ThrowStatement:
+    case ReturnStatement:
+    case AwaitExpression:
+    case RestElement:
+    case SpreadElement:
+      addTranslatableStringsFromExpression(expression.argument);
+      break;
+    case ArrayExpression:
+      for (const element of expression.elements) {
+        addTranslatableStringsFromExpression(element);
+      }
+      break;
+    case TryStatement:
+    case CatchClause:
+      addTranslatableStringsFromExpression(expression.block);
+      break;
+    case TemplateLiteral:
+      for (const nestedExpression of expression.expressions) {
+        addTranslatableStringsFromExpression(nestedExpression);
+      }
+      break;
+    case ThisExpression:
+    case MemberExpression:
+    case ComputedMemberExpression:
+    case StaticMemberExpression:
+    case Identifier:
+    case Literal:
+    case UpdateExpression:
+    case UnaryExpression:
+    case BreakStatement:
+    case ContinueStatement:
+      break;
+    default:
+      console.debug(`Unknown expression type: ${expression.type}`);
+      console.debug(expression);
+  }
+}
+
+if (!poFiles.has(JS_POFILE)) {
+  createPoFile(JS_POFILE);
+}
+
+const jsPoFile = poFiles.get(JS_POFILE);
+const jsItemsById = itemsByIdByPofile.get(JS_POFILE);
+
+const TRANSLATOR_COMMENT_REGEX = /^\s*translator:\s?(.*)$/i;
+
+for (const path of JS_FILES) {
+  const file = fs.readFileSync(path).toString();
+  const script = esprima.parseScript(file, { range: true, comment: true });
+
+  for (const expression of script.body) {
+    addTranslatableStringsFromExpression(expression);
+  }
+
+  for (const [start, end] of translatableStrings) {
+    const relevantComments = script.comments.filter(comment => {
+      const [commentStart, commentEnd] = comment.range;
+
+      if (!TRANSLATOR_COMMENT_REGEX.test(comment.value)) {
+        return false;
+      }
+
+      if (commentEnd < start) {
+        // before string
+
+        const newlineCount = Array.from(file
+          .substring(commentEnd, start)
+          .matchAll('\n')).length;
+
+        return newlineCount < 2;
+      } else {
+        // after string
+
+        const hasNewline = file
+          .substring(end, commentStart)
+          .indexOf('\n') !== -1;
+
+        return !hasNewline;
+      }
+    }).map(comment => TRANSLATOR_COMMENT_REGEX.exec(comment.value)[1]);
+
+    const id = contract(file.substring(start, end), 1);
+    const callLine = offsetToLine(file, start);
+    const callLocalOffset = globalOffsetToLocal(file, start);
+
+    if (!jsItemsById.has(id)) {
+      stringCount++;
+      const item = new PO.Item();
+      jsItemsById.set(id, item);
+      jsPoFile.items.push(item);
+    }
+
+    const item = jsItemsById.get(id);
+
+    item.msgid = id;
+    item.references.push(`${path}:${callLine + 1}:${callLocalOffset + 1}`);
+
+    for (const comment of relevantComments) {
+      item.extractedComments.push(comment);
+    }
+  }
+
+  // clear the strings array
+  // because none of this code is well-structured
+  translatableStrings.splice(0);
+}
+
 for (const [name, poFile] of poFiles.entries()) {
   poFile.save(`po/${name}.pot`, e => e ? console.error : null);
 }
 
-console.info(`Parsed ${FILES.length} files.`);
+console.info(`Parsed ${PEBBLE_FILES.length + JS_FILES.length} files.`);
 console.info(`${stringCount} strings found.`);
 console.info(`Output ${poFiles.size} files.`);

--- a/generate-potfile.js
+++ b/generate-potfile.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const PO = require('pofile');
 const esprima = require('esprima');
 
-const { findTranslationCalls } = require('./localization-util');
+const { findTranslationCalls, contract, shave } = require('./localization-util');
 
 const PEBBLE_FILES = [
   'resources/public/pebble_templates/index.html',
@@ -18,9 +18,6 @@ const PEBBLE_CODE_MATCH = /{([%])((?!\1}).)*\1}|{{((?!}}).)*}}/g;
 const I18N_MATCH = /i18n\s*[(]/g;
 // a string matching regex, handles escapes and escaped escapes.
 const STRING_MATCH = /(["'])((\\{2})*|(.*?[^\\](\\{2})*))\1/g;
-
-const contract = (s, size) => s.slice(size, -size);
-const shave = (s, size) => contract(s, size).trim();
 
 const poFiles = new Map();
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,6 +7,12 @@ const gulpIf = require('gulp-if');
 const browserify = require('browserify');
 const tap = require('gulp-tap');
 const buffer = require('gulp-buffer');
+const through = require('through2');
+const esprima = require('esprima');
+const PO = require('pofile');
+const rename = require('gulp-rename');
+
+const { findTranslationCalls, contract } = require('./localization-util');
 
 const isDevEnvironment = process.env.NODE_ENV === 'dev';
 
@@ -45,22 +51,80 @@ function lint() {
     .pipe(eslint.failAfterError());
 }
 
+function translate(pofile) {
+  return through.obj(function(file, enc, callback) {
+    if (file.isBuffer()) {
+      PO.load(pofile, (error, pofile) => {
+        if (error) {
+          callback(error);
+        } else {
+          let contents = file.contents.toString();
+          const script = esprima.parseScript(contents, { range: true });
+          const translationCalls = script.body
+            .map(findTranslationCalls)
+            .flat()
+            .sort((a, b) => a.range.start - b.range.start);
+
+          let offset = 0;
+
+          for (const call of translationCalls) {
+            const [argument] = call.arguments;
+
+            const [start, end] = call.range;
+            const length = end - start;
+
+            const original = contract(contents.substring(...argument.range.map(p => p + offset)), 1);
+            const quote = contents[argument.range[0] + offset];
+
+            const item = pofile.items.find(i => i.msgid === original);
+
+            const replaceContent = (item && item.msgstr[0]) || original;
+            const replace = quote + replaceContent.replace(new RegExp(`([^\\\\])([${quote}])`, 'g'), '$1\\$2') + quote;
+            contents = contents.substring(0, offset + start) + replace + contents.substring(offset + end);
+            offset += replace.length - length;
+          }
+
+          file.contents = Buffer.from(contents);
+
+          callback(null, file);
+        }
+      });
+    } else {
+      callback(new Error('Expected buffer'));
+    }
+  });
+}
+
 function srcJS () {
-  return src([...SOURCE_FILES, '!resources/public/include/**/*.js', '!resources/public/profile/**/*.js'], { read: false })
-    .pipe(tap(file => {
-      file.contents = browserify(file.path, { debug: isDevEnvironment })
-        .bundle();
-    }))
-    .pipe(buffer())
-    .pipe(gulpIf(isDevEnvironment, sourcemaps.init({ loadMaps: true })))
-    .pipe(minify({
-      ext: {
-        src: '.src.js',
-        min: '.js'
-      }
-    }))
-    .pipe(gulpIf(isDevEnvironment, sourcemaps.write()))
-    .pipe(dest('target/classes/public'));
+  return src(['po/*.po'])
+    .pipe(through.obj(function(file, enc, callback) {
+      const codeIndex = file.basename.lastIndexOf('_');
+      const extIndex = file.basename.lastIndexOf('.');
+      const langcode = codeIndex === -1
+        ? ''
+        : file.basename.substring(codeIndex, extIndex === -1
+          ? file.basename.length
+          : extIndex);
+
+      src([...SOURCE_FILES, '!resources/public/include/**/*.js', '!resources/public/profile/**/*.js'], { read: false })
+        .pipe(tap(file => {
+          file.contents = browserify(file.path, { debug: isDevEnvironment })
+            .bundle();
+        }))
+        .pipe(buffer())
+        .pipe(translate(file.path))
+        .pipe(gulpIf(isDevEnvironment, sourcemaps.init({ loadMaps: true })))
+        .pipe(minify({
+          ext: {
+            src: '.src.js',
+            min: '.js'
+          }
+        }))
+        .pipe(gulpIf(isDevEnvironment, sourcemaps.write()))
+        .pipe(rename({ suffix: langcode }))
+        .pipe(dest('target/classes/public'))
+        .once('end', callback);
+    }));
 }
 
 exports.html = html;

--- a/localization-util.js
+++ b/localization-util.js
@@ -1,0 +1,180 @@
+const esprima = require('esprima');
+
+const {
+  AssignmentExpression,
+  AssignmentPattern,
+  FunctionExpression,
+  ExpressionStatement,
+  BlockStatement,
+  CallExpression,
+  IfStatement,
+  BinaryExpression,
+  StaticMemberExpression,
+  ComputedMemberExpression,
+  Identifier,
+  ForInStatement,
+  MemberExpression,
+  ClassDeclaration,
+  ClassBody,
+  VariableDeclaration,
+  VariableDeclarator,
+  ThisExpression,
+  ArrowFunctionExpression,
+  LogicalExpression,
+  ReturnStatement,
+  ObjectExpression,
+  Property,
+  SpreadElement,
+  Literal,
+  ArrayExpression,
+  ForStatement,
+  UpdateExpression,
+  NewExpression,
+  UnaryExpression,
+  FunctionDeclaration,
+  TemplateLiteral,
+  ConditionalExpression,
+  SwitchStatement,
+  SwitchCase,
+  TryStatement,
+  CatchClause,
+  RestElement,
+  ObjectPattern,
+  BreakStatement,
+  ForOfStatement,
+  AwaitExpression,
+  WhileStatement,
+  ThrowStatement,
+  ContinueStatement
+} = esprima.Syntax;
+
+function isGettextCall(callExpression) {
+  return callExpression.callee.type === Identifier &&
+    callExpression.callee.name === GETTEXT_FUNCTION_NAME;
+}
+
+const GETTEXT_FUNCTION_NAME = '__';
+function findTranslationCalls(expression) {
+  if (expression === null) {
+    return [];
+  }
+
+  switch (expression.type) {
+    case ExpressionStatement:
+      return findTranslationCalls(expression.expression);
+    case VariableDeclaration:
+      return expression.declarations
+        .map(findTranslationCalls)
+        .flat();
+    case VariableDeclarator:
+      return findTranslationCalls(expression.init);
+    case AssignmentPattern:
+    case AssignmentExpression:
+      return findTranslationCalls(expression.right);
+    case ArrowFunctionExpression:
+    case FunctionDeclaration:
+    case FunctionExpression:
+      return expression.params
+        .map(findTranslationCalls)
+        .concat(findTranslationCalls(expression.body))
+        .flat();
+    case ClassBody:
+    case BlockStatement:
+      return expression.body
+        .map(findTranslationCalls)
+        .flat();
+    case NewExpression:
+      return expression.arguments
+        .map(findTranslationCalls)
+        .concat(findTranslationCalls(expression.callee))
+        .flat();
+    case CallExpression:
+      if (isGettextCall(expression)) {
+        if (expression.arguments.length !== 1) {
+          throw new Error(`Invalid call to gettext: expected exactly one argument: ${expression}`);
+        }
+
+        return [expression];
+      } else {
+        return expression.arguments
+          .map(findTranslationCalls)
+          .concat(findTranslationCalls(expression.callee))
+          .flat();
+      }
+    case WhileStatement:
+      return [expression.test, expression.body]
+        .map(findTranslationCalls)
+        .flat();
+    case ConditionalExpression:
+    case IfStatement:
+      return [expression.test, expression.consequent, expression.alternate]
+        .map(findTranslationCalls)
+        .flat();
+    case ForStatement:
+      return [expression.init, expression.test, expression.update, expression.body]
+        .map(findTranslationCalls)
+        .flat();
+    case ForOfStatement:
+    case ForInStatement:
+      return [expression.right, expression.body]
+        .map(findTranslationCalls)
+        .flat();
+    case SwitchStatement:
+      return expression.cases
+        .map(findTranslationCalls)
+        .concat(findTranslationCalls(expression.discriminant))
+        .flat();
+    case SwitchCase:
+      return expression.consequent
+        .map(findTranslationCalls)
+        .flat();
+    case ClassDeclaration:
+      return findTranslationCalls(expression.body);
+    case LogicalExpression:
+    case BinaryExpression:
+      return [expression.left, expression.right]
+        .map(findTranslationCalls)
+        .flat();
+    case ObjectPattern:
+    case ObjectExpression:
+      return expression.properties
+        .map(findTranslationCalls)
+        .flat();
+    case Property:
+      return findTranslationCalls(expression.value);
+    case ThrowStatement:
+    case ReturnStatement:
+    case AwaitExpression:
+    case RestElement:
+    case SpreadElement:
+      return findTranslationCalls(expression.argument);
+    case ArrayExpression:
+      return expression.elements
+        .map(findTranslationCalls)
+        .flat();
+    case TryStatement:
+    case CatchClause:
+      return findTranslationCalls(expression.block);
+    case TemplateLiteral:
+      return expression.expressions
+        .map(findTranslationCalls)
+        .flat();
+    case ThisExpression:
+    case MemberExpression:
+    case ComputedMemberExpression:
+    case StaticMemberExpression:
+    case Identifier:
+    case Literal:
+    case UpdateExpression:
+    case UnaryExpression:
+    case BreakStatement:
+    case ContinueStatement:
+      return [];
+    default:
+      console.debug(`Unknown expression type: ${expression.type}`);
+      console.debug(expression);
+      return [];
+  }
+}
+
+module.exports.findTranslationCalls = findTranslationCalls;

--- a/localization-util.js
+++ b/localization-util.js
@@ -45,6 +45,7 @@ const {
   AwaitExpression,
   WhileStatement,
   ThrowStatement,
+  SequenceExpression,
   ContinueStatement
 } = esprima.Syntax;
 
@@ -156,6 +157,7 @@ function findTranslationCalls(expression) {
     case CatchClause:
       return findTranslationCalls(expression.block);
     case TemplateLiteral:
+    case SequenceExpression:
       return expression.expressions
         .map(findTranslationCalls)
         .flat();
@@ -178,3 +180,5 @@ function findTranslationCalls(expression) {
 }
 
 module.exports.findTranslationCalls = findTranslationCalls;
+module.exports.contract = (s, size) => s.slice(size, -size);
+module.exports.shave = (s, size) => module.exports.contract(s, size).trim();

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4125,6 +4125,12 @@
         }
       }
     },
+    "gulp-rename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-2.0.0.tgz",
+      "integrity": "sha512-97Vba4KBzbYmR5VBs9mWmK+HwIf5mj+/zioxfZhOKeXtx5ZjBk57KFlePf5nxq9QsTtFl0ejnHE3zTC9MHXqyQ==",
+      "dev": true
+    },
     "gulp-sourcemaps": {
       "version": "2.6.5",
       "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-2.6.5.tgz",

--- a/package.json
+++ b/package.json
@@ -24,5 +24,9 @@
     "gulp-tap": "^2.0.0",
     "merge-stream": "^2.0.0",
     "pofile": "^1.1.0"
+  },
+  "devDependencies": {
+    "gulp-rename": "^2.0.0",
+    "through2": "^2.0.5"
   }
 }

--- a/po/Localization.pot
+++ b/po/Localization.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Pxls\n"
-"POT-Creation-Date: 2021-08-18T19:06:20.007Z\n"
+"POT-Creation-Date: 2021-08-19T06:22:24.977Z\n"
 "Language: \n"
 "Content-Type: text/plain; charset=UTF-8\n"
 

--- a/po/Localization.pot
+++ b/po/Localization.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Pxls\n"
-"POT-Creation-Date: 2021-08-18T06:09:53.979Z\n"
+"POT-Creation-Date: 2021-08-18T19:06:20.007Z\n"
 "Language: \n"
 "Content-Type: text/plain; charset=UTF-8\n"
 
@@ -935,7 +935,7 @@ msgid "Play sound on ping:"
 msgstr ""
 
 #: resources/public/pebble_templates/index.html:689:56
-#: resources/public/include/chat.js:1925:100
+#: resources/public/include/chat.js:1926:100
 msgid "Off"
 msgstr ""
 
@@ -968,8 +968,8 @@ msgid "Public Discord name:"
 msgstr ""
 
 #: resources/public/pebble_templates/index.html:717:83
-#: resources/public/include/chat.js:1927:92
-#: resources/public/include/chat.js:1991:92
+#: resources/public/include/chat.js:1928:92
+#: resources/public/include/chat.js:1992:92
 msgid "Set"
 msgstr ""
 
@@ -1444,7 +1444,7 @@ msgid "Edit"
 msgstr ""
 
 #: resources/public/pebble_templates/profile.html:244:168
-#: resources/public/include/chat.js:1450:24
+#: resources/public/include/chat.js:1451:24
 msgid "Delete"
 msgstr ""
 
@@ -1477,7 +1477,7 @@ msgstr ""
 
 #. bans a user from the faction
 #: resources/public/pebble_templates/profile.html:294:122
-#: resources/public/include/chat.js:1721:60
+#: resources/public/include/chat.js:1722:60
 msgid "Ban"
 msgstr ""
 
@@ -1491,8 +1491,8 @@ msgid "Faction Bans"
 msgstr ""
 
 #: resources/public/pebble_templates/profile.html:318:125
-#: resources/public/include/chat.js:1617:36
-#: resources/public/include/chat.js:1721:46
+#: resources/public/include/chat.js:1618:36
+#: resources/public/include/chat.js:1722:46
 #: resources/public/admin/admin.js:317:88
 #: resources/public/admin/admin.js:344:52
 msgid "Unban"
@@ -1557,281 +1557,298 @@ msgstr ""
 msgid "pxls canvas"
 msgstr ""
 
-#: resources/public/include/chat.js:1248:42
-#: resources/public/include/chat.js:1741:27
+#. template link action
+#: resources/public/include/chat.js:79:21
+msgid "Ask"
+msgstr ""
+
+#: resources/public/include/chat.js:83:21
+msgid "Open in a new tab"
+msgstr ""
+
+#: resources/public/include/chat.js:87:21
+msgid "Open in current tab (replacing template)"
+msgstr ""
+
+#: resources/public/include/chat.js:91:21
+msgid "Jump to coordinates without replacing template"
+msgstr ""
+
+#: resources/public/include/chat.js:1249:42
+#: resources/public/include/chat.js:1742:27
 msgid "none provided"
 msgstr ""
 
-#: resources/public/include/chat.js:1249:38
+#: resources/public/include/chat.js:1250:38
 msgid "Purged by ${purge.initiator} with reason: ${reason}"
 msgstr ""
 
-#: resources/public/include/chat.js:1267:26
+#: resources/public/include/chat.js:1268:26
 msgid "template:"
 msgstr ""
 
-#: resources/public/include/chat.js:1319:56
-#: resources/public/include/chat.js:2045:56
+#: resources/public/include/chat.js:1320:56
+#: resources/public/include/chat.js:2046:56
 msgid "Open Failed"
 msgstr ""
 
-#: resources/public/include/chat.js:1321:32
-#: resources/public/include/chat.js:2047:32
+#: resources/public/include/chat.js:1322:32
+#: resources/public/include/chat.js:2048:32
 msgid "Failed to automatically open in a new tab"
 msgstr ""
 
-#: resources/public/include/chat.js:1325:24
-#: resources/public/include/chat.js:2051:24
+#: resources/public/include/chat.js:1326:24
+#: resources/public/include/chat.js:2052:24
 msgid "Click here to open in a new tab instead"
 msgstr ""
 
-#: resources/public/include/chat.js:1339:52
+#: resources/public/include/chat.js:1340:52
 msgid "Open Template"
 msgstr ""
 
-#: resources/public/include/chat.js:1341:54
+#: resources/public/include/chat.js:1342:54
 msgid "This link will overwrite your current template. What would you like to do?"
 msgstr ""
 
-#: resources/public/include/chat.js:1352:55
+#: resources/public/include/chat.js:1353:55
 msgid "Note: You can set a default action in the settings menu which bypasses this popup completely."
 msgstr ""
 
-#: resources/public/include/chat.js:1443:24
-#: resources/public/include/chat.js:1522:18
+#: resources/public/include/chat.js:1444:24
+#: resources/public/include/chat.js:1523:18
 #: resources/public/include/lookup.js:18:90
 msgid "Report"
 msgstr ""
 
-#: resources/public/include/chat.js:1444:24
+#: resources/public/include/chat.js:1445:24
 msgid "Mention"
 msgstr ""
 
-#: resources/public/include/chat.js:1445:24
+#: resources/public/include/chat.js:1446:24
 msgid "Ignore"
 msgstr ""
 
-#: resources/public/include/chat.js:1446:102
+#: resources/public/include/chat.js:1447:102
 #: resources/public/admin/admin.js:190:16
 msgid "Profile"
 msgstr ""
 
-#: resources/public/include/chat.js:1447:24
+#: resources/public/include/chat.js:1448:24
 msgid "Chat (un)ban"
 msgstr ""
 
-#: resources/public/include/chat.js:1449:43
-#: resources/public/include/chat.js:1899:54
+#: resources/public/include/chat.js:1450:43
+#: resources/public/include/chat.js:1900:54
 msgid "Purge User"
 msgstr ""
 
-#: resources/public/include/chat.js:1451:24
+#: resources/public/include/chat.js:1452:24
 msgid "Mod Lookup"
 msgstr ""
 
-#: resources/public/include/chat.js:1452:24
+#: resources/public/include/chat.js:1453:24
 msgid "Chat Lookup"
 msgstr ""
 
-#: resources/public/include/chat.js:1524:30
+#: resources/public/include/chat.js:1525:30
 msgid "Enter a reason for your report"
 msgstr ""
 
-#: resources/public/include/chat.js:1553:26
-#: resources/public/include/chat.js:1674:18
-#: resources/public/include/chat.js:1833:22
-#: resources/public/include/chat.js:1881:22
-#: resources/public/include/chat.js:1949:22
-#: resources/public/include/chat.js:2009:22
+#: resources/public/include/chat.js:1554:26
+#: resources/public/include/chat.js:1675:18
+#: resources/public/include/chat.js:1834:22
+#: resources/public/include/chat.js:1882:22
+#: resources/public/include/chat.js:1950:22
+#: resources/public/include/chat.js:2010:22
 #: resources/public/include/lookup.js:64:91
 #: resources/public/include/user.js:73:87
 #: resources/public/admin/admin.js:331:20
 msgid "Cancel"
 msgstr ""
 
-#: resources/public/include/chat.js:1568:34
+#: resources/public/include/chat.js:1569:34
 #: resources/public/include/lookup.js:45:30
 msgid "Error sending report."
 msgstr ""
 
-#: resources/public/include/chat.js:1573:54
+#: resources/public/include/chat.js:1574:54
 msgid "Report User"
 msgstr ""
 
-#: resources/public/include/chat.js:1587:34
+#: resources/public/include/chat.js:1588:34
 msgid "User ignored. You can unignore from chat settings."
 msgstr ""
 
-#: resources/public/include/chat.js:1589:34
+#: resources/public/include/chat.js:1590:34
 msgid "Failed to ignore user. Either they\\'re already ignored, or an error occurred. If the problem persists, contact a developer."
 msgstr ""
 
-#: resources/public/include/chat.js:1617:55
+#: resources/public/include/chat.js:1618:55
 msgid "Permanent"
 msgstr ""
 
-#: resources/public/include/chat.js:1617:78
+#: resources/public/include/chat.js:1618:78
 msgid "Temporary"
 msgstr ""
 
-#: resources/public/include/chat.js:1644:32
+#: resources/public/include/chat.js:1645:32
 msgid "Rule 3: Spam"
 msgstr ""
 
-#: resources/public/include/chat.js:1645:32
+#: resources/public/include/chat.js:1646:32
 msgid "Rule 1: Chat civility"
 msgstr ""
 
-#: resources/public/include/chat.js:1646:32
+#: resources/public/include/chat.js:1647:32
 msgid "Rule 2: Hate Speech"
 msgstr ""
 
-#: resources/public/include/chat.js:1647:32
+#: resources/public/include/chat.js:1648:32
 msgid "Rule 5: NSFW"
 msgstr ""
 
-#: resources/public/include/chat.js:1648:32
-#: resources/public/include/chat.js:1726:58
-#: resources/public/include/chat.js:1747:45
+#: resources/public/include/chat.js:1649:32
+#: resources/public/include/chat.js:1727:58
+#: resources/public/include/chat.js:1748:45
 msgid "Custom"
 msgstr ""
 
-#: resources/public/include/chat.js:1681:33
+#: resources/public/include/chat.js:1682:33
 msgid "Banning:"
 msgstr ""
 
-#: resources/public/include/chat.js:1681:50
+#: resources/public/include/chat.js:1682:50
 msgid "Message:"
 msgstr ""
 
-#: resources/public/include/chat.js:1683:26
+#: resources/public/include/chat.js:1684:26
 msgid "Ban Length"
 msgstr ""
 
-#: resources/public/include/chat.js:1690:28
+#: resources/public/include/chat.js:1691:28
 msgid "Reason"
 msgstr ""
 
-#: resources/public/include/chat.js:1695:28
+#: resources/public/include/chat.js:1696:28
 msgid "Purge Messages"
 msgstr ""
 
-#: resources/public/include/chat.js:1699:27
+#: resources/public/include/chat.js:1700:27
 msgid "Purging all messages is disabled during snip mode"
 msgstr ""
 
-#: resources/public/include/chat.js:1702:79
+#: resources/public/include/chat.js:1703:79
 #: resources/public/include/user.js:174:22
 #: resources/public/admin/admin.js:182:41
 #: resources/public/admin/admin.js:184:94
 msgid "Yes"
 msgstr ""
 
-#: resources/public/include/chat.js:1703:78
+#: resources/public/include/chat.js:1704:78
 #: resources/public/include/user.js:178:22
 #: resources/public/admin/admin.js:182:53
 #: resources/public/admin/admin.js:184:106
 msgid "No"
 msgstr ""
 
-#: resources/public/include/chat.js:1727:63
+#: resources/public/include/chat.js:1728:63
 msgid "Custom reason"
 msgstr ""
 
-#: resources/public/include/chat.js:1727:85
+#: resources/public/include/chat.js:1728:85
 #: resources/public/include/lookup.js:59:30
 msgid "Additional information (if applicable)"
 msgstr ""
 
-#: resources/public/include/chat.js:1752:45
+#: resources/public/include/chat.js:1753:45
 msgid "Additional information:"
 msgstr ""
 
-#: resources/public/include/chat.js:1774:34
+#: resources/public/include/chat.js:1775:34
 msgid "Error occurred while chatbanning"
 msgstr ""
 
-#: resources/public/include/chat.js:1778:54
+#: resources/public/include/chat.js:1779:54
 msgid "Chatban"
 msgstr ""
 
-#: resources/public/include/chat.js:1798:32
+#: resources/public/include/chat.js:1799:32
 msgid "Failed to delete"
 msgstr ""
 
-#: resources/public/include/chat.js:1809:32
-#: resources/public/include/chat.js:1851:32
+#: resources/public/include/chat.js:1810:32
+#: resources/public/include/chat.js:1852:32
 msgid "ID: "
 msgstr ""
 
-#: resources/public/include/chat.js:1813:32
-#: resources/public/include/chat.js:1861:32
+#: resources/public/include/chat.js:1814:32
+#: resources/public/include/chat.js:1862:32
 msgid "User: "
 msgstr ""
 
-#: resources/public/include/chat.js:1817:32
-#: resources/public/include/chat.js:1855:32
+#: resources/public/include/chat.js:1818:32
+#: resources/public/include/chat.js:1856:32
 msgid "Message: "
 msgstr ""
 
-#: resources/public/include/chat.js:1821:32
+#: resources/public/include/chat.js:1822:32
 msgid "Reason: "
 msgstr ""
 
-#: resources/public/include/chat.js:1838:54
+#: resources/public/include/chat.js:1839:54
 msgid "Delete Message"
 msgstr ""
 
-#: resources/public/include/chat.js:1846:106
+#: resources/public/include/chat.js:1847:106
 msgid "Purge"
 msgstr ""
 
-#: resources/public/include/chat.js:1867:28
+#: resources/public/include/chat.js:1868:28
 msgid "Selected Message"
 msgstr ""
 
-#: resources/public/include/chat.js:1870:30
+#: resources/public/include/chat.js:1871:30
 msgid "Purge Reason"
 msgstr ""
 
-#: resources/public/include/chat.js:1895:34
+#: resources/public/include/chat.js:1896:34
 msgid "Error sending purge."
 msgstr ""
 
-#: resources/public/include/chat.js:1914:23
+#: resources/public/include/chat.js:1915:23
 msgid "ChatLookup"
 msgstr ""
 
-#: resources/public/include/chat.js:1924:98
+#: resources/public/include/chat.js:1925:98
 msgid "On"
 msgstr ""
 
-#: resources/public/include/chat.js:1937:28
+#: resources/public/include/chat.js:1938:28
 msgid "Toggle Rename Request"
 msgstr ""
 
-#: resources/public/include/chat.js:1938:27
+#: resources/public/include/chat.js:1939:27
 msgid "Select one of the options below to set the current rename request state."
 msgstr ""
 
-#: resources/public/include/chat.js:1963:30
-#: resources/public/include/chat.js:2022:30
+#: resources/public/include/chat.js:1964:30
+#: resources/public/include/chat.js:2023:30
 msgid "An unknown error occurred. Please contact a developer"
 msgstr ""
 
-#: resources/public/include/chat.js:1989:52
+#: resources/public/include/chat.js:1990:52
 msgid "New Name: "
 msgstr ""
 
-#: resources/public/include/chat.js:1999:27
+#: resources/public/include/chat.js:2000:27
 msgid "Enter the new name for the user below. Please note that if you\\'re trying to change the caps, you\\'ll have to rename to something else first."
 msgstr ""
 
-#: resources/public/include/chat.js:2037:54
+#: resources/public/include/chat.js:2038:54
 msgid "Force Rename"
 msgstr ""
 
-#: resources/public/include/chat.js:2076:118
+#: resources/public/include/chat.js:2077:118
 msgid "You cannot use chat while canvas banned."
 msgstr ""
 
@@ -1944,11 +1961,51 @@ msgstr ""
 msgid "Your next pixel is available!"
 msgstr ""
 
-#: resources/public/include/uiHelper.js:453:30
+#. theme name
+#: resources/public/include/uiHelper.js:47:19
+msgid "Dark"
+msgstr ""
+
+#. theme name
+#: resources/public/include/uiHelper.js:53:19
+msgid "Darker"
+msgstr ""
+
+#. theme name
+#: resources/public/include/uiHelper.js:59:19
+msgid "Blue"
+msgstr ""
+
+#. theme name
+#: resources/public/include/uiHelper.js:65:19
+msgid "Purple"
+msgstr ""
+
+#. theme name
+#: resources/public/include/uiHelper.js:71:19
+msgid "Green"
+msgstr ""
+
+#. theme name
+#: resources/public/include/uiHelper.js:77:19
+msgid "Matte"
+msgstr ""
+
+#. theme name
+#: resources/public/include/uiHelper.js:83:19
+msgid "Terminal"
+msgstr ""
+
+#. theme name
+#: resources/public/include/uiHelper.js:89:19
+msgid "Red"
+msgstr ""
+
+#: resources/public/include/uiHelper.js:461:30
 msgid "Discord name updated successfully"
 msgstr ""
 
-#: resources/public/include/uiHelper.js:460:32
+#: resources/public/include/uiHelper.js:468:32
 msgid "Couldn\\'t change discord name: "
 msgstr ""
 

--- a/po/Localization.pot
+++ b/po/Localization.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Pxls\n"
-"POT-Creation-Date: 2021-08-12T13:23:05.243Z\n"
+"POT-Creation-Date: 2021-08-18T06:09:53.979Z\n"
 "Language: \n"
 "Content-Type: text/plain; charset=UTF-8\n"
 
@@ -50,6 +50,8 @@ msgid "Loading online user count&hellip;"
 msgstr ""
 
 #: resources/public/pebble_templates/index.html:101:30
+#: resources/public/include/lookup.js:276:21
+#: resources/public/admin/admin.js:196:16
 msgid "Pixels"
 msgstr ""
 
@@ -933,6 +935,7 @@ msgid "Play sound on ping:"
 msgstr ""
 
 #: resources/public/pebble_templates/index.html:689:56
+#: resources/public/include/chat.js:1925:100
 msgid "Off"
 msgstr ""
 
@@ -965,6 +968,8 @@ msgid "Public Discord name:"
 msgstr ""
 
 #: resources/public/pebble_templates/index.html:717:83
+#: resources/public/include/chat.js:1927:92
+#: resources/public/include/chat.js:1991:92
 msgid "Set"
 msgstr ""
 
@@ -1254,7 +1259,7 @@ msgid "Template generator, archives, timelapses, and other utilities"
 msgstr ""
 
 #. link to pxlsfiddle.com
-#: resources/public/pebble_templates/info.html:87:159
+#: resources/public/pebble_templates/info.html:87:165
 msgid "PxlsFiddle (templates, archives, etc.)"
 msgstr ""
 
@@ -1302,6 +1307,7 @@ msgid "Registration Date"
 msgstr ""
 
 #: resources/public/pebble_templates/profile.html:82:72
+#: resources/public/include/lookup.js:280:21
 msgid "Alltime Pixels"
 msgstr ""
 
@@ -1314,6 +1320,7 @@ msgid "Discord Tag"
 msgstr ""
 
 #: resources/public/pebble_templates/profile.html:95:72
+#: resources/public/include/lookup.js:235:21
 msgid "Faction"
 msgstr ""
 
@@ -1322,6 +1329,7 @@ msgid "None"
 msgstr ""
 
 #: resources/public/pebble_templates/profile.html:99:72
+#: resources/public/admin/admin.js:195:16
 msgid "Roles"
 msgstr ""
 
@@ -1436,6 +1444,7 @@ msgid "Edit"
 msgstr ""
 
 #: resources/public/pebble_templates/profile.html:244:168
+#: resources/public/include/chat.js:1450:24
 msgid "Delete"
 msgstr ""
 
@@ -1468,6 +1477,7 @@ msgstr ""
 
 #. bans a user from the faction
 #: resources/public/pebble_templates/profile.html:294:122
+#: resources/public/include/chat.js:1721:60
 msgid "Ban"
 msgstr ""
 
@@ -1481,6 +1491,10 @@ msgid "Faction Bans"
 msgstr ""
 
 #: resources/public/pebble_templates/profile.html:318:125
+#: resources/public/include/chat.js:1617:36
+#: resources/public/include/chat.js:1721:46
+#: resources/public/admin/admin.js:317:88
+#: resources/public/admin/admin.js:344:52
 msgid "Unban"
 msgstr ""
 
@@ -1532,4 +1546,594 @@ msgstr ""
 
 #: resources/public/pebble_templates/40x.html:59:23
 msgid "The action you attempted to perform is not allowed or resulted in an error. Please ensure you have access to the endpoint and try again later."
+msgstr ""
+
+#: resources/public/pxls.js:134:38
+msgid "Alert"
+msgstr ""
+
+#. Snapshot save name
+#: resources/public/include/board.js:800:100
+msgid "pxls canvas"
+msgstr ""
+
+#: resources/public/include/chat.js:1248:42
+#: resources/public/include/chat.js:1741:27
+msgid "none provided"
+msgstr ""
+
+#: resources/public/include/chat.js:1249:38
+msgid "Purged by ${purge.initiator} with reason: ${reason}"
+msgstr ""
+
+#: resources/public/include/chat.js:1267:26
+msgid "template:"
+msgstr ""
+
+#: resources/public/include/chat.js:1319:56
+#: resources/public/include/chat.js:2045:56
+msgid "Open Failed"
+msgstr ""
+
+#: resources/public/include/chat.js:1321:32
+#: resources/public/include/chat.js:2047:32
+msgid "Failed to automatically open in a new tab"
+msgstr ""
+
+#: resources/public/include/chat.js:1325:24
+#: resources/public/include/chat.js:2051:24
+msgid "Click here to open in a new tab instead"
+msgstr ""
+
+#: resources/public/include/chat.js:1339:52
+msgid "Open Template"
+msgstr ""
+
+#: resources/public/include/chat.js:1341:54
+msgid "This link will overwrite your current template. What would you like to do?"
+msgstr ""
+
+#: resources/public/include/chat.js:1352:55
+msgid "Note: You can set a default action in the settings menu which bypasses this popup completely."
+msgstr ""
+
+#: resources/public/include/chat.js:1443:24
+#: resources/public/include/chat.js:1522:18
+#: resources/public/include/lookup.js:18:90
+msgid "Report"
+msgstr ""
+
+#: resources/public/include/chat.js:1444:24
+msgid "Mention"
+msgstr ""
+
+#: resources/public/include/chat.js:1445:24
+msgid "Ignore"
+msgstr ""
+
+#: resources/public/include/chat.js:1446:102
+#: resources/public/admin/admin.js:190:16
+msgid "Profile"
+msgstr ""
+
+#: resources/public/include/chat.js:1447:24
+msgid "Chat (un)ban"
+msgstr ""
+
+#: resources/public/include/chat.js:1449:43
+#: resources/public/include/chat.js:1899:54
+msgid "Purge User"
+msgstr ""
+
+#: resources/public/include/chat.js:1451:24
+msgid "Mod Lookup"
+msgstr ""
+
+#: resources/public/include/chat.js:1452:24
+msgid "Chat Lookup"
+msgstr ""
+
+#: resources/public/include/chat.js:1524:30
+msgid "Enter a reason for your report"
+msgstr ""
+
+#: resources/public/include/chat.js:1553:26
+#: resources/public/include/chat.js:1674:18
+#: resources/public/include/chat.js:1833:22
+#: resources/public/include/chat.js:1881:22
+#: resources/public/include/chat.js:1949:22
+#: resources/public/include/chat.js:2009:22
+#: resources/public/include/lookup.js:64:91
+#: resources/public/include/user.js:73:87
+#: resources/public/admin/admin.js:331:20
+msgid "Cancel"
+msgstr ""
+
+#: resources/public/include/chat.js:1568:34
+#: resources/public/include/lookup.js:45:30
+msgid "Error sending report."
+msgstr ""
+
+#: resources/public/include/chat.js:1573:54
+msgid "Report User"
+msgstr ""
+
+#: resources/public/include/chat.js:1587:34
+msgid "User ignored. You can unignore from chat settings."
+msgstr ""
+
+#: resources/public/include/chat.js:1589:34
+msgid "Failed to ignore user. Either they\\'re already ignored, or an error occurred. If the problem persists, contact a developer."
+msgstr ""
+
+#: resources/public/include/chat.js:1617:55
+msgid "Permanent"
+msgstr ""
+
+#: resources/public/include/chat.js:1617:78
+msgid "Temporary"
+msgstr ""
+
+#: resources/public/include/chat.js:1644:32
+msgid "Rule 3: Spam"
+msgstr ""
+
+#: resources/public/include/chat.js:1645:32
+msgid "Rule 1: Chat civility"
+msgstr ""
+
+#: resources/public/include/chat.js:1646:32
+msgid "Rule 2: Hate Speech"
+msgstr ""
+
+#: resources/public/include/chat.js:1647:32
+msgid "Rule 5: NSFW"
+msgstr ""
+
+#: resources/public/include/chat.js:1648:32
+#: resources/public/include/chat.js:1726:58
+#: resources/public/include/chat.js:1747:45
+msgid "Custom"
+msgstr ""
+
+#: resources/public/include/chat.js:1681:33
+msgid "Banning:"
+msgstr ""
+
+#: resources/public/include/chat.js:1681:50
+msgid "Message:"
+msgstr ""
+
+#: resources/public/include/chat.js:1683:26
+msgid "Ban Length"
+msgstr ""
+
+#: resources/public/include/chat.js:1690:28
+msgid "Reason"
+msgstr ""
+
+#: resources/public/include/chat.js:1695:28
+msgid "Purge Messages"
+msgstr ""
+
+#: resources/public/include/chat.js:1699:27
+msgid "Purging all messages is disabled during snip mode"
+msgstr ""
+
+#: resources/public/include/chat.js:1702:79
+#: resources/public/include/user.js:174:22
+#: resources/public/admin/admin.js:182:41
+#: resources/public/admin/admin.js:184:94
+msgid "Yes"
+msgstr ""
+
+#: resources/public/include/chat.js:1703:78
+#: resources/public/include/user.js:178:22
+#: resources/public/admin/admin.js:182:53
+#: resources/public/admin/admin.js:184:106
+msgid "No"
+msgstr ""
+
+#: resources/public/include/chat.js:1727:63
+msgid "Custom reason"
+msgstr ""
+
+#: resources/public/include/chat.js:1727:85
+#: resources/public/include/lookup.js:59:30
+msgid "Additional information (if applicable)"
+msgstr ""
+
+#: resources/public/include/chat.js:1752:45
+msgid "Additional information:"
+msgstr ""
+
+#: resources/public/include/chat.js:1774:34
+msgid "Error occurred while chatbanning"
+msgstr ""
+
+#: resources/public/include/chat.js:1778:54
+msgid "Chatban"
+msgstr ""
+
+#: resources/public/include/chat.js:1798:32
+msgid "Failed to delete"
+msgstr ""
+
+#: resources/public/include/chat.js:1809:32
+#: resources/public/include/chat.js:1851:32
+msgid "ID: "
+msgstr ""
+
+#: resources/public/include/chat.js:1813:32
+#: resources/public/include/chat.js:1861:32
+msgid "User: "
+msgstr ""
+
+#: resources/public/include/chat.js:1817:32
+#: resources/public/include/chat.js:1855:32
+msgid "Message: "
+msgstr ""
+
+#: resources/public/include/chat.js:1821:32
+msgid "Reason: "
+msgstr ""
+
+#: resources/public/include/chat.js:1838:54
+msgid "Delete Message"
+msgstr ""
+
+#: resources/public/include/chat.js:1846:106
+msgid "Purge"
+msgstr ""
+
+#: resources/public/include/chat.js:1867:28
+msgid "Selected Message"
+msgstr ""
+
+#: resources/public/include/chat.js:1870:30
+msgid "Purge Reason"
+msgstr ""
+
+#: resources/public/include/chat.js:1895:34
+msgid "Error sending purge."
+msgstr ""
+
+#: resources/public/include/chat.js:1914:23
+msgid "ChatLookup"
+msgstr ""
+
+#: resources/public/include/chat.js:1924:98
+msgid "On"
+msgstr ""
+
+#: resources/public/include/chat.js:1937:28
+msgid "Toggle Rename Request"
+msgstr ""
+
+#: resources/public/include/chat.js:1938:27
+msgid "Select one of the options below to set the current rename request state."
+msgstr ""
+
+#: resources/public/include/chat.js:1963:30
+#: resources/public/include/chat.js:2022:30
+msgid "An unknown error occurred. Please contact a developer"
+msgstr ""
+
+#: resources/public/include/chat.js:1989:52
+msgid "New Name: "
+msgstr ""
+
+#: resources/public/include/chat.js:1999:27
+msgid "Enter the new name for the user below. Please note that if you\\'re trying to change the caps, you\\'ll have to rename to something else first."
+msgstr ""
+
+#: resources/public/include/chat.js:2037:54
+msgid "Force Rename"
+msgstr ""
+
+#: resources/public/include/chat.js:2076:118
+msgid "You cannot use chat while canvas banned."
+msgstr ""
+
+#: resources/public/include/lookup.js:21:32
+msgid "Sending..."
+msgstr ""
+
+#: resources/public/include/lookup.js:28:32
+msgid "You must specify the details."
+msgstr ""
+
+#: resources/public/include/lookup.js:33:27
+msgid "additional information:"
+msgstr ""
+
+#: resources/public/include/lookup.js:49:50
+msgid "Report Pixel"
+msgstr ""
+
+#: resources/public/include/lookup.js:52:32
+msgid "Rule #1: Hateful/derogatory speech or symbols"
+msgstr ""
+
+#: resources/public/include/lookup.js:53:32
+msgid "Rule #2: Nudity, genitalia, or non-PG-13 content"
+msgstr ""
+
+#: resources/public/include/lookup.js:54:32
+msgid "Rule #3: Multi-account"
+msgstr ""
+
+#: resources/public/include/lookup.js:55:32
+msgid "Rule #4: Botting"
+msgstr ""
+
+#: resources/public/include/lookup.js:56:52
+msgid "Other (specify below)"
+msgstr ""
+
+#: resources/public/include/lookup.js:168:62
+msgid "Hide sensitive information"
+msgstr ""
+
+#: resources/public/include/lookup.js:207:120
+msgid "An error occurred, either you aren't logged in or you may be attempting to look up users too fast. Please try again in 60 seconds"
+msgstr ""
+
+#: resources/public/include/lookup.js:218:21
+msgid "Coords"
+msgstr ""
+
+#: resources/public/include/lookup.js:223:21
+#: resources/public/admin/admin.js:186:16
+msgid "Username"
+msgstr ""
+
+#: resources/public/include/lookup.js:229:28
+msgid "View Profile"
+msgstr ""
+
+#: resources/public/include/lookup.js:239:21
+msgid "Origin"
+msgstr ""
+
+#: resources/public/include/lookup.js:243:28
+msgid "Part of a nuke"
+msgstr ""
+
+#: resources/public/include/lookup.js:245:28
+msgid "Placed by a staff member using placement overrides"
+msgstr ""
+
+#: resources/public/include/lookup.js:252:21
+msgid "Time"
+msgstr ""
+
+#: resources/public/include/lookup.js:263:36
+msgid "just now"
+msgstr ""
+
+#: resources/public/include/lookup.js:271:36
+msgid "${hoursStr}:${minuteStr}:${secsStr} ago"
+msgstr ""
+
+#: resources/public/include/lookup.js:284:21
+msgid "Discord"
+msgstr ""
+
+#: resources/public/include/notifications.js:60:58
+msgid "Posted by ${notification.who}"
+msgstr ""
+
+#: resources/public/include/notifications.js:63:111
+msgid "Expires ${expiry}"
+msgstr ""
+
+#: resources/public/include/template.js:93:50
+msgid "There was an error getting the image"
+msgstr ""
+
+#: resources/public/include/timer.js:41:53
+msgid "Your next pixel will be available in ${delay} seconds!"
+msgstr ""
+
+#: resources/public/include/timer.js:84:61
+msgid "Your next pixel has been available for ${alertDelay} seconds!"
+msgstr ""
+
+#: resources/public/include/timer.js:98:59
+msgid "Your next pixel is available!"
+msgstr ""
+
+#: resources/public/include/uiHelper.js:453:30
+msgid "Discord name updated successfully"
+msgstr ""
+
+#: resources/public/include/uiHelper.js:460:32
+msgid "Couldn\\'t change discord name: "
+msgstr ""
+
+#: resources/public/include/user.js:81:28
+msgid "Sign in with..."
+msgstr ""
+
+#: resources/public/include/user.js:94:149
+msgid "New Accounts Disabled"
+msgstr ""
+
+#: resources/public/include/user.js:167:52
+msgid "Sign Out"
+msgstr ""
+
+#: resources/public/include/user.js:169:27
+msgid "Are you sure you want to sign out?"
+msgstr ""
+
+#: resources/public/include/user.js:194:28
+msgid "Too many sessions open, try closing some tabs."
+msgstr ""
+
+#: resources/public/include/user.js:227:39
+msgid "You are permanently banned."
+msgstr ""
+
+#: resources/public/include/user.js:231:39
+msgid "You are temporarily banned and will not be allowed to place until ${timestamp}"
+msgstr ""
+
+#: resources/public/include/user.js:251:27
+msgid "If you think this was an error, please contact us using one of the links in the info tab."
+msgstr ""
+
+#: resources/public/include/user.js:252:27
+msgid "Ban reason:"
+msgstr ""
+
+#: resources/public/include/user.js:256:28
+#: resources/public/admin/admin.js:200:16
+msgid "Banned"
+msgstr ""
+
+#: resources/public/include/user.js:326:23
+msgid "Staff have required you to change your username, this usually means your name breaks one of our rules."
+msgstr ""
+
+#: resources/public/include/user.js:327:23
+msgid "If you disagree, please contact us on Discord (link in the info panel)."
+msgstr ""
+
+#: resources/public/include/user.js:328:27
+msgid "New Username:"
+msgstr ""
+
+#: resources/public/include/user.js:341:89
+msgid "Not now"
+msgstr ""
+
+#: resources/public/include/user.js:342:86
+msgid "Change"
+msgstr ""
+
+#: resources/public/include/user.js:346:50
+#: resources/public/admin/admin.js:198:16
+msgid "Rename Requested"
+msgstr ""
+
+#: resources/public/admin/admin.js:98:38
+msgid "Something went wrong! Perhaps insufficient permissions?"
+msgstr ""
+
+#: resources/public/admin/admin.js:103:45
+msgid "Shadowban user"
+msgstr ""
+
+#: resources/public/admin/admin.js:103:67
+msgid "Shadowbanned user"
+msgstr ""
+
+#: resources/public/admin/admin.js:106:45
+msgid "Permaban user"
+msgstr ""
+
+#: resources/public/admin/admin.js:106:66
+msgid "Permabanned user"
+msgstr ""
+
+#: resources/public/admin/admin.js:109:45
+msgid "Ban user"
+msgstr ""
+
+#: resources/public/admin/admin.js:109:61
+msgid "Banned user"
+msgstr ""
+
+#: resources/public/admin/admin.js:123:36
+msgid "Unbanned user ${username}"
+msgstr ""
+
+#. Context: ban type
+#: resources/public/admin/admin.js:176:27
+msgid "shadow"
+msgstr ""
+
+#: resources/public/admin/admin.js:177:29
+#: resources/public/admin/admin.js:180:29
+msgid "never"
+msgstr ""
+
+#: resources/public/admin/admin.js:179:27
+msgid "permanent"
+msgstr ""
+
+#: resources/public/admin/admin.js:184:51
+msgid "Yes (permanent)"
+msgstr ""
+
+#: resources/public/admin/admin.js:191:16
+#: resources/public/admin/admin.js:451:21
+msgid "Logins"
+msgstr ""
+
+#: resources/public/admin/admin.js:197:16
+msgid "All Time Pixels"
+msgstr ""
+
+#: resources/public/admin/admin.js:199:16
+msgid "Discord Name"
+msgstr ""
+
+#: resources/public/admin/admin.js:201:16
+msgid "Chatbanned"
+msgstr ""
+
+#: resources/public/admin/admin.js:204:27
+msgid "Ban Reason"
+msgstr ""
+
+#: resources/public/admin/admin.js:205:27
+msgid "Ban Expiracy"
+msgstr ""
+
+#: resources/public/admin/admin.js:208:27
+msgid "Chatban Reason"
+msgstr ""
+
+#: resources/public/admin/admin.js:208:102
+msgid "(canvas ban)"
+msgstr ""
+
+#: resources/public/admin/admin.js:210:97
+msgid "when canvas ban ends"
+msgstr ""
+
+#: resources/public/admin/admin.js:211:29
+msgid "Chatban Expires"
+msgstr ""
+
+#. Admin check. Example: type = 'username', arg = 'pxlsuser94'
+#: resources/public/admin/admin.js:313:36
+msgid "${type} ${arg} not found."
+msgstr ""
+
+#: resources/public/admin/admin.js:319:50
+msgid "Unban Reason:"
+msgstr ""
+
+#: resources/public/admin/admin.js:324:25
+msgid "Unbanning ${username}"
+msgstr ""
+
+#: resources/public/admin/admin.js:446:20
+msgid "profile"
+msgstr ""
+
+#: resources/public/admin/admin.js:470:21
+msgid "User Agent"
+msgstr ""
+
+#: resources/public/admin/admin.js:475:21
+msgid "Send Alert"
+msgstr ""
+
+#: resources/public/admin/admin.js:480:21
+msgid "Mod Actions"
 msgstr ""

--- a/po/Localization_fr.po
+++ b/po/Localization_fr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Pxls\n"
-"POT-Creation-Date: 2021-08-12T13:23:05.243Z\n"
+"POT-Creation-Date: 2021-08-19T06:22:24.977Z\n"
 "Language: \n"
 "Content-Type: text/plain; charset=UTF-8\n"
 
@@ -50,6 +50,8 @@ msgid "Loading online user count&hellip;"
 msgstr "Chargement du nombre d'utilisateurs en ligne&hellip;"
 
 #: resources/public/pebble_templates/index.html:101:30
+#: resources/public/include/lookup.js:276:21
+#: resources/public/admin/admin.js:196:16
 msgid "Pixels"
 msgstr "Pixels"
 
@@ -59,7 +61,7 @@ msgstr "Annuler"
 
 #: resources/public/pebble_templates/index.html:114:20
 msgid "You are not signed in.&nbsp;<a href=\"#\">Sign in with...</a>"
-msgstr "Tu n'es pas identifié.&nbsp;<a href=\"#\">S'identifier avec...</a>"
+msgstr "Tu n'es pas connecté.&nbsp;<a href=\"#\">Se connecter avec...</a>"
 
 #: resources/public/pebble_templates/index.html:124:28
 msgid "Loading..."
@@ -529,11 +531,11 @@ msgstr "Animer le bandeau sous le chat"
 
 #: resources/public/pebble_templates/index.html:409:44
 msgid "max;messages;truncate"
-msgstr ""
+msgstr "max;messages;tronquer;troncature"
 
 #: resources/public/pebble_templates/index.html:411:57
 msgid "Maximum amount of chat messages:"
-msgstr ""
+msgstr "Maximum de messages visibles dans le chat"
 
 #: resources/public/pebble_templates/index.html:415:44
 msgid "link;url;behaviour"
@@ -685,15 +687,15 @@ msgstr "Sensibilité du zoom :"
 
 #: resources/public/pebble_templates/index.html:512:44
 msgid "zooming limit;scrolling limit;mousewheel;zooming minimum;zooming maximum"
-msgstr "limites du zoom;limites du scroll;roulette de souris;molette de souris;maximum du zoom"
+msgstr "limites du zoom;limites du scroll;roulette de souris;molette de souris;minimum du zoom;maximum du zoom"
 
 #: resources/public/pebble_templates/index.html:514:57
 msgid "Minimum scale:"
-msgstr ""
+msgstr "Échelle minimale :"
 
 #: resources/public/pebble_templates/index.html:518:57
 msgid "Maximum scale:"
-msgstr ""
+msgstr "Échelle maximale :"
 
 #: resources/public/pebble_templates/index.html:522:44
 msgid "rounding;zooming;scrolling;mousewheel;integer;decimal"
@@ -721,31 +723,31 @@ msgstr "Activer l'échantillonnage de couleur sur le canvas avec le clic du mili
 
 #: resources/public/pebble_templates/index.html:543:44
 msgid "right click action"
-msgstr ""
+msgstr "raccourci clic droit"
 
 #: resources/public/pebble_templates/index.html:545:57
 msgid "Right-click action:"
-msgstr ""
+msgstr "Action du clic droit :"
 
 #: resources/public/pebble_templates/index.html:547:60
 msgid "Nothing"
-msgstr ""
+msgstr "Rien"
 
 #: resources/public/pebble_templates/index.html:548:58
 msgid "Clear color"
-msgstr ""
+msgstr "Retirer la couleur"
 
 #: resources/public/pebble_templates/index.html:549:57
 msgid "Copy color"
-msgstr ""
+msgstr "Copier la couleur"
 
 #: resources/public/pebble_templates/index.html:550:59
 msgid "Lookup"
-msgstr "Inspecter"
+msgstr "inspection du pixel"
 
 #: resources/public/pebble_templates/index.html:551:64
 msgid "Clear color + Lookup"
-msgstr ""
+msgstr "Retirer la couleur + inspection du pixel"
 
 #: resources/public/pebble_templates/index.html:558:36
 msgid "snapshots;screenshot;download;picture;canvas"
@@ -933,6 +935,7 @@ msgid "Play sound on ping:"
 msgstr "Émettre un son quand on est mentionné :"
 
 #: resources/public/pebble_templates/index.html:689:56
+#: resources/public/include/chat.js:1926:100
 msgid "Off"
 msgstr "Jamais"
 
@@ -965,6 +968,8 @@ msgid "Public Discord name:"
 msgstr "Nom Public Discord :"
 
 #: resources/public/pebble_templates/index.html:717:83
+#: resources/public/include/chat.js:1928:92
+#: resources/public/include/chat.js:1992:92
 msgid "Set"
 msgstr "Définir"
 
@@ -1254,7 +1259,7 @@ msgid "Template generator, archives, timelapses, and other utilities"
 msgstr "Générateur de modèles, archives, timelapses et autres outils"
 
 #. link to pxlsfiddle.com
-#: resources/public/pebble_templates/info.html:87:159
+#: resources/public/pebble_templates/info.html:87:165
 msgid "PxlsFiddle (templates, archives, etc.)"
 msgstr "PxlsFiddle (modèles, archives, etc.)"
 
@@ -1302,18 +1307,20 @@ msgid "Registration Date"
 msgstr "Date d'inscription"
 
 #: resources/public/pebble_templates/profile.html:82:72
+#: resources/public/include/lookup.js:280:21
 msgid "Alltime Pixels"
 msgstr "Pixels totaux"
 
 #: resources/public/pebble_templates/profile.html:86:72
 msgid "Current Canvas Pixels"
-msgstr "Pixels du canvas actuel"
+msgstr "Pixels placés ce canvas"
 
 #: resources/public/pebble_templates/profile.html:91:72
 msgid "Discord Tag"
 msgstr "Tag Discord"
 
 #: resources/public/pebble_templates/profile.html:95:72
+#: resources/public/include/lookup.js:235:21
 msgid "Faction"
 msgstr "Faction"
 
@@ -1322,6 +1329,7 @@ msgid "None"
 msgstr "Aucune"
 
 #: resources/public/pebble_templates/profile.html:99:72
+#: resources/public/admin/admin.js:195:16
 msgid "Roles"
 msgstr "Rôles"
 
@@ -1436,6 +1444,7 @@ msgid "Edit"
 msgstr "Modifier"
 
 #: resources/public/pebble_templates/profile.html:244:168
+#: resources/public/include/chat.js:1451:24
 msgid "Delete"
 msgstr "Supprimer"
 
@@ -1468,6 +1477,7 @@ msgstr "Transférer la possession"
 
 #. bans a user from the faction
 #: resources/public/pebble_templates/profile.html:294:122
+#: resources/public/include/chat.js:1722:60
 msgid "Ban"
 msgstr "Exclure"
 
@@ -1481,6 +1491,10 @@ msgid "Faction Bans"
 msgstr "Bannissements de la Faction"
 
 #: resources/public/pebble_templates/profile.html:318:125
+#: resources/public/include/chat.js:1618:36
+#: resources/public/include/chat.js:1722:46
+#: resources/public/admin/admin.js:317:88
+#: resources/public/admin/admin.js:344:52
 msgid "Unban"
 msgstr "Révoquer le bannissement"
 
@@ -1533,3 +1547,653 @@ msgstr "Non Autorisé"
 #: resources/public/pebble_templates/40x.html:59:23
 msgid "The action you attempted to perform is not allowed or resulted in an error. Please ensure you have access to the endpoint and try again later."
 msgstr "L'action que tu essayes d'effectuer n'est pas permise ou une erreur est survenue. Merci de t'assurer que tu as l'accès nécessaire et de réessayer plus tard."
+
+#: resources/public/pxls.js:134:38
+msgid "Alert"
+msgstr "Alerte"
+
+#. Snapshot save name
+#: resources/public/include/board.js:800:100
+msgid "pxls canvas"
+msgstr "canvas de pxls"
+
+#. template link action
+#: resources/public/include/chat.js:79:21
+msgid "Ask"
+msgstr "Demander"
+
+#: resources/public/include/chat.js:83:21
+msgid "Open in a new tab"
+msgstr "Ouvrir dans un nouvel onglet"
+
+#: resources/public/include/chat.js:87:21
+msgid "Open in current tab (replacing template)"
+msgstr "Ouvrir dans cet onglet (en remplaçant le modèle)"
+
+#: resources/public/include/chat.js:91:21
+msgid "Jump to coordinates without replacing template"
+msgstr "Aller aux coordonnées sans remplacer le modèle"
+
+#: resources/public/include/chat.js:1249:42
+#: resources/public/include/chat.js:1742:27
+msgid "none provided"
+msgstr "aucune donnée"
+
+#: resources/public/include/chat.js:1250:38
+msgid "Purged by ${purge.initiator} with reason: ${reason}"
+msgstr "Purgé par ${purge.initiator} pour la raison: ${reason}"
+
+#: resources/public/include/chat.js:1268:26
+msgid "template:"
+msgstr "modèle :"
+
+#: resources/public/include/chat.js:1320:56
+#: resources/public/include/chat.js:2046:56
+msgid "Open Failed"
+msgstr "Échec de l'ouverture"
+
+#: resources/public/include/chat.js:1322:32
+#: resources/public/include/chat.js:2048:32
+msgid "Failed to automatically open in a new tab"
+msgstr "Échec de l'ouverture automatique dans un nouvel onglet"
+
+#: resources/public/include/chat.js:1326:24
+#: resources/public/include/chat.js:2052:24
+msgid "Click here to open in a new tab instead"
+msgstr "Clique ici pour ouvrir dans un nouveau onglet à la place"
+
+#: resources/public/include/chat.js:1340:52
+msgid "Open Template"
+msgstr "Ouvrir le Modèle"
+
+#: resources/public/include/chat.js:1342:54
+msgid "This link will overwrite your current template. What would you like to do?"
+msgstr "Ce lien va écraser ton modèle actuel. Que voudrais-tu faire ?"
+
+#: resources/public/include/chat.js:1353:55
+msgid "Note: You can set a default action in the settings menu which bypasses this popup completely."
+msgstr "Note : Tu peux définir une action par défaut dans les paramètres qui passera ce pop-up."
+
+#: resources/public/include/chat.js:1444:24
+#: resources/public/include/chat.js:1523:18
+#: resources/public/include/lookup.js:18:90
+msgid "Report"
+msgstr "Signaler"
+
+#: resources/public/include/chat.js:1445:24
+msgid "Mention"
+msgstr "Mentionner"
+
+#: resources/public/include/chat.js:1446:24
+msgid "Ignore"
+msgstr "Ignorer"
+
+#: resources/public/include/chat.js:1447:102
+#: resources/public/admin/admin.js:190:16
+msgid "Profile"
+msgstr "Profil"
+
+#: resources/public/include/chat.js:1448:24
+msgid "Chat (un)ban"
+msgstr "Bannir/Révoquer le bannissement du chat"
+
+#: resources/public/include/chat.js:1450:43
+#: resources/public/include/chat.js:1900:54
+msgid "Purge User"
+msgstr "Purger l'utilisateur"
+
+#: resources/public/include/chat.js:1452:24
+msgid "Mod Lookup"
+msgstr "Inspection modérateur"
+
+#: resources/public/include/chat.js:1453:24
+msgid "Chat Lookup"
+msgstr "Inspection du chat"
+
+#: resources/public/include/chat.js:1525:30
+msgid "Enter a reason for your report"
+msgstr "Entre une raison pour ton signalement"
+
+#: resources/public/include/chat.js:1554:26
+#: resources/public/include/chat.js:1675:18
+#: resources/public/include/chat.js:1834:22
+#: resources/public/include/chat.js:1882:22
+#: resources/public/include/chat.js:1950:22
+#: resources/public/include/chat.js:2010:22
+#: resources/public/include/lookup.js:64:91
+#: resources/public/include/user.js:73:87
+#: resources/public/admin/admin.js:331:20
+msgid "Cancel"
+msgstr "Annuler"
+
+#: resources/public/include/chat.js:1569:34
+#: resources/public/include/lookup.js:45:30
+msgid "Error sending report."
+msgstr "Erreur lors de l'envoi du signalement."
+
+#: resources/public/include/chat.js:1574:54
+msgid "Report User"
+msgstr "Signaler l'utilisateur"
+
+#: resources/public/include/chat.js:1588:34
+msgid "User ignored. You can unignore from chat settings."
+msgstr "Utilisateur ignoré. Tu peux le désignorer dans les paramètres du chat."
+
+#: resources/public/include/chat.js:1590:34
+msgid "Failed to ignore user. Either they\\'re already ignored, or an error occurred. If the problem persists, contact a developer."
+msgstr "Échec à ignorer l'utilisateur. Il/elle est déjà ignoré(e), ou une erreur s'est produite. Si le problème persiste, merci de contacter un développeur."
+
+#: resources/public/include/chat.js:1618:55
+msgid "Permanent"
+msgstr "Permanent"
+
+#: resources/public/include/chat.js:1618:78
+msgid "Temporary"
+msgstr "Temporaire"
+
+#: resources/public/include/chat.js:1645:32
+msgid "Rule 3: Spam"
+msgstr "Règle 3 : Spam"
+
+#: resources/public/include/chat.js:1646:32
+msgid "Rule 1: Chat civility"
+msgstr "Règle 1 : Civilité du chat"
+
+#: resources/public/include/chat.js:1647:32
+msgid "Rule 2: Hate Speech"
+msgstr "Règle 2 : Propos haineux"
+
+#: resources/public/include/chat.js:1648:32
+msgid "Rule 5: NSFW"
+msgstr "Règle 5 : NSFW"
+
+#: resources/public/include/chat.js:1649:32
+#: resources/public/include/chat.js:1727:58
+#: resources/public/include/chat.js:1748:45
+msgid "Custom"
+msgstr "Personalisée"
+
+#: resources/public/include/chat.js:1682:33
+msgid "Banning:"
+msgstr "Bannir :"
+
+#: resources/public/include/chat.js:1682:50
+msgid "Message:"
+msgstr "Message :"
+
+#: resources/public/include/chat.js:1684:26
+msgid "Ban Length"
+msgstr "Durée du bannissement"
+
+#: resources/public/include/chat.js:1691:28
+msgid "Reason"
+msgstr "Raison"
+
+#: resources/public/include/chat.js:1696:28
+msgid "Purge Messages"
+msgstr "Purger les messages"
+
+#: resources/public/include/chat.js:1700:27
+msgid "Purging all messages is disabled during snip mode"
+msgstr "La purge de tous les messages est désactivée en mode snip"
+
+#: resources/public/include/chat.js:1703:79
+#: resources/public/include/user.js:174:22
+#: resources/public/admin/admin.js:182:41
+#: resources/public/admin/admin.js:184:94
+msgid "Yes"
+msgstr "Oui"
+
+#: resources/public/include/chat.js:1704:78
+#: resources/public/include/user.js:178:22
+#: resources/public/admin/admin.js:182:53
+#: resources/public/admin/admin.js:184:106
+msgid "No"
+msgstr "Non"
+
+#: resources/public/include/chat.js:1728:63
+msgid "Custom reason"
+msgstr "Raison personalisée"
+
+#: resources/public/include/chat.js:1728:85
+#: resources/public/include/lookup.js:59:30
+msgid "Additional information (if applicable)"
+msgstr "Information supplémentaire (si applicable)"
+
+#: resources/public/include/chat.js:1753:45
+msgid "Additional information:"
+msgstr "Information supplémentaire :"
+
+#: resources/public/include/chat.js:1775:34
+msgid "Error occurred while chatbanning"
+msgstr "Une erreur s'est produite lors du bannissement de chat"
+
+#: resources/public/include/chat.js:1779:54
+msgid "Chatban"
+msgstr "Bannissement du chat"
+
+#: resources/public/include/chat.js:1799:32
+msgid "Failed to delete"
+msgstr "Échec de la suppression"
+
+#: resources/public/include/chat.js:1810:32
+#: resources/public/include/chat.js:1852:32
+msgid "ID: "
+msgstr "ID :"
+
+#: resources/public/include/chat.js:1814:32
+#: resources/public/include/chat.js:1862:32
+msgid "User: "
+msgstr "Utilisateur :"
+
+#: resources/public/include/chat.js:1818:32
+#: resources/public/include/chat.js:1856:32
+msgid "Message: "
+msgstr "Message :"
+
+#: resources/public/include/chat.js:1822:32
+msgid "Reason: "
+msgstr "Raison :"
+
+#: resources/public/include/chat.js:1839:54
+msgid "Delete Message"
+msgstr "Supprimer le message :"
+
+#: resources/public/include/chat.js:1847:106
+msgid "Purge"
+msgstr "Purger"
+
+#: resources/public/include/chat.js:1868:28
+msgid "Selected Message"
+msgstr "Message sélectionné"
+
+#: resources/public/include/chat.js:1871:30
+msgid "Purge Reason"
+msgstr "Raison de la purge"
+
+#: resources/public/include/chat.js:1896:34
+msgid "Error sending purge."
+msgstr "Erreur lors de l'envoi de la purge"
+
+#: resources/public/include/chat.js:1915:23
+msgid "ChatLookup"
+msgstr "Inspection du chat"
+
+#: resources/public/include/chat.js:1925:98
+msgid "On"
+msgstr "Activé"
+
+#: resources/public/include/chat.js:1938:28
+msgid "Toggle Rename Request"
+msgstr "Activer/Désactiver la demande de renommage"
+
+#: resources/public/include/chat.js:1939:27
+msgid "Select one of the options below to set the current rename request state."
+msgstr "Sélectionner une des options ci-dessous pour définir le statut actuel de la demande de renommage"
+
+#: resources/public/include/chat.js:1964:30
+#: resources/public/include/chat.js:2023:30
+msgid "An unknown error occurred. Please contact a developer"
+msgstr "Une erreur inconnue s'est produite. Merci de contacter un développeur."
+
+#: resources/public/include/chat.js:1990:52
+msgid "New Name: "
+msgstr "Nouveau Nom :"
+
+#: resources/public/include/chat.js:2000:27
+msgid "Enter the new name for the user below. Please note that if you\\'re trying to change the caps, you\\'ll have to rename to something else first."
+msgstr "Entre un nouveau nom pour l'utilisateur ci-dessous. Merci de prendre en compte que si tu essaies de changer la capitalization, il te faudra d'abord renommer en quelque chose d'autre."
+
+#: resources/public/include/chat.js:2038:54
+msgid "Force Rename"
+msgstr "Forcer le renommage"
+
+#: resources/public/include/chat.js:2077:118
+msgid "You cannot use chat while canvas banned."
+msgstr "Tu ne peux pas utiliser le chat si tu es banni sur le canvas."
+
+#: resources/public/include/lookup.js:21:32
+msgid "Sending..."
+msgstr "Envoi..."
+
+#: resources/public/include/lookup.js:28:32
+msgid "You must specify the details."
+msgstr "Tu dois spécifier les détails."
+
+#: resources/public/include/lookup.js:33:27
+msgid "additional information:"
+msgstr "information supplémentaire :"
+
+#: resources/public/include/lookup.js:49:50
+msgid "Report Pixel"
+msgstr "Signaler un pixel"
+
+#: resources/public/include/lookup.js:52:32
+msgid "Rule #1: Hateful/derogatory speech or symbols"
+msgstr "Règle #1 : Propos ou symboles haineux/dérogatoires"
+
+#: resources/public/include/lookup.js:53:32
+msgid "Rule #2: Nudity, genitalia, or non-PG-13 content"
+msgstr "Règle #2 : Nudité, organes génitaux ou contenu non adapté aux mineurs"
+
+#: resources/public/include/lookup.js:54:32
+msgid "Rule #3: Multi-account"
+msgstr "Règle #3 : Multi-compte"
+
+#: resources/public/include/lookup.js:55:32
+msgid "Rule #4: Botting"
+msgstr "Règle #4 : Usage de bot"
+
+#: resources/public/include/lookup.js:56:52
+msgid "Other (specify below)"
+msgstr "Autre (préciser ci-dessous)"
+
+#: resources/public/include/lookup.js:168:62
+msgid "Hide sensitive information"
+msgstr "Cacher les informations sensibles"
+
+#: resources/public/include/lookup.js:207:120
+msgid "An error occurred, either you aren't logged in or you may be attempting to look up users too fast. Please try again in 60 seconds"
+msgstr "Une erreur s'est produite, tu n'es pas connecté ou tu essaies d'inspecter des pixels trop rapidement. Merci de réessayer dans 60 secondes"
+
+#: resources/public/include/lookup.js:218:21
+msgid "Coords"
+msgstr "Coordonnées"
+
+#: resources/public/include/lookup.js:223:21
+#: resources/public/admin/admin.js:186:16
+msgid "Username"
+msgstr "Nom d'utilisateur"
+
+#: resources/public/include/lookup.js:229:28
+msgid "View Profile"
+msgstr "Voir le profil"
+
+#: resources/public/include/lookup.js:239:21
+msgid "Origin"
+msgstr "Origine"
+
+#: resources/public/include/lookup.js:243:28
+msgid "Part of a nuke"
+msgstr "Fait partie d'un nuke"
+
+#: resources/public/include/lookup.js:245:28
+msgid "Placed by a staff member using placement overrides"
+msgstr "Placé par un membre de l'équipe avec les outils du staff"
+
+#: resources/public/include/lookup.js:252:21
+msgid "Time"
+msgstr "Horaire"
+
+#: resources/public/include/lookup.js:263:36
+msgid "just now"
+msgstr "à l'instant"
+
+#: resources/public/include/lookup.js:271:36
+msgid "${hoursStr}:${minuteStr}:${secsStr} ago"
+msgstr "il y a ${hoursStr}:${minuteStr}:${secsStr}"
+
+#: resources/public/include/lookup.js:284:21
+msgid "Discord"
+msgstr "Discord"
+
+#: resources/public/include/notifications.js:60:58
+msgid "Posted by ${notification.who}"
+msgstr "Posté par ${notification.who}"
+
+#: resources/public/include/notifications.js:63:111
+msgid "Expires ${expiry}"
+msgstr "Expire à"
+
+#: resources/public/include/template.js:93:50
+msgid "There was an error getting the image"
+msgstr "Erreur à l'obtention de l'image"
+
+#: resources/public/include/timer.js:41:53
+msgid "Your next pixel will be available in ${delay} seconds!"
+msgstr "Ton prochain pixel sera disponible dans ${delay} secondes !"
+
+#: resources/public/include/timer.js:84:61
+msgid "Your next pixel has been available for ${alertDelay} seconds!"
+msgstr "Ton nouveau pixel est disponible depuis ${alertDelay} secondes !"
+
+#: resources/public/include/timer.js:98:59
+msgid "Your next pixel is available!"
+msgstr "Ton prochain pixel est disponible !"
+
+#. theme name
+#: resources/public/include/uiHelper.js:47:19
+msgid "Dark"
+msgstr "Sombre"
+
+#. theme name
+#: resources/public/include/uiHelper.js:53:19
+msgid "Darker"
+msgstr "Plus sombre"
+
+#. theme name
+#: resources/public/include/uiHelper.js:59:19
+msgid "Blue"
+msgstr "Bleu"
+
+#. theme name
+#: resources/public/include/uiHelper.js:65:19
+msgid "Purple"
+msgstr "Violet"
+
+#. theme name
+#: resources/public/include/uiHelper.js:71:19
+msgid "Green"
+msgstr "Vert"
+
+#. theme name
+#: resources/public/include/uiHelper.js:77:19
+msgid "Matte"
+msgstr "Mat"
+
+#. theme name
+#: resources/public/include/uiHelper.js:83:19
+msgid "Terminal"
+msgstr "Terminal"
+
+#. theme name
+#: resources/public/include/uiHelper.js:89:19
+msgid "Red"
+msgstr "Rouge"
+
+#: resources/public/include/uiHelper.js:461:30
+msgid "Discord name updated successfully"
+msgstr "Le nom Discord a bien été mis à jour"
+
+#: resources/public/include/uiHelper.js:468:32
+msgid "Couldn\\'t change discord name: "
+msgstr "Échec du changement du nom Discord"
+
+#: resources/public/include/user.js:81:28
+msgid "Sign in with..."
+msgstr "Se connecter avec..."
+
+#: resources/public/include/user.js:94:149
+msgid "New Accounts Disabled"
+msgstr "Nouveaux comptes désactivés"
+
+#: resources/public/include/user.js:167:52
+msgid "Sign Out"
+msgstr "Se déconnecter"
+
+#: resources/public/include/user.js:169:27
+msgid "Are you sure you want to sign out?"
+msgstr "Es-tu sûr(e) de vouloir te déconnecter ?"
+
+#: resources/public/include/user.js:194:28
+msgid "Too many sessions open, try closing some tabs."
+msgstr "Trop de sessions sont ouvertes, merci d'essayer de fermer quelques onglets"
+
+#: resources/public/include/user.js:227:39
+msgid "You are permanently banned."
+msgstr "Tu es banni définitivement."
+
+#: resources/public/include/user.js:231:39
+msgid "You are temporarily banned and will not be allowed to place until ${timestamp}"
+msgstr "Tu es banni temporairement et ne pourra pas placer de pixel jusqu'à ${timestamp}"
+
+#: resources/public/include/user.js:251:27
+msgid "If you think this was an error, please contact us using one of the links in the info tab."
+msgstr "Si tu penses que ceci est une erreur, merci de nous contacter en utilisant un des liens dans la barre d'informations."
+
+#: resources/public/include/user.js:252:27
+msgid "Ban reason:"
+msgstr "Raison du bannissement :"
+
+#: resources/public/include/user.js:256:28
+#: resources/public/admin/admin.js:200:16
+msgid "Banned"
+msgstr "Banni"
+
+#: resources/public/include/user.js:326:23
+msgid "Staff have required you to change your username, this usually means your name breaks one of our rules."
+msgstr "Le staff te demande de changer de nom d'utilisateur, ceci signifie généralement que ton nom enfreint une de nos règles."
+
+#: resources/public/include/user.js:327:23
+msgid "If you disagree, please contact us on Discord (link in the info panel)."
+msgstr "Si tu n'es pas d'accord, merci de nous contacter sur Discord (lien dans la barre d'informations)."
+
+#: resources/public/include/user.js:328:27
+msgid "New Username:"
+msgstr "Nouveau nom d'utilisateur :"
+
+#: resources/public/include/user.js:341:89
+msgid "Not now"
+msgstr "Pas maintenant"
+
+#: resources/public/include/user.js:342:86
+msgid "Change"
+msgstr "Changer"
+
+#: resources/public/include/user.js:346:50
+#: resources/public/admin/admin.js:198:16
+msgid "Rename Requested"
+msgstr "Renommage demandé"
+
+#: resources/public/admin/admin.js:98:38
+msgid "Something went wrong! Perhaps insufficient permissions?"
+msgstr "Il y a eu un problème ! Peut-être un manque de permissions ?"
+
+#: resources/public/admin/admin.js:103:45
+msgid "Shadowban user"
+msgstr "Shadowban l'utilisateur"
+
+#: resources/public/admin/admin.js:103:67
+msgid "Shadowbanned user"
+msgstr "L'utilisateur a été shadowban"
+
+#: resources/public/admin/admin.js:106:45
+msgid "Permaban user"
+msgstr "Bannir l'utilisateur définitivement"
+
+#: resources/public/admin/admin.js:106:66
+msgid "Permabanned user"
+msgstr "L'utilisateur a été banni définitivement"
+
+#: resources/public/admin/admin.js:109:45
+msgid "Ban user"
+msgstr "Bannir l'utilisateur"
+
+#: resources/public/admin/admin.js:109:61
+msgid "Banned user"
+msgstr "L'utilisateur a été banni"
+
+#: resources/public/admin/admin.js:123:36
+msgid "Unbanned user ${username}"
+msgstr "L'utilisateur ${username} n'est plus banni"
+
+#. Context: ban type
+#: resources/public/admin/admin.js:176:27
+msgid "shadow"
+msgstr "shadow"
+
+#: resources/public/admin/admin.js:177:29
+#: resources/public/admin/admin.js:180:29
+msgid "never"
+msgstr "jamais"
+
+#: resources/public/admin/admin.js:179:27
+msgid "permanent"
+msgstr "définitif"
+
+#: resources/public/admin/admin.js:184:51
+msgid "Yes (permanent)"
+msgstr "Oui (définitif)"
+
+#: resources/public/admin/admin.js:191:16
+#: resources/public/admin/admin.js:451:21
+msgid "Logins"
+msgstr "Logins"
+
+#: resources/public/admin/admin.js:197:16
+msgid "All Time Pixels"
+msgstr "Pixels totaux"
+
+#: resources/public/admin/admin.js:199:16
+msgid "Discord Name"
+msgstr "Nom Discord"
+
+#: resources/public/admin/admin.js:201:16
+msgid "Chatbanned"
+msgstr "Banni du chat"
+
+#: resources/public/admin/admin.js:204:27
+msgid "Ban Reason"
+msgstr "Raison du bannissement"
+
+#: resources/public/admin/admin.js:205:27
+msgid "Ban Expiracy"
+msgstr "Expiration du bannissement"
+
+#: resources/public/admin/admin.js:208:27
+msgid "Chatban Reason"
+msgstr "Raison du bannissement du chat"
+
+#: resources/public/admin/admin.js:208:102
+msgid "(canvas ban)"
+msgstr "(bannissement de canvas)"
+
+#: resources/public/admin/admin.js:210:97
+msgid "when canvas ban ends"
+msgstr "quand le bannissement de canvas prend fin"
+
+#: resources/public/admin/admin.js:211:29
+msgid "Chatban Expires"
+msgstr "Expiration du bannissement de chat"
+
+#. Admin check. Example: type = 'username', arg = 'pxlsuser94'
+#: resources/public/admin/admin.js:313:36
+msgid "${type} ${arg} not found."
+msgstr "${type} ${arg} non trouvé"
+
+#: resources/public/admin/admin.js:319:50
+msgid "Unban Reason:"
+msgstr "Raison de la révocation du bannissement"
+
+#: resources/public/admin/admin.js:324:25
+msgid "Unbanning ${username}"
+msgstr "Révocation du bannissement de ${username}"
+
+#: resources/public/admin/admin.js:446:20
+msgid "profile"
+msgstr "profil"
+
+#: resources/public/admin/admin.js:470:21
+msgid "User Agent"
+msgstr "Agent Utilisateur"
+
+#: resources/public/admin/admin.js:475:21
+msgid "Send Alert"
+msgstr "Envoyer une alerte"
+
+#: resources/public/admin/admin.js:480:21
+msgid "Mod Actions"
+msgstr "Actions modérateur"
+
+#~ msgid "Note: These values are based on QWERTY keyboards. For other layouts, use the keys corresponding to the same position on a QWERTY keyboard."
+#~ msgstr "Note : Ces touches sont basées sur les claviers QWERTY. Pour d'autres claviers, utilise les touches correspondantes aux positions sur un clavier QWERTY."

--- a/resources/Localization_fr.properties
+++ b/resources/Localization_fr.properties
@@ -36,13 +36,15 @@ All\ Time\:=Total \:
 Loading\ online\ user\ count&hellip;=Chargement du nombre d'utilisateurs en ligne&hellip;
 
 #: resources/public/pebble_templates/index.html:101:30
+#: resources/public/include/lookup.js:276:21
+#: resources/public/admin/admin.js:196:16
 Pixels=Pixels
 
 #: resources/public/pebble_templates/index.html:112:54
 Undo=Annuler
 
 #: resources/public/pebble_templates/index.html:114:20
-You\ are\ not\ signed\ in.&nbsp;<a\ href\="\#">Sign\ in\ with...</a>=Tu n'es pas identifi\u00e9.&nbsp;<a href\="\#">S'identifier avec...</a>
+You\ are\ not\ signed\ in.&nbsp;<a\ href\="\#">Sign\ in\ with...</a>=Tu n'es pas connect\u00e9.&nbsp;<a href\="\#">Se connecter avec...</a>
 
 #: resources/public/pebble_templates/index.html:124:28
 Loading...=Chargement...
@@ -236,7 +238,7 @@ hidden;shown;hide;show=cach\u00e9;affich\u00e9;cacher;afficher
 <kbd>V</kbd>\ to\ toggle\ visibility=<kbd>V</kbd> pour activer/d\u00e9sactiver la visibilit\u00e9 d'un mod\u00e8le
 
 #: resources/public/pebble_templates/index.html:252:24
-Note\:\ These\ values\ are\ based\ on\ QWERTY\ keyboards.\\nFor\ other\ layouts,\ use\ the\ keys\ corresponding\ to\ the\ same\ position\ on\ a\ QWERTY\ keyboard.=Note \: Ces touches sont bas\u00e9es sur les claviers QWERTY. \\nPour d'autres claviers, utilise les touches correspondantes aux positions sur un clavier QWERTY.
+Note\:\ These\ values\ are\ based\ on\ QWERTY\ keyboards.\ For\ other\ layouts,\ use\ the\ keys\ corresponding\ to\ the\ same\ position\ on\ a\ QWERTY\ keyboard.=Note \: Ces touches sont bas\u00e9es sur les claviers QWERTY. Pour d'autres claviers, utilise les touches correspondantes aux positions sur un clavier QWERTY.
 
 #: resources/public/pebble_templates/index.html:256:36
 ui;interface=interface utilisateur;interface
@@ -398,10 +400,10 @@ banner;animation=banni\u00e8re;bandeau;animation
 Enable\ the\ rotating\ banner\ under\ chat=Animer le bandeau sous le chat
 
 #: resources/public/pebble_templates/index.html:409:44
-!max;messages;truncate=
+max;messages;truncate=max;messages;tronquer;troncature
 
 #: resources/public/pebble_templates/index.html:411:57
-!Maximum\ amount\ of\ chat\ messages\:=
+Maximum\ amount\ of\ chat\ messages\:=Maximum de messages visibles dans le chat
 
 #: resources/public/pebble_templates/index.html:415:44
 link;url;behaviour=lien;url
@@ -515,13 +517,13 @@ scrolling\ sensitivity;zooming\ sensitivity;mousewheel\ sensitivity=sensibilit\u
 Zoom\ sensitivity\:=Sensibilit\u00e9 du zoom \:
 
 #: resources/public/pebble_templates/index.html:512:44
-zooming\ limit;scrolling\ limit;mousewheel;zooming\ minimum;zooming\ maximum=limites du zoom;limites du scroll;roulette de souris;molette de souris;maximum du zoom
+zooming\ limit;scrolling\ limit;mousewheel;zooming\ minimum;zooming\ maximum=limites du zoom;limites du scroll;roulette de souris;molette de souris;minimum du zoom;maximum du zoom
 
 #: resources/public/pebble_templates/index.html:514:57
-!Minimum\ scale\:=
+Minimum\ scale\:=\u00c9chelle minimale \:
 
 #: resources/public/pebble_templates/index.html:518:57
-!Maximum\ scale\:=
+Maximum\ scale\:=\u00c9chelle maximale \:
 
 #: resources/public/pebble_templates/index.html:522:44
 rounding;zooming;scrolling;mousewheel;integer;decimal=arrondissement;zoom;scrolling;roulette de souris;molette de souris;nombre entier
@@ -542,25 +544,25 @@ MMB\ picker;mouse\ picker;selection;palette\ picker=s\u00e9lectionner une couleu
 Enable\ middle\ mouse\ button\ selecting\ color\ from\ board=Activer l'\u00e9chantillonnage de couleur sur le canvas avec le clic du milieu
 
 #: resources/public/pebble_templates/index.html:543:44
-!right\ click\ action=
+right\ click\ action=raccourci clic droit
 
 #: resources/public/pebble_templates/index.html:545:57
-!Right-click\ action\:=
+Right-click\ action\:=Action du clic droit \:
 
 #: resources/public/pebble_templates/index.html:547:60
-!Nothing=
+Nothing=Rien
 
 #: resources/public/pebble_templates/index.html:548:58
-!Clear\ color=
+Clear\ color=Retirer la couleur
 
 #: resources/public/pebble_templates/index.html:549:57
-!Copy\ color=
+Copy\ color=Copier la couleur
 
 #: resources/public/pebble_templates/index.html:550:59
-Lookup=Inspecter
+Lookup=inspection du pixel
 
 #: resources/public/pebble_templates/index.html:551:64
-!Clear\ color\ +\ Lookup=
+Clear\ color\ +\ Lookup=Retirer la couleur + inspection du pixel
 
 #: resources/public/pebble_templates/index.html:558:36
 snapshots;screenshot;download;picture;canvas=captures;capture d'\u00e9cran;t\u00e9l\u00e9charger;image;canvas
@@ -702,6 +704,7 @@ mention\ sound=son de mention;ping
 Play\ sound\ on\ ping\:=\u00c9mettre un son quand on est mentionn\u00e9 \:
 
 #: resources/public/pebble_templates/index.html:689:56
+#: resources/public/include/chat.js:1925:100
 Off=Jamais
 
 #: resources/public/pebble_templates/index.html:690:61
@@ -726,6 +729,8 @@ Account\ Settings=Param\u00e8tres du Compte
 Public\ Discord\ name\:=Nom Public Discord \:
 
 #: resources/public/pebble_templates/index.html:717:83
+#: resources/public/include/chat.js:1927:92
+#: resources/public/include/chat.js:1991:92
 Set=D\u00e9finir
 
 #: resources/public/pebble_templates/index.html:718:86
@@ -982,21 +987,24 @@ You\ must\ be\ logged\ in\ to\ view\ your\ profile.=Tu dois \u00eatre connect\u0
 Registration\ Date=Date d'inscription
 
 #: resources/public/pebble_templates/profile.html:82:72
+#: resources/public/include/lookup.js:280:21
 Alltime\ Pixels=Pixels totaux
 
 #: resources/public/pebble_templates/profile.html:86:72
-Current\ Canvas\ Pixels=Pixels du canvas actuel
+Current\ Canvas\ Pixels=Pixels plac\u00e9s ce canvas
 
 #: resources/public/pebble_templates/profile.html:91:72
 Discord\ Tag=Tag Discord
 
 #: resources/public/pebble_templates/profile.html:95:72
+#: resources/public/include/lookup.js:235:21
 Faction=Faction
 
 #: resources/public/pebble_templates/profile.html:96:259
 None=Aucune
 
 #: resources/public/pebble_templates/profile.html:99:72
+#: resources/public/admin/admin.js:195:16
 Roles=R\u00f4les
 
 #: resources/public/pebble_templates/profile.html:104:72
@@ -1085,6 +1093,7 @@ Members=Membres
 Edit=Modifier
 
 #: resources/public/pebble_templates/profile.html:244:168
+#: resources/public/include/chat.js:1450:24
 Delete=Supprimer
 
 #: resources/public/pebble_templates/profile.html:246:174
@@ -1110,6 +1119,7 @@ Transfer\ Ownership=Transf\u00e9rer la possession
 
 #. bans a user from the faction
 #: resources/public/pebble_templates/profile.html:294:122
+#: resources/public/include/chat.js:1721:60
 Ban=Exclure
 
 #: resources/public/pebble_templates/profile.html:300:79
@@ -1120,6 +1130,10 @@ Nothing\ to\ see\ here\!=Rien \u00e0 voir ici \!
 Faction\ Bans=Bannissements de la Faction
 
 #: resources/public/pebble_templates/profile.html:318:125
+#: resources/public/include/chat.js:1617:36
+#: resources/public/include/chat.js:1721:46
+#: resources/public/admin/admin.js:317:88
+#: resources/public/admin/admin.js:344:52
 Unban=R\u00e9voquer le bannissement
 
 #: resources/public/pebble_templates/profile.html:341:52
@@ -1160,3 +1174,500 @@ Not\ Allowed=Non Autoris\u00e9
 
 #: resources/public/pebble_templates/40x.html:59:23
 The\ action\ you\ attempted\ to\ perform\ is\ not\ allowed\ or\ resulted\ in\ an\ error.\ Please\ ensure\ you\ have\ access\ to\ the\ endpoint\ and\ try\ again\ later.=L'action que tu essayes d'effectuer n'est pas permise ou une erreur est survenue. Merci de t'assurer que tu as l'acc\u00e8s n\u00e9cessaire et de r\u00e9essayer plus tard.
+
+#: resources/public/pxls.js:134:38
+Alert=Alerte
+
+#. Snapshot save name
+#: resources/public/include/board.js:800:100
+pxls\ canvas=canvas de pxls
+
+#. template link action
+#: resources/public/include/chat.js:79:21
+Ask=Demander
+
+#: resources/public/include/chat.js:83:21
+Open\ in\ a\ new\ tab=Ouvrir dans un nouvel onglet
+
+#: resources/public/include/chat.js:87:21
+Open\ in\ current\ tab\ (replacing\ template)=Ouvrir dans cet onglet (en rempla\u00e7ant le mod\u00e8le)
+
+#: resources/public/include/chat.js:91:21
+Jump\ to\ coordinates\ without\ replacing\ template=Aller aux coordonn\u00e9es sans remplacer le mod\u00e8le
+
+#: resources/public/include/chat.js:1248:42
+#: resources/public/include/chat.js:1741:27
+none\ provided=aucune donn\u00e9e
+
+#: resources/public/include/chat.js:1249:38
+Purged\ by\ ${purge.initiator}\ with\ reason\:\ ${reason}=Purg\u00e9 par ${purge.initiator} pour la raison\: ${reason}
+
+#: resources/public/include/chat.js:1267:26
+template\:=mod\u00e8le \:
+
+#: resources/public/include/chat.js:1319:56
+#: resources/public/include/chat.js:2045:56
+Open\ Failed=\u00c9chec de l'ouverture
+
+#: resources/public/include/chat.js:1321:32
+#: resources/public/include/chat.js:2047:32
+Failed\ to\ automatically\ open\ in\ a\ new\ tab=\u00c9chec de l'ouverture automatique dans un nouvel onglet
+
+#: resources/public/include/chat.js:1325:24
+#: resources/public/include/chat.js:2051:24
+Click\ here\ to\ open\ in\ a\ new\ tab\ instead=Clique ici pour ouvrir dans un nouveau onglet \u00e0 la place
+
+#: resources/public/include/chat.js:1339:52
+Open\ Template=Ouvrir le Mod\u00e8le
+
+#: resources/public/include/chat.js:1341:54
+This\ link\ will\ overwrite\ your\ current\ template.\ What\ would\ you\ like\ to\ do?=Ce lien va \u00e9craser ton mod\u00e8le actuel. Que voudrais-tu faire ?
+
+#: resources/public/include/chat.js:1352:55
+Note\:\ You\ can\ set\ a\ default\ action\ in\ the\ settings\ menu\ which\ bypasses\ this\ popup\ completely.=Note \: Tu peux d\u00e9finir une action par d\u00e9faut dans les param\u00e8tres qui passera ce pop-up.
+
+#: resources/public/include/chat.js:1443:24
+#: resources/public/include/chat.js:1522:18
+#: resources/public/include/lookup.js:18:90
+Report=Signaler
+
+#: resources/public/include/chat.js:1444:24
+Mention=Mentionner
+
+#: resources/public/include/chat.js:1445:24
+Ignore=Ignorer
+
+#: resources/public/include/chat.js:1446:102
+#: resources/public/admin/admin.js:190:16
+Profile=Profil
+
+#: resources/public/include/chat.js:1447:24
+Chat\ (un)ban=Bannir/R\u00e9voquer le bannissement du chat
+
+#: resources/public/include/chat.js:1449:43
+#: resources/public/include/chat.js:1899:54
+Purge\ User=Purger l'utilisateur
+
+#: resources/public/include/chat.js:1451:24
+Mod\ Lookup=Inspection mod\u00e9rateur
+
+#: resources/public/include/chat.js:1452:24
+Chat\ Lookup=Inspection du chat
+
+#: resources/public/include/chat.js:1524:30
+Enter\ a\ reason\ for\ your\ report=Entre une raison pour ton signalement
+
+#: resources/public/include/chat.js:1553:26
+#: resources/public/include/chat.js:1674:18
+#: resources/public/include/chat.js:1833:22
+#: resources/public/include/chat.js:1881:22
+#: resources/public/include/chat.js:1949:22
+#: resources/public/include/chat.js:2009:22
+#: resources/public/include/lookup.js:64:91
+#: resources/public/include/user.js:73:87
+#: resources/public/admin/admin.js:331:20
+Cancel=Annuler
+
+#: resources/public/include/chat.js:1568:34
+#: resources/public/include/lookup.js:45:30
+Error\ sending\ report.=Erreur lors de l'envoi du signalement.
+
+#: resources/public/include/chat.js:1573:54
+Report\ User=Signaler l'utilisateur
+
+#: resources/public/include/chat.js:1587:34
+User\ ignored.\ You\ can\ unignore\ from\ chat\ settings.=Utilisateur ignor\u00e9. Tu peux le d\u00e9signorer dans les param\u00e8tres du chat.
+
+#: resources/public/include/chat.js:1589:34
+Failed\ to\ ignore\ user.\ Either\ they\\'re\ already\ ignored,\ or\ an\ error\ occurred.\ If\ the\ problem\ persists,\ contact\ a\ developer.=\u00c9chec \u00e0 ignorer l'utilisateur. Il/elle est d\u00e9j\u00e0 ignor\u00e9(e), ou une erreur s'est produite. Si le probl\u00e8me persiste, merci de contacter un d\u00e9veloppeur.
+
+#: resources/public/include/chat.js:1617:55
+Permanent=Permanent
+
+#: resources/public/include/chat.js:1617:78
+Temporary=Temporaire
+
+#: resources/public/include/chat.js:1644:32
+Rule\ 3\:\ Spam=R\u00e8gle 3 \: Spam
+
+#: resources/public/include/chat.js:1645:32
+Rule\ 1\:\ Chat\ civility=R\u00e8gle 1 \: Civilit\u00e9 du chat
+
+#: resources/public/include/chat.js:1646:32
+Rule\ 2\:\ Hate\ Speech=R\u00e8gle 2 \: Propos haineux
+
+#: resources/public/include/chat.js:1647:32
+Rule\ 5\:\ NSFW=R\u00e8gle 5 \: NSFW
+
+#: resources/public/include/chat.js:1648:32
+#: resources/public/include/chat.js:1726:58
+#: resources/public/include/chat.js:1747:45
+Custom=Personalis\u00e9e
+
+#: resources/public/include/chat.js:1681:33
+Banning\:=Bannir \:
+
+#: resources/public/include/chat.js:1681:50
+Message\:=Message \:
+
+#: resources/public/include/chat.js:1683:26
+Ban\ Length=Dur\u00e9e du bannissement
+
+#: resources/public/include/chat.js:1690:28
+Reason=Raison
+
+#: resources/public/include/chat.js:1695:28
+Purge\ Messages=Purger les messages
+
+#: resources/public/include/chat.js:1699:27
+Purging\ all\ messages\ is\ disabled\ during\ snip\ mode=La purge de tous les messages est d\u00e9sactiv\u00e9e en mode snip
+
+#: resources/public/include/chat.js:1702:79
+#: resources/public/include/user.js:174:22
+#: resources/public/admin/admin.js:182:41
+#: resources/public/admin/admin.js:184:94
+Yes=Oui
+
+#: resources/public/include/chat.js:1703:78
+#: resources/public/include/user.js:178:22
+#: resources/public/admin/admin.js:182:53
+#: resources/public/admin/admin.js:184:106
+No=Non
+
+#: resources/public/include/chat.js:1727:63
+Custom\ reason=Raison personalis\u00e9e
+
+#: resources/public/include/chat.js:1727:85
+#: resources/public/include/lookup.js:59:30
+Additional\ information\ (if\ applicable)=Information suppl\u00e9mentaire (si applicable)
+
+#: resources/public/include/chat.js:1752:45
+Additional\ information\:=Information suppl\u00e9mentaire \:
+
+#: resources/public/include/chat.js:1774:34
+Error\ occurred\ while\ chatbanning=Une erreur s'est produite lors du bannissement de chat
+
+#: resources/public/include/chat.js:1778:54
+Chatban=Bannissement du chat
+
+#: resources/public/include/chat.js:1798:32
+Failed\ to\ delete=\u00c9chec de la suppression
+
+#: resources/public/include/chat.js:1809:32
+#: resources/public/include/chat.js:1851:32
+ID\:\ =ID \:
+
+#: resources/public/include/chat.js:1813:32
+#: resources/public/include/chat.js:1861:32
+User\:\ =Utilisateur \:
+
+#: resources/public/include/chat.js:1817:32
+#: resources/public/include/chat.js:1855:32
+Message\:\ =Message \:
+
+#: resources/public/include/chat.js:1821:32
+Reason\:\ =Raison \:
+
+#: resources/public/include/chat.js:1838:54
+Delete\ Message=Supprimer le message \:
+
+#: resources/public/include/chat.js:1846:106
+Purge=Purger
+
+#: resources/public/include/chat.js:1867:28
+Selected\ Message=Message s\u00e9lectionn\u00e9
+
+#: resources/public/include/chat.js:1870:30
+Purge\ Reason=Raison de la purge
+
+#: resources/public/include/chat.js:1895:34
+Error\ sending\ purge.=Erreur lors de l'envoi de la purge
+
+#: resources/public/include/chat.js:1914:23
+ChatLookup=Inspection du chat
+
+#: resources/public/include/chat.js:1924:98
+On=Activ\u00e9
+
+#: resources/public/include/chat.js:1937:28
+Toggle\ Rename\ Request=Activer/D\u00e9sactiver la demande de renommage
+
+#: resources/public/include/chat.js:1938:27
+Select\ one\ of\ the\ options\ below\ to\ set\ the\ current\ rename\ request\ state.=S\u00e9lectionner une des options ci-dessous pour d\u00e9finir le statut actuel de la demande de renommage
+
+#: resources/public/include/chat.js:1963:30
+#: resources/public/include/chat.js:2022:30
+An\ unknown\ error\ occurred.\ Please\ contact\ a\ developer=Une erreur inconnue s'est produite. Merci de contacter un d\u00e9veloppeur.
+
+#: resources/public/include/chat.js:1989:52
+New\ Name\:\ =Nouveau Nom \:
+
+#: resources/public/include/chat.js:1999:27
+Enter\ the\ new\ name\ for\ the\ user\ below.\ Please\ note\ that\ if\ you\\'re\ trying\ to\ change\ the\ caps,\ you\\'ll\ have\ to\ rename\ to\ something\ else\ first.=Entre un nouveau nom pour l'utilisateur ci-dessous. Merci de prendre en compte que si tu essaies de changer la capitalization, il te faudra d'abord renommer en quelque chose d'autre.
+
+#: resources/public/include/chat.js:2037:54
+Force\ Rename=Forcer le renommage
+
+#: resources/public/include/chat.js:2076:118
+You\ cannot\ use\ chat\ while\ canvas\ banned.=Tu ne peux pas utiliser le chat si tu es banni sur le canvas.
+
+#: resources/public/include/lookup.js:21:32
+Sending...=Envoi...
+
+#: resources/public/include/lookup.js:28:32
+You\ must\ specify\ the\ details.=Tu dois sp\u00e9cifier les d\u00e9tails.
+
+#: resources/public/include/lookup.js:33:27
+additional\ information\:=information suppl\u00e9mentaire \:
+
+#: resources/public/include/lookup.js:49:50
+Report\ Pixel=Signaler un pixel
+
+#: resources/public/include/lookup.js:52:32
+Rule\ \#1\:\ Hateful/derogatory\ speech\ or\ symbols=R\u00e8gle \#1 \: Propos ou symboles haineux/d\u00e9rogatoires
+
+#: resources/public/include/lookup.js:53:32
+Rule\ \#2\:\ Nudity,\ genitalia,\ or\ non-PG-13\ content=R\u00e8gle \#2 \: Nudit\u00e9, organes g\u00e9nitaux ou contenu non adapt\u00e9 aux mineurs
+
+#: resources/public/include/lookup.js:54:32
+Rule\ \#3\:\ Multi-account=R\u00e8gle \#3 \: Multi-compte
+
+#: resources/public/include/lookup.js:55:32
+Rule\ \#4\:\ Botting=R\u00e8gle \#4 \: Usage de bot
+
+#: resources/public/include/lookup.js:56:52
+Other\ (specify\ below)=Autre (pr\u00e9ciser ci-dessous)
+
+#: resources/public/include/lookup.js:168:62
+Hide\ sensitive\ information=Cacher les informations sensibles
+
+#: resources/public/include/lookup.js:207:120
+An\ error\ occurred,\ either\ you\ aren't\ logged\ in\ or\ you\ may\ be\ attempting\ to\ look\ up\ users\ too\ fast.\ Please\ try\ again\ in\ 60\ seconds=Une erreur s'est produite, tu n'es pas connect\u00e9 ou tu essaies d'inspecter des pixels trop rapidement. Merci de r\u00e9essayer dans 60 secondes
+
+#: resources/public/include/lookup.js:218:21
+Coords=Coordonn\u00e9es
+
+#: resources/public/include/lookup.js:223:21
+#: resources/public/admin/admin.js:186:16
+Username=Nom d'utilisateur
+
+#: resources/public/include/lookup.js:229:28
+View\ Profile=Voir le profil
+
+#: resources/public/include/lookup.js:239:21
+Origin=Origine
+
+#: resources/public/include/lookup.js:243:28
+Part\ of\ a\ nuke=Fait partie d'un nuke
+
+#: resources/public/include/lookup.js:245:28
+Placed\ by\ a\ staff\ member\ using\ placement\ overrides=Plac\u00e9 par un membre de l'\u00e9quipe avec les outils du staff
+
+#: resources/public/include/lookup.js:252:21
+Time=Horaire
+
+#: resources/public/include/lookup.js:263:36
+just\ now=\u00e0 l'instant
+
+#: resources/public/include/lookup.js:271:36
+${hoursStr}\:${minuteStr}\:${secsStr}\ ago=il y a ${hoursStr}\:${minuteStr}\:${secsStr}
+
+#: resources/public/include/lookup.js:284:21
+Discord=Discord
+
+#: resources/public/include/notifications.js:60:58
+Posted\ by\ ${notification.who}=Post\u00e9 par ${notification.who}
+
+#: resources/public/include/notifications.js:63:111
+Expires\ ${expiry}=Expire \u00e0
+
+#: resources/public/include/template.js:93:50
+There\ was\ an\ error\ getting\ the\ image=Erreur \u00e0 l'obtention de l'image
+
+#: resources/public/include/timer.js:41:53
+Your\ next\ pixel\ will\ be\ available\ in\ ${delay}\ seconds\!=Ton prochain pixel sera disponible dans ${delay} secondes \!
+
+#: resources/public/include/timer.js:84:61
+Your\ next\ pixel\ has\ been\ available\ for\ ${alertDelay}\ seconds\!=Ton nouveau pixel est disponible depuis ${alertDelay} secondes \!
+
+#: resources/public/include/timer.js:98:59
+Your\ next\ pixel\ is\ available\!=Ton prochain pixel est disponible \!
+
+#. theme name
+#: resources/public/include/uiHelper.js:47:19
+Dark=Sombre
+
+#. theme name
+#: resources/public/include/uiHelper.js:53:19
+Darker=Plus sombre
+
+#. theme name
+#: resources/public/include/uiHelper.js:59:19
+Blue=Bleu
+
+#. theme name
+#: resources/public/include/uiHelper.js:65:19
+Purple=Violet
+
+#. theme name
+#: resources/public/include/uiHelper.js:71:19
+Green=Vert
+
+#. theme name
+#: resources/public/include/uiHelper.js:77:19
+Matte=Mat
+
+#. theme name
+#: resources/public/include/uiHelper.js:83:19
+Terminal=Terminal
+
+#. theme name
+#: resources/public/include/uiHelper.js:89:19
+Red=Rouge
+
+#: resources/public/include/uiHelper.js:453:30
+Discord\ name\ updated\ successfully=Le nom Discord a bien \u00e9t\u00e9 mis \u00e0 jour
+
+#: resources/public/include/uiHelper.js:460:32
+Couldn\\'t\ change\ discord\ name\:\ =\u00c9chec du changement du nom Discord
+
+#: resources/public/include/user.js:81:28
+Sign\ in\ with...=Se connecter avec...
+
+#: resources/public/include/user.js:94:149
+New\ Accounts\ Disabled=Nouveaux comptes d\u00e9sactiv\u00e9s
+
+#: resources/public/include/user.js:167:52
+Sign\ Out=Se d\u00e9connecter
+
+#: resources/public/include/user.js:169:27
+Are\ you\ sure\ you\ want\ to\ sign\ out?=Es-tu s\u00fbr(e) de vouloir te d\u00e9connecter ?
+
+#: resources/public/include/user.js:194:28
+Too\ many\ sessions\ open,\ try\ closing\ some\ tabs.=Trop de sessions sont ouvertes, merci d'essayer de fermer quelques onglets
+
+#: resources/public/include/user.js:227:39
+You\ are\ permanently\ banned.=Tu es banni d\u00e9finitivement.
+
+#: resources/public/include/user.js:231:39
+You\ are\ temporarily\ banned\ and\ will\ not\ be\ allowed\ to\ place\ until\ ${timestamp}=Tu es banni temporairement et ne pourra pas placer de pixel jusqu'\u00e0 ${timestamp}
+
+#: resources/public/include/user.js:251:27
+If\ you\ think\ this\ was\ an\ error,\ please\ contact\ us\ using\ one\ of\ the\ links\ in\ the\ info\ tab.=Si tu penses que ceci est une erreur, merci de nous contacter en utilisant un des liens dans la barre d'informations.
+
+#: resources/public/include/user.js:252:27
+Ban\ reason\:=Raison du bannissement \:
+
+#: resources/public/include/user.js:256:28
+#: resources/public/admin/admin.js:200:16
+Banned=Banni
+
+#: resources/public/include/user.js:326:23
+Staff\ have\ required\ you\ to\ change\ your\ username,\ this\ usually\ means\ your\ name\ breaks\ one\ of\ our\ rules.=Le staff te demande de changer de nom d'utilisateur, ceci signifie g\u00e9n\u00e9ralement que ton nom enfreint une de nos r\u00e8gles.
+
+#: resources/public/include/user.js:327:23
+If\ you\ disagree,\ please\ contact\ us\ on\ Discord\ (link\ in\ the\ info\ panel).=Si tu n'es pas d'accord, merci de nous contacter sur Discord (lien dans la barre d'informations).
+
+#: resources/public/include/user.js:328:27
+New\ Username\:=Nouveau nom d'utilisateur \:
+
+#: resources/public/include/user.js:341:89
+Not\ now=Pas maintenant
+
+#: resources/public/include/user.js:342:86
+Change=Changer
+
+#: resources/public/include/user.js:346:50
+#: resources/public/admin/admin.js:198:16
+Rename\ Requested=Renommage demand\u00e9
+
+#: resources/public/admin/admin.js:98:38
+Something\ went\ wrong\!\ Perhaps\ insufficient\ permissions?=Il y a eu un probl\u00e8me \! Peut-\u00eatre un manque de permissions ?
+
+#: resources/public/admin/admin.js:103:45
+Shadowban\ user=Shadowban l'utilisateur
+
+#: resources/public/admin/admin.js:103:67
+Shadowbanned\ user=L'utilisateur a \u00e9t\u00e9 shadowban
+
+#: resources/public/admin/admin.js:106:45
+Permaban\ user=Bannir l'utilisateur d\u00e9finitivement
+
+#: resources/public/admin/admin.js:106:66
+Permabanned\ user=L'utilisateur a \u00e9t\u00e9 banni d\u00e9finitivement
+
+#: resources/public/admin/admin.js:109:45
+Ban\ user=Bannir l'utilisateur
+
+#: resources/public/admin/admin.js:109:61
+Banned\ user=L'utilisateur a \u00e9t\u00e9 banni
+
+#: resources/public/admin/admin.js:123:36
+Unbanned\ user\ ${username}=L'utilisateur ${username} n'est plus banni
+
+#. Context: ban type
+#: resources/public/admin/admin.js:176:27
+shadow=shadow
+
+#: resources/public/admin/admin.js:177:29
+#: resources/public/admin/admin.js:180:29
+never=jamais
+
+#: resources/public/admin/admin.js:179:27
+permanent=d\u00e9finitif
+
+#: resources/public/admin/admin.js:184:51
+Yes\ (permanent)=Oui (d\u00e9finitif)
+
+#: resources/public/admin/admin.js:191:16
+#: resources/public/admin/admin.js:451:21
+Logins=Logins
+
+#: resources/public/admin/admin.js:197:16
+All\ Time\ Pixels=Pixels totaux
+
+#: resources/public/admin/admin.js:199:16
+Discord\ Name=Nom Discord
+
+#: resources/public/admin/admin.js:201:16
+Chatbanned=Banni du chat
+
+#: resources/public/admin/admin.js:204:27
+Ban\ Reason=Raison du bannissement
+
+#: resources/public/admin/admin.js:205:27
+Ban\ Expiracy=Expiration du bannissement
+
+#: resources/public/admin/admin.js:208:27
+Chatban\ Reason=Raison du bannissement du chat
+
+#: resources/public/admin/admin.js:208:102
+(canvas\ ban)=(bannissement de canvas)
+
+#: resources/public/admin/admin.js:210:97
+when\ canvas\ ban\ ends=quand le bannissement de canvas prend fin
+
+#: resources/public/admin/admin.js:211:29
+Chatban\ Expires=Expiration du bannissement de chat
+
+#. Admin check. Example: type = 'username', arg = 'pxlsuser94'
+#: resources/public/admin/admin.js:313:36
+${type}\ ${arg}\ not\ found.=${type} ${arg} non trouv\u00e9
+
+#: resources/public/admin/admin.js:319:50
+Unban\ Reason\:=Raison de la r\u00e9vocation du bannissement
+
+#: resources/public/admin/admin.js:324:25
+Unbanning\ ${username}=R\u00e9vocation du bannissement de ${username}
+
+#: resources/public/admin/admin.js:446:20
+profile=profil
+
+#: resources/public/admin/admin.js:470:21
+User\ Agent=Agent Utilisateur
+
+#: resources/public/admin/admin.js:475:21
+Send\ Alert=Envoyer une alerte
+
+#: resources/public/admin/admin.js:480:21
+Mod\ Actions=Actions mod\u00e9rateur

--- a/resources/public/admin/admin.js
+++ b/resources/public/admin/admin.js
@@ -10,7 +10,7 @@
     }).addClass('text-button').text(s);
   };
   const sendAlert = function(username) {
-    return $('<input>').attr('type', 'text').attr('placeholder', 'Send alert...').keydown(function (evt) {
+    return $('<input>').attr('type', 'text').attr('placeholder', __('Send alert...')).keydown(function (evt) {
       if (evt.which === 13) {
         admin.socket.send({
           type: 'admin_message',
@@ -31,29 +31,30 @@
       deinit: function () {},
       prompt: function (s, time, fn) {
         const timeInput = $('<input>').attr('type', 'number').attr('step', 'any').addClass('admin-bannumber').val(time);
+        const timeInputHTML = $('<span>').append(timeInput).html();
         self.elements.prompt.empty().append(
           $('<p>').addClass('text').css({
             fontWeight: 800,
             marginTop: 0
           }).text(s),
           $('<select>').append(
-            $('<option>').text('Rule #1: Hateful/derogatory speech or symbols'),
-            $('<option>').text('Rule #2: Nudity, genitalia, or non-PG-13 content'),
-            $('<option>').text('Rule #3: Multi-account'),
-            $('<option>').text('Rule #4: Botting'),
-            $('<option>').attr('value', 'other').text('Other (specify below)')
+            $('<option>').text(__('Rule #1: Hateful/derogatory speech or symbols')),
+            $('<option>').text(__('Rule #2: Nudity, genitalia, or non-PG-13 content')),
+            $('<option>').text(__('Rule #3: Multi-account')),
+            $('<option>').text(__('Rule #4: Botting')),
+            $('<option>').attr('value', 'other').text(__('Other (specify below)'))
           ).css({
             width: '100%',
             'margin-bottom': '1em'
           }),
-          $('<textarea>').attr('placeholder', 'Additional information (if applicable)').css({
+          $('<textarea>').attr('placeholder', __('Additional information (if applicable)')).css({
             width: '100%',
             height: '5em'
           }).keydown(function (evt) {
             evt.stopPropagation();
           }),
-          $('<div>').addClass('text').append(
-            'Revert pixels of the last ', timeInput, ' hours'
+          $('<div>').addClass('text').html(
+            __(`Revert pixels of the last ${timeInputHTML} hours`)
           ),
           $('<div>').addClass('buttons').append(
             genButton('Cancel').click(function () {
@@ -65,7 +66,7 @@
               let msg = selectedRule;
               if (selectedRule === 'other') {
                 if (textarea === '') {
-                  alert.show('You must specify the details.');
+                  alert.show(__('You must specify the details.'));
                   return;
                 }
                 msg = textarea;
@@ -94,18 +95,18 @@
               fn();
             }
           }).fail(function () {
-            admin.modal.showText('Something went wrong! Perhaps insufficient permissions?');
+            admin.modal.showText(__('Something went wrong! Perhaps insufficient permissions?'));
           });
         });
       },
       shadow: function (username, fn) {
-        self.ban_internal(username, fn, 'Shadowban user', 'Shadowbanned user', '/admin/shadowban');
+        self.ban_internal(username, fn, __('Shadowban user'), __('Shadowbanned user'), '/admin/shadowban');
       },
       perma: function (username, fn) {
-        self.ban_internal(username, fn, 'Permaban user', 'Permabanned user', '/admin/permaban');
+        self.ban_internal(username, fn, __('Permaban user'), __('Permabanned user'), '/admin/permaban');
       },
       ban: function (username, time, fn) {
-        self.ban_internal(username, fn, 'Ban user', 'Banned user', '/admin/ban', time);
+        self.ban_internal(username, fn, __('Ban user'), __('Banned user'), '/admin/ban', time);
       },
       ban_24h: function (username, fn) {
         self.ban(username, 24 * 3600, fn);
@@ -119,7 +120,7 @@
           username,
           reason
         }, function () {
-          admin.modal.showText(`Unbanned user ${username}`, { modalOpts: { closeExisting: true } });
+          admin.modal.showText(__(`Unbanned user ${username}`), { modalOpts: { closeExisting: true } });
           if (fn) {
             fn();
           }
@@ -171,42 +172,43 @@
         let expiracyStr = hoursStr + ':' + minuteStr + ':' + secsStr;
         let chatbannedStr = '';
         if (data.shadowBanned) {
-          bannedStr = 'shadow';
-          expiracyStr = 'never';
+          // Shadow banned
+          bannedStr = __('shadow');
+          expiracyStr = __('never');
         } else if (data.banExpiry === 0) {
-          bannedStr = 'permanent';
-          expiracyStr = 'never';
+          bannedStr = __('permanent');
+          expiracyStr = __('never');
         } else {
-          bannedStr = data.banned ? 'Yes' : 'No';
+          bannedStr = data.banned ? __('Yes') : __('No');
         }
-        chatbannedStr = data.chatbanIsPerma ? 'Yes (permanent)' : (data.chatBanned ? 'Yes' : 'No');
+        chatbannedStr = data.chatbanIsPerma ? __('Yes (permanent)') : (data.chatBanned ? __('Yes') : __('No'));
         const items = [
-          ['Username', crel('a', {
+          [__('Username'), crel('a', {
             href: `https://admin.${location.host}/userinfo/${data.username}`,
             target: '_blank'
           }, data.username)],
-          ['Profile', crel('a', { href: `/profile/${data.username}`, target: '_blank' }, data.username)],
-          ['Logins', data.logins
+          [__('Profile'), crel('a', { href: `/profile/${data.username}`, target: '_blank' }, data.username)],
+          [__('Logins'), data.logins
             ? data.logins.map(({ serviceID, serviceUserID }) => `${serviceID}:${serviceUserID}`).join(', ')
             : null
           ],
-          ['Roles', data.roles.map(role => role.name).join(', ')],
-          ['Pixels', data.pixelCount],
-          ['All Time Pixels', data.pixelCountAllTime],
-          ['Rename Requested', data.renameRequested ? 'Yes' : 'No'],
-          ['Discord Name', data.discordName || '(not set)'],
-          ['Banned', bannedStr],
-          ['Chatbanned', chatbannedStr]
+          [__('Roles'), data.roles.map(role => role.name).join(', ')],
+          [__('Pixels'), data.pixelCount],
+          [__('All Time Pixels'), data.pixelCountAllTime],
+          [__('Rename Requested'), data.renameRequested ? 'Yes' : 'No'],
+          [__('Discord Name'), data.discordName || '(not set)'],
+          [__('Banned'), bannedStr],
+          [__('Chatbanned'), chatbannedStr]
         ];
         if (data.banned) {
-          items.push(['Ban Reason', data.ban_reason]);
-          items.push(['Ban Expiracy', expiracyStr]);
+          items.push([__('Ban Reason'), data.ban_reason]);
+          items.push([__('Ban Expiracy'), expiracyStr]);
         }
         if (data.chatBanned) {
-          items.push(['Chatban Reason', App.chat.canvasBanRespected && !data.chatbanReason ? '(canvas ban)' : data.chatbanReason]);
+          items.push([__('Chatban Reason'), App.chat.canvasBanRespected && !data.chatbanReason ? __('(canvas ban)') : data.chatbanReason]);
           if (!data.isChatbanPerma) {
-            const chatbannedExpiracyStr = App.chat.canvasBanRespected && chatbanDelta < 0 ? 'when canvas ban ends' : `${chatbanDelta >> 0}s`;
-            items.push(['Chatban Expires', chatbannedExpiracyStr]);
+            const chatbannedExpiracyStr = App.chat.canvasBanRespected && chatbanDelta < 0 ? __('when canvas ban ends') : `${chatbanDelta >> 0}s`;
+            items.push([__('Chatban Expires'), chatbannedExpiracyStr]);
           }
         }
         self.elements.check.empty().append(
@@ -223,20 +225,20 @@
             }),
             (admin.user.hasPermission('user.alert') ? $('<div>').append(sendAlert(data.username)) : ''),
             $('<div>').append(
-              genButton('Ban (24h)').click(function () {
+              genButton(__('Ban (24h)')).click(function () {
                 ban.ban_24h(data.username, function () {
                   self.elements.check.fadeOut(200);
                 });
               }),
-              (admin.user.hasPermission('user.permaban') ? genButton('Permaban').click(function () {
+              (admin.user.hasPermission('user.permaban') ? genButton(__('Permaban')).click(function () {
                 ban.perma(data.username, function () {
                   self.elements.check.fadeOut(200);
                 });
               }) : '')
             ),
             $('<div>').append(
-              (data.banned ? genButton('Unban').click(() => self.popUnban(data.username)) : ''),
-              (admin.user.hasPermission('user.shadowban') ? genButton('Shadowban').click(function () {
+              (data.banned ? genButton(__('Unban')).click(() => self.popUnban(data.username)) : ''),
+              (admin.user.hasPermission('user.shadowban') ? genButton(__('Shadowban')).click(function () {
                 ban.shadow(data.username, function () {
                   self.elements.check.fadeOut(200);
                 });
@@ -282,7 +284,7 @@
               }, 'Force Rename') : '')
             ) : ''),
             $('<div>').append(
-              $('<b>').text('Custom ban length: '), '<br>',
+              $('<b>').text(__('Custom ban length: ')), '<br>',
               $('<input>').attr('type', 'number').attr('step', 'any').addClass('admin-bannumber').val(24),
               ' hours ',
               genButton('Ban').click(function () {
@@ -292,7 +294,7 @@
               })
             )
           ),
-          genButton('Close').addClass('float-right').click(function () {
+          genButton(__('Close')).addClass('float-right').click(function () {
             self.elements.check.fadeOut(200);
           })
         ).fadeIn(200);
@@ -307,25 +309,26 @@
         const toPost = {};
         toPost[type] = arg;
         $.post('/admin/check', toPost, self.callback).fail(function () {
-          admin.modal.showText(`${type} ${arg} not found.`);
+          // Admin check. Example: type = 'username', arg = 'pxlsuser94'
+          admin.modal.showText(__(`${type} ${arg} not found.`));
         });
       },
       popUnban: username => {
-        const btnSubmit = crel('button', { class: 'text-button', type: 'submit' }, 'Unban');
+        const btnSubmit = crel('button', { class: 'text-button', type: 'submit' }, __('Unban'));
         const txtUnbanReason = crel('input', { type: 'text', required: 'true' });
-        const lblUnbanReason = crel('label', 'Unban Reason: ', txtUnbanReason);
+        const lblUnbanReason = crel('label', __('Unban Reason:') + ' ', txtUnbanReason);
 
         txtUnbanReason.addEventListener('keydown', e => e.stopPropagation());
 
         const unbanWrapper = crel('form', { class: 'chatmod-container' },
-          crel('p', `Unbanning ${username}`),
+          crel('p', __(`Unbanning ${username}`)),
           lblUnbanReason,
           crel('div', { class: 'buttons' },
             crel('button', {
               class: 'text-button',
               type: 'button',
               onclick: () => { admin.modal.closeAll(); }
-            }, 'Cancel'),
+            }, __('Cancel')),
             btnSubmit
           )
         );
@@ -338,7 +341,7 @@
         };
 
         admin.modal.show(admin.modal.buildDom(
-          crel('h2', { class: 'modal-title' }, 'Unban'),
+          crel('h2', { class: 'modal-title' }, __('Unban')),
           unbanWrapper
         ));
       }
@@ -357,13 +360,14 @@
       },
       init: function () {
         self.elements.panel.hide().addClass('admin bubble').append(
-          $('<h2>').text('MOD'),
+          // Moderator panel label
+          $('<h2>').text(__('MOD')),
           $('<div>').append(
             // first do the checkboxes
             $.map(
               [
                 {
-                  text: 'Ignore cooldown',
+                  text: __('Ignore cooldown'),
                   onChange: function () {
                     admin.socket.send({ type: 'admin_placement_overrides', ignoreCooldown: this.checked });
                   },
@@ -371,7 +375,7 @@
                   disabled: !(admin.user.hasPermission('board.cooldown.override') || admin.user.hasPermission('board.cooldown.ignore'))
                 },
                 {
-                  text: 'Place any color',
+                  text: __('Place any color'),
                   onChange: function () {
                     admin.socket.send({ type: 'admin_placement_overrides', canPlaceAnyColor: this.checked });
                   },
@@ -379,7 +383,7 @@
                   disabled: !admin.user.hasPermission('board.palette.all')
                 },
                 {
-                  text: 'Ignore placemap',
+                  text: __('Ignore placemap'),
                   onChange: function () {
                     admin.socket.send({ type: 'admin_placement_overrides', ignorePlacemap: this.checked });
                   },
@@ -395,9 +399,9 @@
             ),
             // next do the text input
             $.map([
-              ['Ban user (24h)', ban.ban_24h],
-              ['Unban user', checkUser.popUnban],
-              ['Check user', checkUser.check]
+              [__('Ban user (24h)'), ban.ban_24h],
+              [__('Unban user'), checkUser.popUnban],
+              [__('Check user'), checkUser.check]
             ], function (o) {
               return $('<input>').attr({
                 type: 'text',
@@ -439,12 +443,12 @@
             }, data.username), ' (', crel('a', {
               href: `/profile/${data.username}`,
               target: '_blank'
-            }, 'profile'), ')')
+            }, __('profile')), ')')
             : null
         });
         App.lookup.registerHook({
           id: 'logins',
-          name: 'Logins',
+          name: __('Logins'),
           sensitive: true,
           get: data => {
             if (data.logins == null) {
@@ -463,25 +467,25 @@
           }
         }, {
           id: 'user_agent',
-          name: 'User Agent',
+          name: __('User Agent'),
           sensitive: true,
           get: data => $('<div>').text(data.userAgent)
         }, {
           id: 'alert',
-          name: 'Send Alert',
+          name: __('Send Alert'),
           sensitive: true,
           get: data => sendAlert(data.username)
         }, {
           id: 'admin_actions',
-          name: 'Mod Actions',
+          name: __('Mod Actions'),
           sensitive: true,
           get: data => $('<span>').append(
-            genButton('Ban (24h)').click(() => {
+            genButton(__('Ban (24h)')).click(() => {
               ban.ban_24h(data.username, function () {
                 self.elements.lookup.fadeOut(200);
               });
             }),
-            genButton('More...').click(() => {
+            genButton(__('More...')).click(() => {
               checkUser.check(data.username);
               self.elements.lookup.fadeOut(200);
             })

--- a/resources/public/admin/admin.js
+++ b/resources/public/admin/admin.js
@@ -172,7 +172,7 @@
         let expiracyStr = hoursStr + ':' + minuteStr + ':' + secsStr;
         let chatbannedStr = '';
         if (data.shadowBanned) {
-          // Shadow banned
+          // translator: Context: ban type
           bannedStr = __('shadow');
           expiracyStr = __('never');
         } else if (data.banExpiry === 0) {
@@ -309,7 +309,7 @@
         const toPost = {};
         toPost[type] = arg;
         $.post('/admin/check', toPost, self.callback).fail(function () {
-          // Admin check. Example: type = 'username', arg = 'pxlsuser94'
+          // translator: Admin check. Example: type = 'username', arg = 'pxlsuser94'
           admin.modal.showText(__(`${type} ${arg} not found.`));
         });
       },

--- a/resources/public/include/board.js
+++ b/resources/public/include/board.js
@@ -796,7 +796,8 @@ const board = (function() {
       const format = settings.board.snapshot.format.get();
 
       a.href = self.elements.board[0].toDataURL(format, 1);
-      a.download = (new Date()).toISOString().replace(/^(\d+-\d+-\d+)T(\d+):(\d+):(\d).*$/, `pxls canvas $1 $2.$3.$4.${format.split('/')[1]}`);
+      // Snapshot save name
+      a.download = (new Date()).toISOString().replace(/^(\d+-\d+-\d+)T(\d+):(\d+):(\d).*$/, `${__('pxls canvas')} $1 $2.$3.$4.${format.split('/')[1]}`);
       document.body.appendChild(a);
       a.click();
       document.body.removeChild(a);

--- a/resources/public/include/board.js
+++ b/resources/public/include/board.js
@@ -796,7 +796,7 @@ const board = (function() {
       const format = settings.board.snapshot.format.get();
 
       a.href = self.elements.board[0].toDataURL(format, 1);
-      // Snapshot save name
+      // translator: Snapshot save name
       a.download = (new Date()).toISOString().replace(/^(\d+-\d+-\d+)T(\d+):(\d+):(\d).*$/, `${__('pxls canvas')} $1 $2.$3.$4.${format.split('/')[1]}`);
       document.body.appendChild(a);
       a.click();

--- a/resources/public/include/chat.js
+++ b/resources/public/include/chat.js
@@ -75,19 +75,20 @@ const chat = (function() {
     TEMPLATE_ACTIONS: {
       ASK: {
         id: 'ask',
-        pretty: 'Ask'
+        // translator: template link action
+        pretty: __('Ask')
       },
       NEW_TAB: {
         id: 'new tab',
-        pretty: 'Open in a new tab'
+        pretty: __('Open in a new tab')
       },
       CURRENT_TAB: {
         id: 'current tab',
-        pretty: 'Open in current tab (replacing template)'
+        pretty: __('Open in current tab (replacing template)')
       },
       JUMP_ONLY: {
         id: 'jump only',
-        pretty: 'Jump to coordinates without replacing template'
+        pretty: __('Jump to coordinates without replacing template')
       }
     },
     init: () => {

--- a/resources/public/include/chat.js
+++ b/resources/public/include/chat.js
@@ -1245,7 +1245,8 @@ const chat = (function() {
     },
     _markMessagePurged: (elem, purge) => {
       elem.classList.add('purged');
-      elem.setAttribute('title', `Purged by ${purge.initiator} with reason: ${purge.reason || 'none provided'}`);
+      const reason = purge.reason || __('none provided');
+      elem.setAttribute('title', __(`Purged by ${purge.initiator} with reason: ${reason}`));
       elem.dataset.purgedBy = purge.initiator;
     },
     _markMessageShadowBanned: (elem) => {
@@ -1255,12 +1256,15 @@ const chat = (function() {
     _makeCoordinatesElement: (raw, x, y, scale, template, title) => {
       let text = `(${x}, ${y}${scale != null ? `, ${scale}x` : ''})`;
       if (template != null && template.length >= 11) { // we have a template, should probably make that known
-        const tmplName = decodeURIComponent(
+        let tmplName = decodeURIComponent(
           settings.chat.links.templates.preferurls.get() !== true && title && title.trim()
             ? title
             : template
         );
-        text += ` (template: ${(tmplName > 25) ? `${tmplName.substr(0, 22)}...` : tmplName})`;
+        if (tmplName.length > 25) {
+          tmplName = `${tmplName.substr(0, 22)}...`;
+        }
+        text += ` (${__('template:')} ${tmplName})`;
       }
 
       function handleClick(e) {
@@ -1312,13 +1316,13 @@ const chat = (function() {
         case self.TEMPLATE_ACTIONS.NEW_TAB.id: {
           if (!window.open(linkElem.dataset.raw, '_blank')) { // what popup blocker still blocks _blank redirects? idk but i'm sure they exist.
             modal.show(modal.buildDom(
-              crel('h2', { class: 'modal-title' }, 'Open Failed'),
+              crel('h2', { class: 'modal-title' }, __('Open Failed')),
               crel('div',
-                crel('h3', 'Failed to automatically open in a new tab'),
+                crel('h3', __('Failed to automatically open in a new tab')),
                 crel('a', {
                   href: linkElem.dataset.raw,
                   target: '_blank'
-                }, 'Click here to open in a new tab instead')
+                }, __('Click here to open in a new tab instead'))
               )
             ));
           }
@@ -1332,9 +1336,9 @@ const chat = (function() {
         // const buttons = crel('div', { style: 'text-align: right; display: block; width: 100%;' });
 
         modal.show(modal.buildDom(
-          crel('h2', { class: 'modal-title' }, 'Open Template'),
+          crel('h2', { class: 'modal-title' }, __('Open Template')),
           crel(bodyWrapper,
-            crel('h3', { class: 'text-orange' }, 'This link will overwrite your current template. What would you like to do?'),
+            crel('h3', { class: 'text-orange' }, __('This link will overwrite your current template. What would you like to do?')),
             Object.values(self.TEMPLATE_ACTIONS).map(action => action.id === self.TEMPLATE_ACTIONS.ASK.id ? null
               : crel('label', { style: 'display: block; margin: 3px 3px 3px 1rem; margin-left: 1rem;' },
                 crel('input', {
@@ -1345,11 +1349,11 @@ const chat = (function() {
                 action.pretty
               )
             ),
-            crel('span', { class: 'text-muted' }, 'Note: You can set a default action in the settings menu which bypasses this popup completely.')
+            crel('span', { class: 'text-muted' }, __('Note: You can set a default action in the settings menu which bypasses this popup completely.'))
           ),
           [
-            ['Cancel', () => resolve(false)],
-            ['OK', () => resolve(bodyWrapper.querySelector('input[type=radio]:checked').dataset.actionId)]
+            [__('Cancel'), () => resolve(false)],
+            [__('OK'), () => resolve(bodyWrapper.querySelector('input[type=radio]:checked').dataset.actionId)]
           ].map(x =>
             crel('button', {
               class: 'text-button',
@@ -1436,16 +1440,16 @@ const chat = (function() {
         const actionsList = crel('ul', { class: 'actions-list' });
 
         const actions = [
-          { label: 'Report', action: 'report', class: 'dangerous-button' },
-          { label: 'Mention', action: 'mention' },
-          { label: 'Ignore', action: 'ignore' },
-          (!board.snipMode || App.user.hasPermission('user.receivestaffbroadcasts')) && { label: 'Profile', action: 'profile' },
-          { label: 'Chat (un)ban', action: 'chatban', staffaction: true },
+          { label: __('Report'), action: 'report', class: 'dangerous-button' },
+          { label: __('Mention'), action: 'mention' },
+          { label: __('Ignore'), action: 'ignore' },
+          (!board.snipMode || App.user.hasPermission('user.receivestaffbroadcasts')) && { label: __('Profile'), action: 'profile' },
+          { label: __('Chat (un)ban'), action: 'chatban', staffaction: true },
           // TODO(netux): Fix infraestructure and allow to purge during snip mode
-          !board.snipMode && { label: 'Purge User', action: 'purge', staffaction: true },
-          { label: 'Delete', action: 'delete', staffaction: true },
-          { label: 'Mod Lookup', action: 'lookup-mod', staffaction: true },
-          { label: 'Chat Lookup', action: 'lookup-chat', staffaction: true }
+          !board.snipMode && { label: __('Purge User'), action: 'purge', staffaction: true },
+          { label: __('Delete'), action: 'delete', staffaction: true },
+          { label: __('Mod Lookup'), action: 'lookup-mod', staffaction: true },
+          { label: __('Chat Lookup'), action: 'lookup-chat', staffaction: true }
         ];
 
         crel(leftPanel, crel('p', { class: 'popup-timestamp-header text-muted' }, moment.unix(closest.dataset.date >> 0).format(`MMM Do YYYY, ${(settings.chat.timestamps['24h'].get() === true ? 'HH:mm:ss' : 'hh:mm:ss A')}`)));
@@ -1515,20 +1519,27 @@ const chat = (function() {
           const reportButton = crel('button', {
             class: 'text-button dangerous-button',
             type: 'submit'
-          }, 'Report');
+          }, __('Report'));
           const textArea = crel('textarea', {
-            placeholder: 'Enter a reason for your report',
+            placeholder: __('Enter a reason for your report'),
             style: 'width: 100%; border: 1px solid #999;',
             onkeydown: e => e.stopPropagation()
           });
 
+          // NOTE ([  ]): these names are bad — they are functionally the same
+          // as the ones used above but contain different content.
+          // Also, the code is awful but getting a clean translation string is
+          // more important than having clean code for what I'm doing right now.
+          const reportTarget = crel('span', crel('span', { style: 'font-weight: bold' }, reportingTarget)).innerHTML;
+          const reportMessage = crel('span', crel('span', { title: reportingMessage }, reportingMessage.substr(0, 60) + (reportingMessage.length > 60 ? '...' : ''))).innerHTML;
+
           const chatReport =
               crel('form', { class: 'report chat-report', 'data-chat-id': this.dataset.id },
-                crel('p', { style: 'font-size: 1rem !important;' },
-                  'You are reporting a chat message from ',
-                  crel('span', { style: 'font-weight: bold' }, reportingTarget),
-                  crel('span', { title: reportingMessage }, ` with the content "${reportingMessage.substr(0, 60)}${reportingMessage.length > 60 ? '...' : ''}"`)
-                ),
+                // NOTE ([  ]): Using $ here instead of crel because the content
+                // contains HTML as a string (reportTarget and reportMessage).
+                $('<p>').style('font-size', '1rem !important;').html(
+                  __(`You are reporting a chat message from ${reportTarget} with the content:`) + reportMessage
+                )[0],
                 textArea,
                 crel('div', { style: 'text-align: right' },
                   crel('button', {
@@ -1539,7 +1550,7 @@ const chat = (function() {
                       modal.closeAll();
                       chatReport.remove();
                     }
-                  }, 'Cancel'),
+                  }, __('Cancel')),
                   reportButton
                 )
               );
@@ -1552,14 +1563,14 @@ const chat = (function() {
               report_message: textArea.value
             }, function() {
               chatReport.remove();
-              modal.showText('Sent report!');
+              modal.showText(__('Sent report!'));
             }).fail(function() {
-              modal.showText('Error sending report.');
+              modal.showText(__('Error sending report.'));
               reportButton.disabled = false;
             });
           };
           modal.show(modal.buildDom(
-            crel('h2', { class: 'modal-title' }, 'Report User'),
+            crel('h2', { class: 'modal-title' }, __('Report User')),
             chatReport
           ));
           break;
@@ -1573,9 +1584,9 @@ const chat = (function() {
         case 'ignore': {
           if (reportingTarget) {
             if (chat.addIgnore(reportingTarget)) {
-              modal.showText('User ignored. You can unignore from chat settings.');
+              modal.showText(__('User ignored. You can unignore from chat settings.'));
             } else {
-              modal.showText('Failed to ignore user. Either they\'re already ignored, or an error occurred. If the problem persists, contact a developer.');
+              modal.showText(__('Failed to ignore user. Either they\'re already ignored, or an error occurred. If the problem persists, contact a developer.'));
             }
           } else console.warn('no reportingTarget');
           break;
@@ -1603,7 +1614,7 @@ const chat = (function() {
               )
             );
 
-          const banLengths = [['Unban', -3], ['Permanent', -1], ['Temporary', -2]];
+          const banLengths = [[__('Unban'), -3], [__('Permanent'), -1], [__('Temporary'), -2]];
           const _selBanLength = crel('select', { name: 'selBanLength' },
             banLengths.map(lenPart =>
               crel('option', { value: lenPart[1] }, lenPart[0])
@@ -1630,11 +1641,11 @@ const chat = (function() {
           });
 
           const _selBanReason = crel('select',
-            crel('option', 'Rule 3: Spam'),
-            crel('option', 'Rule 1: Chat civility'),
-            crel('option', 'Rule 2: Hate Speech'),
-            crel('option', 'Rule 5: NSFW'),
-            crel('option', 'Custom')
+            crel('option', __('Rule 3: Spam')),
+            crel('option', __('Rule 1: Chat civility')),
+            crel('option', __('Rule 2: Hate Speech')),
+            crel('option', __('Rule 5: NSFW')),
+            crel('option', __('Custom'))
           );
 
           const _additionalReasonInfoWrap = crel('div', { style: 'margin-top: .5rem;' });
@@ -1660,36 +1671,36 @@ const chat = (function() {
               chatbanContainer.remove();
               modal.closeAll();
             }
-          }, 'Cancel');
+          }, __('Cancel'));
           const _btnOK = crel('button', { class: 'text-button dangerous-button', type: 'submit' }, 'Ban');
 
           const chatbanContainer = crel('form', {
             class: 'chatmod-container',
             'data-chat-id': this.dataset.id
           },
-          crel('h5', mode ? 'Banning:' : 'Message:'),
+          crel('h5', mode ? __('Banning:') : __('Message:')),
           messageTable,
-          crel('h5', 'Ban Length'),
+          crel('h5', __('Ban Length')),
           _selBanLength,
           crel(_customLenWrap,
             _txtCustomLength,
             _selCustomLength
           ),
           crel(_reasonWrap,
-            crel('h5', 'Reason'),
+            crel('h5', __('Reason')),
             _selBanReason,
             crel(_additionalReasonInfoWrap, _txtAdditionalReason)
           ),
           crel(_purgeWrap,
-            crel('h5', 'Purge Messages'),
+            crel('h5', __('Purge Messages')),
             board.snipMode
               ? crel('span', { class: 'text-orange extra-warning' },
                 crel('i', { class: 'fas fa-exclamation-triangle' }),
-                ' Purging all messages is disabled during snip mode'
+                ' ' + __('Purging all messages is disabled during snip mode')
               )
               : [
-                crel('label', { style: 'display: inline;' }, _rbPurgeYes, 'Yes'),
-                crel('label', { style: 'display: inline;' }, _rbPurgeNo, 'No')
+                crel('label', { style: 'display: inline;' }, _rbPurgeYes, __('Yes')),
+                crel('label', { style: 'display: inline;' }, _rbPurgeNo, __('No'))
               ]
           ),
           crel('div', { class: 'buttons' },
@@ -1707,13 +1718,13 @@ const chat = (function() {
             const isUnban = _selBanLength.value === '-3';
             _reasonWrap.style.display = isUnban ? 'none' : 'block';
             _purgeWrap.style.display = isUnban ? 'none' : 'block';
-            _btnOK.innerHTML = isUnban ? 'Unban' : 'Ban';
+            _btnOK.innerHTML = isUnban ? __('Unban') : __('Ban');
           });
           _selCustomLength.selectedIndex = 1; // minutes
 
           const updateAdditionalTextarea = () => {
-            const isCustom = _selBanReason.value === 'Custom';
-            _txtAdditionalReason.placeholder = isCustom ? 'Custom reason' : 'Additional information (if applicable)';
+            const isCustom = _selBanReason.value === __('Custom');
+            _txtAdditionalReason.placeholder = isCustom ? __('Custom reason') : __('Additional information (if applicable)');
             _txtAdditionalReason.required = isCustom;
           };
 
@@ -1727,18 +1738,18 @@ const chat = (function() {
             e.preventDefault();
             const postData = {
               type: 'temp',
-              reason: 'none provided',
+              reason: __('none provided'),
               // TODO(netux): Fix infraestructure and allow to purge during snip mode
               removalAmount: !board.snipMode ? (_rbPurgeYes.checked ? -1 : 0) : 0, // message purges are based on username, so if we purge when everyone in chat is -snip-, we aren't gonna have a good time
               banLength: 0
             };
 
-            if (_selBanReason.value === 'Custom') {
+            if (_selBanReason.value === __('Custom')) {
               postData.reason = _txtAdditionalReason.value;
             } else {
               postData.reason = _selBanReason.value;
               if (_txtAdditionalReason.value) {
-                postData.reason += `. Additional information: ${_txtAdditionalReason.value}`;
+                postData.reason += `. ${__('Additional information:')} ${_txtAdditionalReason.value}`;
               }
             }
 
@@ -1758,13 +1769,13 @@ const chat = (function() {
             if (mode) { postData.cmid = this.dataset.id; } else { postData.who = reportingTarget; }
 
             $.post('/admin/chatban', postData, () => {
-              modal.showText('Chatban initiated');
+              modal.showText(__('Chatban initiated'));
             }).fail(() => {
-              modal.showText('Error occurred while chatbanning');
+              modal.showText(__('Error occurred while chatbanning'));
             });
           };
           modal.show(modal.buildDom(
-            crel('h2', { class: 'modal-title' }, 'Chatban'),
+            crel('h2', { class: 'modal-title' }, __('Chatban')),
             crel('div', { style: 'padding-left: 1em' },
               chatbanContainer
             )
@@ -1784,7 +1795,7 @@ const chat = (function() {
           }, () => {
             modal.closeAll();
           }).fail(() => {
-            modal.showText('Failed to delete');
+            modal.showText(__('Failed to delete'));
           });
 
           if (e.shiftKey === true) {
@@ -1795,19 +1806,19 @@ const chat = (function() {
           const deleteWrapper = crel('div', { class: 'chatmod-container' },
             crel('table',
               crel('tr',
-                crel('th', 'ID: '),
+                crel('th', __('ID: ')),
                 crel('td', this.dataset.id)
               ),
               crel('tr',
-                crel('th', 'User: '),
+                crel('th', __('User: ')),
                 crel('td', reportingTarget)
               ),
               crel('tr',
-                crel('th', 'Message: '),
+                crel('th', __('Message: ')),
                 crel('td', { title: reportingMessage }, `${reportingMessage.substr(0, 120)}${reportingMessage.length > 120 ? '...' : ''}`)
               ),
               crel('tr',
-                crel('th', 'Reason: '),
+                crel('th', __('Reason: ')),
                 crel('td', _txtReason)
               )
             ),
@@ -1819,12 +1830,12 @@ const chat = (function() {
                   deleteWrapper.remove();
                   modal.closeAll();
                 }
-              }, 'Cancel'),
+              }, __('Cancel')),
               btndelete
             )
           );
           modal.show(modal.buildDom(
-            crel('h2', { class: 'modal-title' }, 'Delete Message'),
+            crel('h2', { class: 'modal-title' }, __('Delete Message')),
             deleteWrapper
           ));
           break;
@@ -1832,31 +1843,31 @@ const chat = (function() {
         case 'purge': {
           const txtPurgeReason = crel('input', { type: 'text', onkeydown: e => e.stopPropagation() });
 
-          const btnPurge = crel('button', { class: 'text-button dangerous-button', type: 'submit' }, 'Purge');
+          const btnPurge = crel('button', { class: 'text-button dangerous-button', type: 'submit' }, __('Purge'));
 
           const messageTable = mode
             ? crel('table',
               crel('tr',
-                crel('th', 'ID: '),
+                crel('th', __('ID: ')),
                 crel('td', this.dataset.id)
               ),
               crel('tr',
-                crel('th', 'Message: '),
+                crel('th', __('Message: ')),
                 crel('td', { title: reportingMessage }, `${reportingMessage.substr(0, 120)}${reportingMessage.length > 120 ? '...' : ''}`)
               )
             )
             : crel('table', { class: 'chatmod-table' },
               crel('tr',
-                crel('th', 'User: '),
+                crel('th', __('User: ')),
                 crel('td', reportingTarget)
               )
             );
 
           const purgeWrapper = crel('form', { class: 'chatmod-container' },
-            crel('h5', 'Selected Message'),
+            crel('h5', __('Selected Message')),
             messageTable,
             crel('div',
-              crel('h5', 'Purge Reason'),
+              crel('h5', __('Purge Reason')),
               txtPurgeReason
             ),
             crel('div', { class: 'buttons' },
@@ -1867,7 +1878,7 @@ const chat = (function() {
                   purgeWrapper.remove();
                   modal.closeAll();
                 }
-              }, 'Cancel'),
+              }, __('Cancel')),
               btnPurge
             )
           );
@@ -1879,13 +1890,13 @@ const chat = (function() {
               reason: txtPurgeReason.value
             }, function() {
               purgeWrapper.remove();
-              modal.showText('User purged');
+              modal.showText(__('User purged'));
             }).fail(function() {
-              modal.showText('Error sending purge.');
+              modal.showText(__('Error sending purge.'));
             });
           };
           modal.show(modal.buildDom(
-            crel('h2', { class: 'modal-title' }, 'Purge User'),
+            crel('h2', { class: 'modal-title' }, __('Purge User')),
             crel('div', { style: 'padding-left: 1em' }, purgeWrapper)
           ));
           break;
@@ -1900,7 +1911,7 @@ const chat = (function() {
         }
         case 'lookup-chat': {
           socket.send({
-            type: 'ChatLookup',
+            type: __('ChatLookup'),
             arg: board.snipMode ? this.dataset.id : reportingTarget,
             mode: board.snipMode ? 'cmid' : 'username'
           });
@@ -1910,10 +1921,10 @@ const chat = (function() {
           const rbStateOn = crel('input', { type: 'radio', name: 'rbState' });
           const rbStateOff = crel('input', { type: 'radio', name: 'rbState' });
 
-          const stateOn = crel('label', { style: 'display: inline-block' }, rbStateOn, ' On');
-          const stateOff = crel('label', { style: 'display: inline-block' }, rbStateOff, ' Off');
+          const stateOn = crel('label', { style: 'display: inline-block' }, rbStateOn, ' ' + __('On'));
+          const stateOff = crel('label', { style: 'display: inline-block' }, rbStateOff, ' ' + __('Off'));
 
-          const btnSetState = crel('button', { class: 'text-button', type: 'submit' }, 'Set');
+          const btnSetState = crel('button', { class: 'text-button', type: 'submit' }, __('Set'));
 
           const renameError = crel('p', {
             style: 'display: none; color: #f00; font-weight: bold; font-size: .9rem',
@@ -1923,8 +1934,8 @@ const chat = (function() {
           rbStateOff.checked = true;
 
           const renameWrapper = crel('form', { class: 'chatmod-container' },
-            crel('h3', 'Toggle Rename Request'),
-            crel('p', 'Select one of the options below to set the current rename request state.'),
+            crel('h3', __('Toggle Rename Request')),
+            crel('p', __('Select one of the options below to set the current rename request state.')),
             crel('div', stateOn, stateOff),
             renameError,
             crel('div', { class: 'buttons' },
@@ -1935,7 +1946,7 @@ const chat = (function() {
                   renameWrapper.remove();
                   modal.closeAll();
                 }
-              }, 'Cancel'),
+              }, __('Cancel')),
               btnSetState
             )
           );
@@ -1947,9 +1958,9 @@ const chat = (function() {
               flagState: rbStateOn.checked === true
             }, function() {
               renameWrapper.remove();
-              modal.showText('Rename request updated');
+              modal.showText(__('Rename request updated'));
             }).fail(function(xhrObj) {
-              let resp = 'An unknown error occurred. Please contact a developer';
+              let resp = __('An unknown error occurred. Please contact a developer');
               if (xhrObj.responseJSON) {
                 resp = xhrObj.responseJSON.details || resp;
               } else if (xhrObj.responseText) {
@@ -1975,9 +1986,9 @@ const chat = (function() {
             required: 'true',
             onkeydown: e => e.stopPropagation()
           });
-          const newNameWrapper = crel('label', 'New Name: ', newNameInput);
+          const newNameWrapper = crel('label', __('New Name: '), newNameInput);
 
-          const btnSetState = crel('button', { class: 'text-button', type: 'submit' }, 'Set');
+          const btnSetState = crel('button', { class: 'text-button', type: 'submit' }, __('Set'));
 
           const renameError = crel('p', {
             style: 'display: none; color: #f00; font-weight: bold; font-size: .9rem',
@@ -1985,7 +1996,7 @@ const chat = (function() {
           }, '');
 
           const renameWrapper = crel('form', { class: 'chatmod-container' },
-            crel('p', 'Enter the new name for the user below. Please note that if you\'re trying to change the caps, you\'ll have to rename to something else first.'),
+            crel('p', __('Enter the new name for the user below. Please note that if you\'re trying to change the caps, you\'ll have to rename to something else first.')),
             newNameWrapper,
             renameError,
             crel('div', { class: 'buttons' },
@@ -1995,7 +2006,7 @@ const chat = (function() {
                 onclick: () => {
                   modal.closeAll();
                 }
-              }, 'Cancel'),
+              }, __('Cancel')),
               btnSetState
             )
           );
@@ -2006,9 +2017,9 @@ const chat = (function() {
               user: reportingTarget,
               newName: newNameInput.value.trim()
             }, function() {
-              modal.showText('User renamed');
+              modal.showText(__('User renamed'));
             }).fail(function(xhrObj) {
-              let resp = 'An unknown error occurred. Please contact a developer';
+              let resp = __('An unknown error occurred. Please contact a developer');
               if (xhrObj.responseJSON) {
                 resp = xhrObj.responseJSON.details || resp;
               } else if (xhrObj.responseText) {
@@ -2023,7 +2034,7 @@ const chat = (function() {
             });
           };
           modal.show(modal.buildDom(
-            crel('h2', { class: 'modal-title' }, 'Force Rename'),
+            crel('h2', { class: 'modal-title' }, __('Force Rename')),
             renameWrapper
           ));
           break;
@@ -2031,13 +2042,13 @@ const chat = (function() {
         case 'profile': {
           if (!window.open(`/profile/${reportingTarget}`, '_blank')) {
             modal.show(modal.buildDom(
-              crel('h2', { class: 'modal-title' }, 'Open Failed'),
+              crel('h2', { class: 'modal-title' }, __('Open Failed')),
               crel('div',
-                crel('h3', 'Failed to automatically open in a new tab'),
+                crel('h3', __('Failed to automatically open in a new tab')),
                 crel('a', {
                   href: `/profile/${reportingTarget}`,
                   target: '_blank'
-                }, 'Click here to open in a new tab instead')
+                }, __('Click here to open in a new tab instead'))
               )
             ));
           }
@@ -2062,7 +2073,7 @@ const chat = (function() {
       const canChat = self._canChat();
       self._handleChatbanVisualState(canChat);
       if (!canChat) {
-        if (self.elements.rate_limit_counter.text().trim().length === 0) { self.elements.rate_limit_counter.text('You cannot use chat while canvas banned.'); }
+        if (self.elements.rate_limit_counter.text().trim().length === 0) { self.elements.rate_limit_counter.text(__('You cannot use chat while canvas banned.')); }
       }
     }
   };

--- a/resources/public/include/chat.js
+++ b/resources/public/include/chat.js
@@ -425,7 +425,7 @@ const chat = (function() {
             self._handleChatbanVisualState(self._canChat());
           } else {
             self._handleChatbanVisualState(false);
-            self.elements.rate_limit_counter.text('You must be logged in to chat');
+            self.elements.rate_limit_counter.text(__('You must be logged in to chat'));
           }
         }
       });
@@ -943,7 +943,7 @@ const chat = (function() {
         self.elements.input.prop('disabled', true);
         self.elements.rate_limit_overlay.show();
         if (!isChatBanned) {
-          self.elements.rate_limit_counter.text('You must be logged in to chat.');
+          self.elements.rate_limit_counter.text(__('You must be logged in to chat.'));
         }
         self.elements.emoji_button.hide();
       }

--- a/resources/public/include/lookup.js
+++ b/resources/public/include/lookup.js
@@ -15,22 +15,22 @@ module.exports.lookup = (function() {
     },
     handle: null,
     report: function(id, x, y) {
-      const reportButton = crel('button', { class: 'text-button dangerous-button' }, 'Report');
+      const reportButton = crel('button', { class: 'text-button dangerous-button' }, __('Report'));
       reportButton.addEventListener('click', function() {
         this.disabled = true;
-        this.textContent = 'Sending...';
+        this.textContent = __('Sending...');
 
         const selectedRule = this.closest('.modal').querySelector('select').value;
         const textarea = this.closest('.modal').querySelector('textarea').value.trim();
         let msg = selectedRule;
         if (selectedRule === 'other') {
           if (textarea === '') {
-            modal.showText('You must specify the details.');
+            modal.showText(__('You must specify the details.'));
             return;
           }
           msg = textarea;
         } else if (textarea !== '') {
-          msg += '; additional information: ' + textarea;
+          msg += `; ${__('additional information:')} ' ${textarea}`;
         }
         $.post('/report', {
           id: id,
@@ -38,30 +38,30 @@ module.exports.lookup = (function() {
           y: y,
           message: msg
         }, function() {
-          modal.showText('Sent report!');
+          modal.showText(__('Sent report!'));
           self.elements.prompt.hide();
           self.elements.lookup.hide();
         }).fail(function() {
-          modal.showText('Error sending report.');
+          modal.showText(__('Error sending report.'));
         });
       });
       modal.show(modal.buildDom(
-        crel('h2', { class: 'modal-title' }, 'Report Pixel'),
+        crel('h2', { class: 'modal-title' }, __('Report Pixel')),
         crel('div',
           crel('select', { style: 'width: 100%; margin-bottom: 1em;' },
-            crel('option', 'Rule #1: Hateful/derogatory speech or symbols'),
-            crel('option', 'Rule #2: Nudity, genitalia, or non-PG-13 content'),
-            crel('option', 'Rule #3: Multi-account'),
-            crel('option', 'Rule #4: Botting'),
-            crel('option', { value: 'other' }, 'Other (specify below)')
+            crel('option', __('Rule #1: Hateful/derogatory speech or symbols')),
+            crel('option', __('Rule #2: Nudity, genitalia, or non-PG-13 content')),
+            crel('option', __('Rule #3: Multi-account')),
+            crel('option', __('Rule #4: Botting')),
+            crel('option', { value: 'other' }, __('Other (specify below)'))
           ),
           crel('textarea', {
-            placeholder: 'Additional information (if applicable)',
+            placeholder: __('Additional information (if applicable)'),
             style: 'width: 100%; height: 5em',
             onkeydown: e => e.stopPropagation()
           }),
           crel('div', { class: 'buttons' },
-            crel('button', { class: 'text-button', onclick: () => modal.closeAll() }, 'Cancel'),
+            crel('button', { class: 'text-button', onclick: () => modal.closeAll() }, __('Cancel')),
             reportButton
           )
         )
@@ -130,7 +130,7 @@ module.exports.lookup = (function() {
           return '';
         }
 
-        return $('<p>').text('This pixel is background (was not placed by a user).');
+        return $('<p>').text(__('This pixel is background (was not placed by a user).'));
       }).append(() => {
         const hooks = data.bg
           ? self.hooks.filter((hook) => hook.backgroundCompatible)
@@ -165,7 +165,7 @@ module.exports.lookup = (function() {
 
         const label = $('<label>');
         const checkbox = $('<input type="checkbox">').css('margin-top', '10px');
-        const span = $('<span class="label-text">').text('Hide sensitive information');
+        const span = $('<span class="label-text">').text(__('Hide sensitive information'));
         label.prepend(checkbox, span);
         settings.lookup.filter.sensitive.enable.controls.add(checkbox);
         return label;
@@ -176,14 +176,14 @@ module.exports.lookup = (function() {
       return self.elements.lookup.empty().append(
         $('<div>').addClass('content'),
         (!data.bg && user.isLoggedIn()
-          ? $('<button>').css('float', 'left').addClass('dangerous-button text-button').text('Report').click(function() {
+          ? $('<button>').css('float', 'left').addClass('dangerous-button text-button').text(__('Report')).click(function() {
             self.report(data.id, data.x, data.y);
           })
           : ''),
-        $('<button>').css('float', 'right').addClass('text-button').text('Close').click(function() {
+        $('<button>').css('float', 'right').addClass('text-button').text(__('Close')).click(function() {
           self.elements.lookup.fadeOut(200);
         }),
-        (template.getOptions().use ? $('<button>').css('float', 'right').addClass('text-button').text('Move Template Here').click(function() {
+        (template.getOptions().use ? $('<button>').css('float', 'right').addClass('text-button').text(__('Move Template Here')).click(function() {
           template.queueUpdate({
             ox: data.x,
             oy: data.y
@@ -204,7 +204,7 @@ module.exports.lookup = (function() {
           self.create(data);
         }
       }).fail(function() {
-        self._makeShell({ x: pos.x, y: pos.y }).find('.content').first().append($('<p>').css('color', '#c00').text("An error occurred, either you aren't logged in or you may be attempting to look up users too fast. Please try again in 60 seconds"));
+        self._makeShell({ x: pos.x, y: pos.y }).find('.content').first().append($('<p>').css('color', '#c00').text(__("An error occurred, either you aren't logged in or you may be attempting to look up users too fast. Please try again in 60 seconds")));
         self.elements.lookup.fadeIn(200);
       });
     },
@@ -215,41 +215,41 @@ module.exports.lookup = (function() {
       self.registerHook(
         {
           id: 'coords',
-          name: 'Coords',
+          name: __('Coords'),
           get: data => $('<a>').text('(' + data.x + ', ' + data.y + ')').attr('href', coords.getLinkToCoords(data.x, data.y)),
           backgroundCompatible: true
         }, {
           id: 'username',
-          name: 'Username',
+          name: __('Username'),
           get: data => data.username
             ? !board.snipMode
               ? crel('a', {
                 href: `/profile/${data.username}`,
                 target: '_blank',
-                title: 'View Profile'
+                title: __('View Profile')
               }, data.username)
               : data.username
             : null
         }, {
           id: 'faction',
-          name: 'Faction',
+          name: __('Faction'),
           get: data => data.faction || null
         }, {
           id: 'origin',
-          name: 'Origin',
+          name: __('Origin'),
           get: data => {
             switch (data.origin) {
               case 'nuke':
-                return 'Part of a nuke';
+                return __('Part of a nuke');
               case 'mod':
-                return 'Placed by a staff member using placement overrides';
+                return __('Placed by a staff member using placement overrides');
               default:
                 return null;
             }
           }
         }, {
           id: 'time',
-          name: 'Time',
+          name: __('Time'),
           get: data => {
             const delta = ((new Date()).getTime() - data.time) / 1000;
             const stamp = (new Date(data.time)).toLocaleString();
@@ -260,7 +260,7 @@ module.exports.lookup = (function() {
             if (delta > 24 * 3600) {
               return span.text(stamp);
             } else if (delta < 5) {
-              return span.text('just now');
+              return span.text(__('just now'));
             } else {
               const secs = Math.floor(delta % 60);
               const secsStr = secs < 10 ? '0' + secs : secs;
@@ -268,20 +268,20 @@ module.exports.lookup = (function() {
               const minuteStr = minutes < 10 ? '0' + minutes : minutes;
               const hours = Math.floor(delta / 3600);
               const hoursStr = hours < 10 ? '0' + hours : hours;
-              return span.text(hoursStr + ':' + minuteStr + ':' + secsStr + ' ago');
+              return span.text(__(`${hoursStr}:${minuteStr}:${secsStr} ago`));
             }
           }
         }, {
           id: 'pixels',
-          name: 'Pixels',
+          name: __('Pixels'),
           get: data => data.pixelCount
         }, {
           id: 'pixels_alltime',
-          name: 'Alltime Pixels',
+          name: __('Alltime Pixels'),
           get: data => data.pixelCountAlltime
         }, {
           id: 'discord_name',
-          name: 'Discord',
+          name: __('Discord'),
           get: data => data.discordName
         }
       );

--- a/resources/public/include/notifications.js
+++ b/resources/public/include/notifications.js
@@ -51,14 +51,16 @@ module.exports.notifications = (function() {
       }
     },
     makeDomForNotification(notification) {
+      const expiry = notification.expiry ? moment.unix(notification.expiry).format('MMM DD YYYY') : null;
+
       return crel('article', { class: 'notification', 'data-notification-id': notification.id },
         crel('header', { class: 'notification-title' }, crel('h2', notification.title)),
         crel('div', { class: 'notification-body' }, chat.processMessage(notification.content)),
         crel('footer', { class: 'notification-footer' },
-          notification.who ? document.createTextNode(`Posted by ${notification.who}`) : null,
+          notification.who ? document.createTextNode(__(`Posted by ${notification.who}`)) : null,
           notification.expiry !== 0 ? crel('span', { class: 'notification-expiry float-left' },
             crel('i', { class: 'far fa-clock fa-is-left' }),
-            crel('span', { title: moment.unix(notification.expiry).format('MMMM DD, YYYY, hh:mm:ss A') }, `Expires ${moment.unix(notification.expiry).format('MMM DD YYYY')}`)
+            crel('span', { title: moment.unix(notification.expiry).format('MMMM DD, YYYY, hh:mm:ss A') }, __(`Expires ${expiry}`))
           ) : null
         )
       );

--- a/resources/public/include/template.js
+++ b/resources/public/include/template.js
@@ -90,7 +90,7 @@ module.exports.template = (function() {
         self.elements.template.toggleClass('pixelate', query.get('scale') > self.getWidthRatio());
       }).on('error', () => {
         self.elements.imageErrorWarning.show();
-        self.elements.imageErrorWarning.text('There was an error getting the image');
+        self.elements.imageErrorWarning.text(__('There was an error getting the image'));
         self.elements.template.remove();
       });
       if (board.update(true)) {

--- a/resources/public/include/timer.js
+++ b/resources/public/include/timer.js
@@ -36,8 +36,9 @@ module.exports.timer = (function() {
       if (alertDelay < 0 && delta < Math.abs(alertDelay) && !self.hasFiredNotification) {
         self.playAudio();
         let notif;
+        const delay = Math.abs(alertDelay);
         if (!document.hasFocus()) {
-          notif = nativeNotifications.maybeShow(`Your next pixel will be available in ${Math.abs(alertDelay)} seconds!`);
+          notif = nativeNotifications.maybeShow(__(`Your next pixel will be available in ${delay} seconds!`));
         }
         setTimeout(() => {
           uiHelper.setPlaceableText(1);
@@ -80,7 +81,7 @@ module.exports.timer = (function() {
         setTimeout(() => {
           self.playAudio();
           if (!document.hasFocus()) {
-            const notif = nativeNotifications.maybeShow(`Your next pixel has been available for ${alertDelay} seconds!`);
+            const notif = nativeNotifications.maybeShow(__(`Your next pixel has been available for ${alertDelay} seconds!`));
             if (notif) {
               $(window).one('pxls:ack:place', () => notif.close());
             }
@@ -94,7 +95,7 @@ module.exports.timer = (function() {
       if (!self.hasFiredNotification) {
         self.playAudio();
         if (!document.hasFocus()) {
-          const notif = nativeNotifications.maybeShow('Your next pixel is available!');
+          const notif = nativeNotifications.maybeShow(__('Your next pixel is available!'));
           if (notif) {
             $(window).one('pxls:ack:place', () => notif.close());
           }

--- a/resources/public/include/uiHelper.js
+++ b/resources/public/include/uiHelper.js
@@ -106,7 +106,8 @@ const uiHelper = (function() {
         ), { closeExisting: false });
       });
       socket.on('received_report', (data) => {
-        new SLIDEIN.Slidein(`A new ${data.report_type.toLowerCase()} report has been received.`, 'info-circle').show().closeAfter(3000);
+        const type = data.report_type.toLowerCase();
+        new SLIDEIN.Slidein(__(`A new ${type} report has been received.`), 'info-circle').show().closeAfter(3000);
       });
 
       settings.ui.palette.numbers.enable.listen(function(value) {
@@ -449,14 +450,14 @@ const uiHelper = (function() {
           discordName: name
         },
         success: function() {
-          modal.showText('Discord name updated successfully');
+          modal.showText(__('Discord name updated successfully'));
         },
         error: function(data) {
           const err = data.responseJSON && data.responseJSON.details ? data.responseJSON.details : data.responseText;
           if (data.status === 200) { // seems to be caused when response body isn't json? just show whatever we can and trust server sent good enough details.
             modal.showText(err);
           } else {
-            modal.showText('Couldn\'t change discord name: ' + err);
+            modal.showText(__('Couldn\'t change discord name: ') + err);
           }
         }
       });
@@ -466,7 +467,7 @@ const uiHelper = (function() {
         if (!url) url = 'notify.wav';
         timer.audioElem.src = url;
       } catch (e) {
-        modal.showText('Failed to update audio src, using default sound.');
+        modal.showText(__('Failed to update audio src, using default sound.'));
         timer.audioElem.src = 'notify.wav';
       }
     },

--- a/resources/public/include/uiHelper.js
+++ b/resources/public/include/uiHelper.js
@@ -43,42 +43,50 @@ const uiHelper = (function() {
     },
     themes: [
       {
-        name: 'Dark',
+        // translator: theme name
+        name: __('Dark'),
         location: '/themes/dark.css',
         color: '#1A1A1A'
       },
       {
-        name: 'Darker',
+        // translator: theme name
+        name: __('Darker'),
         location: '/themes/darker.css',
         color: '#000'
       },
       {
-        name: 'Blue',
+        // translator: theme name
+        name: __('Blue'),
         location: '/themes/blue.css',
         color: '#0000FF'
       },
       {
-        name: 'Purple',
+        // translator: theme name
+        name: __('Purple'),
         location: '/themes/purple.css',
         color: '#5a2f71'
       },
       {
-        name: 'Green',
+        // translator: theme name
+        name: __('Green'),
         location: '/themes/green.css',
         color: '#005f00'
       },
       {
-        name: 'Matte',
+        // translator: theme name
+        name: __('Matte'),
         location: '/themes/matte.css',
         color: '#468079'
       },
       {
-        name: 'Terminal',
+        // translator: theme name
+        name: __('Terminal'),
         location: '/themes/terminal.css',
         color: '#94e044'
       },
       {
-        name: 'Red',
+        // translator: theme name
+        name: __('Red'),
         location: '/themes/red.css',
         color: '#cf0000'
       }

--- a/resources/public/include/user.js
+++ b/resources/public/include/user.js
@@ -233,7 +233,15 @@ const user = (function() {
           if (window.deInitAdmin) {
             window.deInitAdmin();
           }
-          $.getScript('admin/admin.js').done(function() {
+
+          let scriptName = 'admin';
+
+          const langcode = document.documentElement.lang;
+          if (langcode !== 'en') {
+            scriptName += '_' + langcode;
+          }
+
+          $.getScript(`admin/${scriptName}.js`).done(function() {
             window.initAdmin({
               socket: socket,
               user: user,

--- a/resources/public/include/user.js
+++ b/resources/public/include/user.js
@@ -70,7 +70,7 @@ const user = (function() {
       self.elements.loginOverlay.find('a').click(function(evt) {
         evt.preventDefault();
 
-        const cancelButton = crel('button', { class: 'float-right text-button' }, 'Cancel');
+        const cancelButton = crel('button', { class: 'float-right text-button' }, __('Cancel'));
         cancelButton.addEventListener('click', function() {
           self.elements.prompt.fadeOut(200);
         });
@@ -78,7 +78,7 @@ const user = (function() {
         self.elements.prompt[0].innerHTML = '';
         crel(self.elements.prompt[0],
           crel('div', { class: 'content' },
-            crel('h1', 'Sign in with...'),
+            crel('h1', __('Sign in with...')),
             crel('ul',
               Object.values(data.authServices).map(service => {
                 const anchor = crel('a', { href: `/signin/${service.id}?redirect=1` }, service.name);
@@ -91,7 +91,7 @@ const user = (function() {
                 });
                 const toRet = crel('li', anchor);
                 if (!service.registrationEnabled) {
-                  crel(toRet, crel('span', { style: 'font-style: italic; font-size: .75em; font-weight: bold; color: red; margin-left: .5em' }, 'New Accounts Disabled'));
+                  crel(toRet, crel('span', { style: 'font-style: italic; font-size: .75em; font-weight: bold; color: red; margin-left: .5em' }, __('New Accounts Disabled')));
                 }
                 return toRet;
               })
@@ -164,18 +164,18 @@ const user = (function() {
         evt.preventDefault();
 
         modal.show(modal.buildDom(
-          crel('h2', { class: 'modal-title' }, 'Sign Out'),
+          crel('h2', { class: 'modal-title' }, __('Sign Out')),
           crel('div',
-            crel('p', 'Are you sure you want to sign out?'),
+            crel('p', __('Are you sure you want to sign out?')),
             crel('div', { class: 'buttons' },
               crel('button', {
                 class: 'dangerous-button text-button',
                 onclick: () => self.doSignOut().then(() => modal.closeAll())
-              }, 'Yes'),
+              }, __('Yes')),
               crel('button', {
                 class: 'text-button',
                 onclick: () => modal.closeAll()
-              }, 'No')
+              }, __('No'))
             )
           )
         ));
@@ -191,7 +191,7 @@ const user = (function() {
       });
       socket.on('session_limit', function(data) {
         socket.close();
-        modal.showText('Too many sessions open, try closing some tabs.');
+        modal.showText(__('Too many sessions open, try closing some tabs.'));
       });
       socket.on('userinfo', function(data) {
         let isBanned = false;
@@ -214,7 +214,7 @@ const user = (function() {
         self.elements.userInfo.find('span#username').html(crel('a', {
           href: `/profile/${data.username}`,
           target: '_blank',
-          title: 'My Profile'
+          title: __('My Profile')
         }, data.username).outerHTML);
         if (data.method === 'ip') {
           self.elements.userInfo.hide();
@@ -224,10 +224,11 @@ const user = (function() {
 
         if (data.banExpiry === 0) {
           isBanned = true;
-          crel(banelem, crel('p', 'You are permanently banned.'));
+          crel(banelem, crel('p', __('You are permanently banned.')));
         } else if (data.banned === true) {
           isBanned = true;
-          crel(banelem, crel('p', `You are temporarily banned and will not be allowed to place until ${new Date(data.banExpiry).toLocaleString()}`));
+          const timestamp = new Date(data.banExpiry).toLocaleString();
+          crel(banelem, crel('p', __(`You are temporarily banned and will not be allowed to place until ${timestamp}`)));
         } else if (self.isStaff()) {
           if (window.deInitAdmin) {
             window.deInitAdmin();
@@ -245,14 +246,14 @@ const user = (function() {
           window.deInitAdmin();
         }
         if (isBanned) {
-          self.elements.userMessage.empty().show().text('You can contact us using one of the links in the info menu.').fadeIn(200);
+          self.elements.userMessage.empty().show().text(__('You can contact us using one of the links in the info menu.')).fadeIn(200);
           crel(banelem,
-            crel('p', 'If you think this was an error, please contact us using one of the links in the info tab.'),
-            crel('p', 'Ban reason:'),
+            crel('p', __('If you think this was an error, please contact us using one of the links in the info tab.')),
+            crel('p', __('Ban reason:')),
             crel('p', data.banReason)
           );
           modal.show(modal.buildDom(
-            crel('h2', 'Banned'),
+            crel('h2', __('Banned')),
             banelem
           ), { escapeClose: false, clickClose: false });
           if (window.deInitAdmin) {
@@ -305,7 +306,7 @@ const user = (function() {
         self.hideRenameRequest();
         modal.closeAll();
       }).fail(function(xhrObj) {
-        let resp = 'An unknown error occurred. Please contact staff on discord';
+        let resp = __('An unknown error occurred. Please contact staff on discord');
         if (xhrObj.responseJSON) {
           resp = xhrObj.responseJSON.details || resp;
         } else if (xhrObj.responseText) {
@@ -322,9 +323,9 @@ const user = (function() {
     },
     _handleRenameClick: function(event) {
       const renamePopup = crel('form', { onsubmit: self._handleRenameSubmit },
-        crel('p', 'Staff have required you to change your username, this usually means your name breaks one of our rules.'),
-        crel('p', 'If you disagree, please contact us on Discord (link in the info panel).'),
-        crel('label', 'New Username: ',
+        crel('p', __('Staff have required you to change your username, this usually means your name breaks one of our rules.')),
+        crel('p', __('If you disagree, please contact us on Discord (link in the info panel).')),
+        crel('label', __('New Username:') + ' ',
           crel('input', {
             type: 'text',
             class: 'rename-input',
@@ -337,23 +338,22 @@ const user = (function() {
           class: 'rename-error'
         }, ''),
         crel('div', { style: 'text-align: right' },
-          crel('button', { class: 'text-button', onclick: () => modal.closeAll() }, 'Not now'),
-          crel('button', { class: 'rename-submit text-button', type: 'submit' }, 'Change')
+          crel('button', { class: 'text-button', onclick: () => modal.closeAll() }, __('Not now')),
+          crel('button', { class: 'rename-submit text-button', type: 'submit' }, __('Change'))
         )
       );
       modal.show(modal.buildDom(
-        crel('h2', { class: 'modal-title' }, 'Rename Requested'),
+        crel('h2', { class: 'modal-title' }, __('Rename Requested')),
         renamePopup
       ));
     },
     showRenameRequest: () => {
       self.elements.userMessage.empty().show().append(
-        crel('span', 'You must change your username. Click ',
+        crel('span', __('You must change your username.') + ' ',
           crel('span', {
             style: 'cursor: pointer; text-decoration: underline;',
             onclick: self._handleRenameClick
-          }, 'here'),
-          document.createTextNode(' to continue.')
+          }, __('Click here to continue.'))
         )
       ).fadeIn(200);
     },

--- a/resources/public/pebble_templates/index.html
+++ b/resources/public/pebble_templates/index.html
@@ -749,7 +749,7 @@
     <div class="panel-body"></div>
 </aside>
 
-<script src="pxls.js"></script>
+<script src="pxls{{locale.getLanguage() == 'en' ? '' : '_' + locale.getLanguage()}}.js"></script>
 
 </body>
 </html>

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -18,6 +18,7 @@ let instaban = false;
 if (window.App !== undefined) {
   instaban = true;
 }
+window.__ = (translatableString) => translatableString;
 window.App = (function() {
   const { ls, ss } = require('./include/storage');
 
@@ -130,7 +131,7 @@ window.App = (function() {
       template.queueUpdate(t);
     },
     alert: function(s) {
-      modal.showText(s, { title: 'Alert', modalOpts: { closeExisting: false } });
+      modal.showText(s, { title: __('Alert'), modalOpts: { closeExisting: false } });
     },
     doPlace: function() {
       ban.me('call to doPlace()');


### PR DESCRIPTION
This adds to `generate-potfile.js` the ability to pull strings out of Javascript files for translation. This is done by calling a dummy function (`__()`) on all user-facing strings. It also adds functionality to the build pipeline to statically compile these translations back into script files, generating a different script file for each supported language. The correct script file will then be loaded based on the user's current browser locale.

There are libraries that exist which can do this, but this implementation is bespoke. I recognise that this is probably a terrible way of doing things, but it's the implementation that I knew would work and probably wouldn't be too hard to adapt into a more widely accepted pattern later.

