### PR TITLE
Fix inability to place after loading with no cooldown

### DIFF
--- a/resources/public/include/uiHelper.js
+++ b/resources/public/include/uiHelper.js
@@ -252,6 +252,8 @@ const uiHelper = (function() {
     },
     _initStack: function() {
       socket.on('pixels', function(data) {
+        timer.cooldown = (new Date()).getTime();
+        timer.update();
         self.updateAvailable(data.count, data.cause);
       });
     },


### PR DESCRIPTION
This implementation seems like a bit of a hack to me, but the whole way the timer operates is nightmare fuel and this should work. My principle concern is that `timer.cooldown` is probably *supposed* to be private data, but it is written to publicly here.

As an added bonus, this should kick the timer into updating immediately when a pixel is available rather than based on locally tracking the time. Funnily enough, this should make most of the timer code irrelevant (and quite a bit more reliable).

That said, I haven't tested this so it could be horribly broken, but it's not like testing the PR that introduced this bug seemed to help much anyway 🤷.