### PR TITLE
Fix heatmap and virginmap rendering out of order

### DIFF
--- a/resources/public/include/overlays.js
+++ b/resources/public/include/overlays.js
@@ -161,6 +161,47 @@ module.exports.overlays = (function() {
         return imageData;
       }
 
+      // virginmap stuff
+      const virginbackground = self.add('virginbackground', () => createOverlayImageData('/virginmap', '/placemap', 0x0000FF00, 0x00));
+      const virginmap = self.add('virginmap', () => createOverlayImageData('/virginmap', '/placemap', 0x00000000, 0xff), (width, height, isReload) => {
+        if (isReload) {
+          return;
+        }
+        socket.on('pixel', (data) => {
+          $.map(data.pixels, (px) => {
+            virginmap.setPixel(px.x, px.y, '#000000');
+          });
+        });
+
+        $(window).keydown(function(evt) {
+          if (['INPUT', 'TEXTAREA'].includes(evt.target.nodeName)) {
+            // prevent inputs from triggering shortcuts
+            return;
+          }
+
+          if (evt.key === 'u' || evt.key === 'U' || evt.which === 117 || evt.which === 85) { // U key
+            virginmap.clear();
+          }
+        });
+      });
+
+      settings.board.virginmap.opacity.listen(function(value) {
+        virginbackground.setOpacity(value);
+      });
+      $('#vmapClear').click(function() {
+        virginmap.clear();
+      });
+
+      settings.board.virginmap.enable.listen(function(value) {
+        if (value) {
+          virginmap.show();
+          virginbackground.show();
+        } else {
+          virginmap.hide();
+          virginbackground.hide();
+        }
+      });
+
       // heatmap stuff
       const heatbackground = self.add('heatbackground', () => createOverlayImageData('/heatmap', '/placemap', 0xFF000000));
       const heatmap = self.add('heatmap', () => createOverlayImageData('/heatmap', '/placemap', 0x005C5CCD), (width, height, isReload) => {
@@ -239,47 +280,6 @@ module.exports.overlays = (function() {
       $(window).keyup(function(e) {
         if (testForH(e)) {
           HKeyPressed = false;
-        }
-      });
-
-      // virginmap stuff
-      const virginbackground = self.add('virginbackground', () => createOverlayImageData('/virginmap', '/placemap', 0x0000FF00, 0x00));
-      const virginmap = self.add('virginmap', () => createOverlayImageData('/virginmap', '/placemap', 0x00000000, 0xff), (width, height, isReload) => {
-        if (isReload) {
-          return;
-        }
-        socket.on('pixel', (data) => {
-          $.map(data.pixels, (px) => {
-            virginmap.setPixel(px.x, px.y, '#000000');
-          });
-        });
-
-        $(window).keydown(function(evt) {
-          if (['INPUT', 'TEXTAREA'].includes(evt.target.nodeName)) {
-            // prevent inputs from triggering shortcuts
-            return;
-          }
-
-          if (evt.key === 'u' || evt.key === 'U' || evt.which === 117 || evt.which === 85) { // U key
-            virginmap.clear();
-          }
-        });
-      });
-
-      settings.board.virginmap.opacity.listen(function(value) {
-        virginbackground.setOpacity(value);
-      });
-      $('#vmapClear').click(function() {
-        virginmap.clear();
-      });
-
-      settings.board.virginmap.enable.listen(function(value) {
-        if (value) {
-          virginmap.show();
-          virginbackground.show();
-        } else {
-          virginmap.hide();
-          virginbackground.hide();
         }
       });
 

--- a/resources/public/include/overlays.js
+++ b/resources/public/include/overlays.js
@@ -162,6 +162,7 @@ module.exports.overlays = (function() {
       }
 
       // heatmap stuff
+      const heatbackground = self.add('heatbackground', () => createOverlayImageData('/heatmap', '/placemap', 0xFF000000));
       const heatmap = self.add('heatmap', () => createOverlayImageData('/heatmap', '/placemap', 0x005C5CCD), (width, height, isReload) => {
         // Ran when lazy init finshes
         if (isReload) {
@@ -197,8 +198,6 @@ module.exports.overlays = (function() {
           }
         });
       });
-
-      const heatbackground = self.add('heatbackground', () => createOverlayImageData('/heatmap', '/placemap', 0xFF000000));
 
       settings.board.heatmap.opacity.listen(function(value) {
         heatbackground.setOpacity(value);
@@ -244,6 +243,7 @@ module.exports.overlays = (function() {
       });
 
       // virginmap stuff
+      const virginbackground = self.add('virginbackground', () => createOverlayImageData('/virginmap', '/placemap', 0x0000FF00, 0x00));
       const virginmap = self.add('virginmap', () => createOverlayImageData('/virginmap', '/placemap', 0x00000000, 0xff), (width, height, isReload) => {
         if (isReload) {
           return;
@@ -265,8 +265,6 @@ module.exports.overlays = (function() {
           }
         });
       });
-
-      const virginbackground = self.add('virginbackground', () => createOverlayImageData('/virginmap', '/placemap', 0x0000FF00, 0x00));
 
       settings.board.virginmap.opacity.listen(function(value) {
         virginbackground.setOpacity(value);


### PR DESCRIPTION
Since #530 reversed the order overlays were added to the DOM, they were rendering out of order. There are two parts to this:
- Each overlay's background was rendering in front of it's foreground.
- The order of the overlays was revesed with respect to eachother (the virginmap was rendering on the heatmap while previously it was the other way around)

This undoes both of these changes.
