### PR TITLE
Fix template rendering above overlays regardless of preference

### DIFF
--- a/resources/public/include/overlays.js
+++ b/resources/public/include/overlays.js
@@ -87,7 +87,7 @@ module.exports.overlays = (function() {
       }
     };
 
-    $('#board-mover').prepend(self.elements.overlay);
+    $('#board').before(self.elements.overlay);
 
     return {
       get name() {


### PR DESCRIPTION
The "Layer template underneath heatmap" preference was broken because of this. The WebGL templates update must have changed the order in which things were added to the DOM. This changes it so that the overlays and template will always be added in a way that they end up in the correct order regardless of which order they are added.