### PR TITLE
Improve chat ratelimit configurabilty

### DIFF
--- a/resources/reference.conf
+++ b/resources/reference.conf
@@ -230,6 +230,9 @@ chat {
       "[fas.fa-gavel.fa-is-left] Read the chat rules in the info panel.",
       "[fas.fa-question-circle.fa-is-left] Ensure you read the FAQ top left!"
     ]
+    // Relative time is appended to this string
+    // For example: Please wait a few seconds
+    ratelimitMessage: "Please wait "
 }
 
 userIdleTimeout: 30m

--- a/resources/roles-reference.conf
+++ b/resources/roles-reference.conf
@@ -85,6 +85,7 @@ staff {
     chat.history.purged
     chat.history.shadowbanned
     chat.usercolor.rainbow
+    chat.cooldown.ignore
     user.admin
     user.alert
     user.ratelimits.bypass

--- a/src/main/java/space/pxls/server/PacketHandler.java
+++ b/src/main/java/space/pxls/server/PacketHandler.java
@@ -450,7 +450,7 @@ public class PacketHandler {
             if (message.trim().length() == 0) return;
             if (user.isRenameRequested(false)) return;
             int remaining = RateLimitFactory.getTimeRemaining(DBChatMessage.class, String.valueOf(user.getId()));
-            if (remaining > 0) {
+            if (!user.hasPermission("chat.cooldown.ignore") && remaining > 0) {
                 server.send(user, new ServerChatCooldown(remaining, message));
                 return;
             }

--- a/src/main/java/space/pxls/server/WebHandler.java
+++ b/src/main/java/space/pxls/server/WebHandler.java
@@ -1802,7 +1802,8 @@ public class WebHandler {
             App.getConfig().getBoolean("chat.canvasBanRespected"),
             App.getConfig().getStringList("chat.bannerText"),
             App.getSnipMode(),
-            App.getConfig().getList("chat.customEmoji").unwrapped()
+            App.getConfig().getList("chat.customEmoji").unwrapped(),
+            App.getConfig().getString("chat.ratelimitMessage")
         )));
     }
 

--- a/src/main/java/space/pxls/server/packets/http/CanvasInfo.java
+++ b/src/main/java/space/pxls/server/packets/http/CanvasInfo.java
@@ -22,8 +22,9 @@ public class CanvasInfo {
     public List<String> chatBannerText;
     public Boolean snipMode;
     public List<Object> customEmoji;
+    public String chatRatelimitMessage;
 
-    public CanvasInfo(String canvasCode, Integer width, Integer height, List<Color> palette, String captchaKey, Integer heatmapCooldown, Integer maxStacked, Map<String, AuthService> authServices, Boolean registrationEnabled, Boolean chatEnabled, Integer chatCharacterLimit, boolean chatRespectsCanvasBan, List<String> chatBannerText, boolean snipMode, List<Object> customEmoji) {
+    public CanvasInfo(String canvasCode, Integer width, Integer height, List<Color> palette, String captchaKey, Integer heatmapCooldown, Integer maxStacked, Map<String, AuthService> authServices, Boolean registrationEnabled, Boolean chatEnabled, Integer chatCharacterLimit, boolean chatRespectsCanvasBan, List<String> chatBannerText, boolean snipMode, List<Object> customEmoji, String chatRatelimitMessage) {
         this.canvasCode = canvasCode;
         this.width = width;
         this.height = height;
@@ -39,6 +40,7 @@ public class CanvasInfo {
         this.chatBannerText = chatBannerText;
         this.snipMode = snipMode;
         this.customEmoji = customEmoji;
+        this.chatRatelimitMessage = chatRatelimitMessage;
     }
 
     public String getCanvasCode() {
@@ -99,5 +101,9 @@ public class CanvasInfo {
 
     public List<Object> getCustomEmoji() {
         return customEmoji;
+    }
+
+    public String getChatRatelimitMessage() {
+        return chatRatelimitMessage;
     }
 }


### PR DESCRIPTION
Adds a new permission for ignoring chat ratelimit.
Adds a new config option for the text shown to users who are waiting for chat cooldown. Default is "Please wait _".

This also changes how the ratelimit time is shown to users to use moment's [toNow](https://momentjs.com/docs/#/displaying/tonow/) function. This is a lot less precise but gives a better overall idea of how long to wait for longer wait times. The [preciserange](https://momentjs.com/docs/#/plugins/preciserange/) plugin would have been a better solution, but I don't think that's available in the current environment and I'd rather not set that up here.