### PR TITLE
Prevent template redraw when unrequired

### DIFF
--- a/resources/public/include/template.js
+++ b/resources/public/include/template.js
@@ -232,9 +232,11 @@ module.exports.template = (function() {
         });
       }
 
-      self.elements.styleImage.attr({
-        src: self.cors(self.options.style)
-      });
+      if (self.elements.styleImage.prop('src') !== self.options.style) {
+        self.elements.styleImage.attr({
+          src: self.cors(self.options.style)
+        });
+      }
 
       self.applyOptions();
 


### PR DESCRIPTION
Setting the `src` attribute when moving the template was triggering the style load event, which caused a template re-raster. This doesn't need to happen, and so not doing so is better.