### PR TITLE
Show the amount of stacked pixels in the document title

### DIFF
--- a/resources/public/include/timer.js
+++ b/resources/public/include/timer.js
@@ -17,6 +17,7 @@ module.exports.timer = (function() {
     runningTimer: false,
     audio: new Audio('notify.wav'),
     title: '',
+    currentTimer: '',
     cooledDown: function() {
       return self.cooldown < (new Date()).getTime();
     },
@@ -55,10 +56,11 @@ module.exports.timer = (function() {
         const secsStr = secs < 10 ? '0' + secs : secs;
         const minutes = Math.floor(delta / 60);
         const minuteStr = minutes < 10 ? '0' + minutes : minutes;
-        self.elements.timer_countdown.text(`${minuteStr}:${secsStr}`);
-        self.elements.timer_chat.text(`(${minuteStr}:${secsStr})`);
+        self.currentTimer = `${minuteStr}:${secsStr}`;
+        self.elements.timer_countdown.text(`${self.currentTimer}`);
+        self.elements.timer_chat.text(`(${self.currentTimer})`);
 
-        document.title = uiHelper.getTitle(`[${minuteStr}:${secsStr}]`);
+        document.title = uiHelper.getTitle();
 
         if (self.runningTimer && !die) {
           return;
@@ -71,6 +73,7 @@ module.exports.timer = (function() {
       }
 
       self.runningTimer = false;
+      self.currentTimer = '';
 
       document.title = uiHelper.getTitle();
       self.elements.timer_container.hide();
@@ -123,12 +126,16 @@ module.exports.timer = (function() {
       if (uiHelper.tabHasFocus() && settings.audio.enable.get()) {
         self.audio.play();
       }
+    },
+    getCurrentTimer: function() {
+      return self.currentTimer;
     }
   };
   return {
     init: self.init,
     cooledDown: self.cooledDown,
     playAudio: self.playAudio,
+    getCurrentTimer: self.getCurrentTimer,
     audioElem: self.audio
   };
 })();

--- a/resources/public/include/uiHelper.js
+++ b/resources/public/include/uiHelper.js
@@ -16,6 +16,7 @@ const uiHelper = (function() {
     tabId: null,
     _workerIsTabFocused: false,
     _available: -1,
+    pixelsAvailable: -1,
     maxStacked: -1,
     _alertUpdateTimer: false,
     initTitle: '',
@@ -479,6 +480,8 @@ const uiHelper = (function() {
     },
     setPlaceableText(placeable) {
       self.elements.stackCount.text(`${placeable}/${self.maxStacked}`);
+      self.pixelsAvailable = placeable;
+      document.title = uiHelper.getTitle();
     },
     setDiscordName(name) {
       self.elements.txtDiscordName.val(name);
@@ -622,7 +625,15 @@ const uiHelper = (function() {
       return self.initTitle;
     },
     getTitle: (prepend) => {
-      if (typeof prepend !== 'string') prepend = '';
+      if (typeof prepend !== 'string') {
+        if (self.pixelsAvailable > 0) {
+          prepend = `[${self.pixelsAvailable}/${self.maxStacked}]`;
+        } else if (self.pixelsAvailable === 0) {
+          prepend = `[${timer.getCurrentTimer()}]`;
+        } else {
+          prepend = '';
+        }
+      }
       const tplOpts = template.getOptions();
       let append = self.initTitle;
 


### PR DESCRIPTION
This works by creating two new variables: `pixelsAvailable` and `currentTimer` which are kept updated. That way, when `getTitle()` is called, it decides whether to prepend the timer or the stacks depending on the pixels available.

This also fixes a bug where the timer would disappear from the title for about 1 second if you disabled/enabled the template while on cooldown.

(This resolves #499).

![image](https://user-images.githubusercontent.com/86915824/138095593-42f587d3-81a2-4e57-9331-9f64855f0bbe.png)
