### PR TITLE
Remove line number and position from localization

### DIFF
--- a/generate-potfile.js
+++ b/generate-potfile.js
@@ -122,7 +122,10 @@ for (const path of PEBBLE_FILES) {
       const item = itemsById.get(id);
 
       item.msgid = id;
-      item.references.push(`${path}:${callLine + 1}:${callLocalOffset + 1}`);
+      // NOTE ([  ]): linenumber and position are cool to have, but they cause
+      // too much noise in localization updates.
+      // item.references.push(`${path}:${callLine + 1}:${callLocalOffset + 1}`);
+      item.references.push(path);
 
       if (commentsByLine.has(callLine - 1)) {
         item.extractedComments.push(...commentsByLine.get(callLine - 1));
@@ -227,7 +230,9 @@ for (const path of JS_FILES) {
     const item = jsItemsById.get(id);
 
     item.msgid = id;
-    item.references.push(`${path}:${callLine + 1}:${callLocalOffset + 1}`);
+    // see note on html reference extraction.
+    // item.references.push(`${path}:${callLine + 1}:${callLocalOffset + 1}`);
+    item.references.push(path);
 
     for (const comment of relevantComments) {
       item.extractedComments.push(comment);

--- a/po/Localization.po
+++ b/po/Localization.po
@@ -1,2245 +1,2176 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Pxls\n"
-"POT-Creation-Date: 2021-11-23T21:32:45.968Z\n"
+"POT-Creation-Date: 2021-12-03T07:36:36.932Z\n"
 "Language: en\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 
 #. Site description
-#: resources/public/pebble_templates/index.html:8:42
+#: resources/public/pebble_templates/index.html
 msgid "Place pixels with people to create art"
 msgstr "Place pixels with people to create art"
 
-#: resources/public/pebble_templates/index.html:56:27
+#: resources/public/pebble_templates/index.html
 msgid "Lost connection to server, reconnecting..."
 msgstr "Lost connection to server, reconnecting..."
 
-#: resources/public/pebble_templates/index.html:71:76
+#: resources/public/pebble_templates/index.html
 msgid "Loading Heatmap (press <kbd>H</kbd> to cancel)"
 msgstr "Loading Heatmap (press <kbd>H</kbd> to cancel)"
 
-#: resources/public/pebble_templates/index.html:72:78
+#: resources/public/pebble_templates/index.html
 msgid "Loading Virginmap (press <kbd>X</kbd> to cancel)"
 msgstr "Loading Virginmap (press <kbd>X</kbd> to cancel)"
 
-#: resources/public/pebble_templates/index.html:80:67
+#: resources/public/pebble_templates/index.html
 msgid "Logout"
 msgstr "Logout"
 
 #. Canvas pixel count
-#: resources/public/pebble_templates/index.html:86:38
+#: resources/public/pebble_templates/index.html
 msgid "Canvas:"
 msgstr "Canvas:"
 
 #. Canvas pixel count
 #. All time pixel count
-#: resources/public/pebble_templates/index.html:86:118
-#: resources/public/pebble_templates/index.html:88:120
-#: resources/public/pebble_templates/index.html:100:51
-#: resources/public/pebble_templates/index.html:126:123
+#: resources/public/pebble_templates/index.html
 msgid "N/A"
 msgstr "N/A"
 
 #. All time pixel count
-#: resources/public/pebble_templates/index.html:88:38
+#: resources/public/pebble_templates/index.html
 msgid "All Time:"
 msgstr "All Time:"
 
-#: resources/public/pebble_templates/index.html:93:48
+#: resources/public/pebble_templates/index.html
 msgid "Loading online user count&hellip;"
 msgstr "Loading online user count&hellip;"
 
-#: resources/public/pebble_templates/index.html:101:30
-#: resources/public/include/lookup.js:276:21
-#: resources/public/admin/admin.js:199:16
+#: resources/public/pebble_templates/index.html
+#: resources/public/include/lookup.js resources/public/admin/admin.js
 msgid "Pixels"
 msgstr "Pixels"
 
-#: resources/public/pebble_templates/index.html:112:54
+#: resources/public/pebble_templates/index.html
 msgid "Undo"
 msgstr "Undo"
 
-#: resources/public/pebble_templates/index.html:114:20
+#: resources/public/pebble_templates/index.html
 msgid "You are not signed in.&nbsp;<a href=\"#\">Sign in with...</a>"
 msgstr "You are not signed in.&nbsp;<a href=\"#\">Sign in with...</a>"
 
-#: resources/public/pebble_templates/index.html:124:28
+#: resources/public/pebble_templates/index.html
 msgid "Loading..."
 msgstr "Loading..."
 
-#: resources/public/pebble_templates/index.html:132:14
-#: resources/public/pebble_templates/index.html:142:67
+#: resources/public/pebble_templates/index.html
 msgid "Sign up"
 msgstr "Sign up"
 
-#: resources/public/pebble_templates/index.html:133:14
+#: resources/public/pebble_templates/index.html
 msgid "Pick a username"
 msgstr "Pick a username"
 
-#: resources/public/pebble_templates/index.html:136:43
+#: resources/public/pebble_templates/index.html
 msgid "Username:"
 msgstr "Username:"
 
-#: resources/public/pebble_templates/index.html:154:65
-#: resources/public/pebble_templates/profile.html:56:96
+#: resources/public/pebble_templates/index.html
+#: resources/public/pebble_templates/profile.html
 msgid "Info"
 msgstr "Info"
 
-#: resources/public/pebble_templates/index.html:168:66
-#: resources/public/pebble_templates/index.html:206:66
-#: resources/public/pebble_templates/index.html:761:66
-#: resources/public/pebble_templates/index.html:774:66
+#: resources/public/pebble_templates/index.html
 msgid "Close Panel"
 msgstr "Close Panel"
 
-#: resources/public/pebble_templates/index.html:170:61
+#: resources/public/pebble_templates/index.html
 msgid "Chat"
 msgstr "Chat"
 
-#: resources/public/pebble_templates/index.html:172:45
+#: resources/public/pebble_templates/index.html
 msgid "Pings"
 msgstr "Pings"
 
-#: resources/public/pebble_templates/index.html:173:45
-#: resources/public/pebble_templates/index.html:209:58
+#: resources/public/pebble_templates/index.html
 msgid "Settings"
 msgstr "Settings"
 
-#: resources/public/pebble_templates/index.html:186:30
+#: resources/public/pebble_templates/index.html
 msgid "Jump To Bottom"
 msgstr "Jump To Bottom"
 
 #. Open emoji picker
-#: resources/public/pebble_templates/index.html:194:49
+#: resources/public/pebble_templates/index.html
 msgid "Emoji"
 msgstr "Emoji"
 
-#: resources/public/pebble_templates/index.html:214:73
+#: resources/public/pebble_templates/index.html
 msgid "Search"
 msgstr "Search"
 
-#: resources/public/pebble_templates/index.html:215:56
+#: resources/public/pebble_templates/index.html
 msgid "keybinds;keys;keyboard;hotkeys"
 msgstr "keybinds;keys;keyboard;hotkeys"
 
-#: resources/public/pebble_templates/index.html:217:24
+#: resources/public/pebble_templates/index.html
 msgid "Keybinds"
 msgstr "Keybinds"
 
-#: resources/public/pebble_templates/index.html:220:44
+#: resources/public/pebble_templates/index.html
 msgid "general"
 msgstr "general"
 
 #. General settings
-#: resources/public/pebble_templates/index.html:222:28
-#: resources/public/pebble_templates/index.html:664:28
+#: resources/public/pebble_templates/index.html
 msgid "General"
 msgstr "General"
 
-#: resources/public/pebble_templates/index.html:223:42
+#: resources/public/pebble_templates/index.html
 msgid "move;moving;panning;drag"
 msgstr "move;moving;panning;drag"
 
-#: resources/public/pebble_templates/index.html:223:102
+#: resources/public/pebble_templates/index.html
 msgid "Mouse/arrows/wasd to pan"
 msgstr "Mouse/arrows/wasd to pan"
 
-#: resources/public/pebble_templates/index.html:224:42
+#: resources/public/pebble_templates/index.html
 msgid "mousewheel;zooming"
 msgstr "mousewheel;zooming"
 
-#: resources/public/pebble_templates/index.html:224:96
+#: resources/public/pebble_templates/index.html
 msgid "Scroll/pinch to zoom"
 msgstr "Scroll/pinch to zoom"
 
-#: resources/public/pebble_templates/index.html:225:42
+#: resources/public/pebble_templates/index.html
 msgid "scroll;zooming"
 msgstr "scroll;zooming"
 
-#: resources/public/pebble_templates/index.html:225:92
+#: resources/public/pebble_templates/index.html
 msgid "<kbd>+</kbd>/<kbd>-</kbd> or <kbd>Q</kbd>/<kbd>E</kbd> to zoom"
 msgstr "<kbd>+</kbd>/<kbd>-</kbd> or <kbd>Q</kbd>/<kbd>E</kbd> to zoom"
 
-#: resources/public/pebble_templates/index.html:226:42
+#: resources/public/pebble_templates/index.html
 msgid "lookups"
 msgstr "lookups"
 
-#: resources/public/pebble_templates/index.html:226:85
+#: resources/public/pebble_templates/index.html
 msgid "<kbd>Shift</kbd> + Click/Hold touch to lookup pixel"
 msgstr "<kbd>Shift</kbd> + Click/Hold touch to lookup pixel"
 
-#: resources/public/pebble_templates/index.html:227:42
-#: resources/public/pebble_templates/index.html:489:44
+#: resources/public/pebble_templates/index.html
 msgid "overlays;alignment;grid hidden;grid shown;hide grid;show grid"
 msgstr "overlays;alignment;grid hidden;grid shown;hide grid;show grid"
 
-#: resources/public/pebble_templates/index.html:227:139
+#: resources/public/pebble_templates/index.html
 msgid "<kbd>G</kbd> to toggle grid"
 msgstr "<kbd>G</kbd> to toggle grid"
 
-#: resources/public/pebble_templates/index.html:228:42
+#: resources/public/pebble_templates/index.html
 msgid "close;information shown;information hidden;info shown;info hidden;hide information;show information"
 msgstr "close;information shown;information hidden;info shown;info hidden;hide information;show information"
 
-#: resources/public/pebble_templates/index.html:228:177
+#: resources/public/pebble_templates/index.html
 msgid "<kbd>I</kbd> to open info"
 msgstr "<kbd>I</kbd> to open info"
 
-#: resources/public/pebble_templates/index.html:229:42
+#: resources/public/pebble_templates/index.html
 msgid "close;settings hidden;settings shown;hide settings;show settings"
 msgstr "close;settings hidden;settings shown;hide settings;show settings"
 
-#: resources/public/pebble_templates/index.html:229:142
+#: resources/public/pebble_templates/index.html
 msgid "<kbd>T</kbd> to open settings"
 msgstr "<kbd>T</kbd> to open settings"
 
-#: resources/public/pebble_templates/index.html:230:42
+#: resources/public/pebble_templates/index.html
 msgid "close;chat hidden;chat shown;hide chat;show chat"
 msgstr "close;chat hidden;chat shown;hide chat;show chat"
 
-#: resources/public/pebble_templates/index.html:230:126
+#: resources/public/pebble_templates/index.html
 msgid "<kbd>B</kbd> to open chat"
 msgstr "<kbd>B</kbd> to open chat"
 
-#: resources/public/pebble_templates/index.html:231:42
+#: resources/public/pebble_templates/index.html
 msgid "canvas locked;move;moving;zoom;zooming"
 msgstr "canvas locked;move;moving;zoom;zooming"
 
-#: resources/public/pebble_templates/index.html:231:116
+#: resources/public/pebble_templates/index.html
 msgid "<kbd>L</kbd> to toggle locking panning of the canvas"
 msgstr "<kbd>L</kbd> to toggle locking panning of the canvas"
 
-#: resources/public/pebble_templates/index.html:232:42
+#: resources/public/pebble_templates/index.html
 msgid "take screenshot;image;download;picture;canvas"
 msgstr "take screenshot;image;download;picture;canvas"
 
-#: resources/public/pebble_templates/index.html:232:123
+#: resources/public/pebble_templates/index.html
 msgid "<kbd>P</kbd> to take a snapshot"
 msgstr "<kbd>P</kbd> to take a snapshot"
 
-#: resources/public/pebble_templates/index.html:233:42
-#: resources/public/pebble_templates/index.html:443:44
+#: resources/public/pebble_templates/index.html
 msgid "overlays;user activity;pixels placed pixels;heatmap hidden;heatmap shown;hide heatmap;show heatmap"
 msgstr "overlays;user activity;pixels placed pixels;heatmap hidden;heatmap shown;hide heatmap;show heatmap"
 
-#: resources/public/pebble_templates/index.html:233:176
+#: resources/public/pebble_templates/index.html
 msgid "<kbd>H</kbd> to toggle heatmap"
 msgstr "<kbd>H</kbd> to toggle heatmap"
 
-#: resources/public/pebble_templates/index.html:234:42
-#: resources/public/pebble_templates/index.html:463:44
+#: resources/public/pebble_templates/index.html
 msgid "overlays;user activity;pixels unplaced pixels;virginmap hidden;virginmap shown;hide virginmap;show virginmap"
 msgstr "overlays;user activity;pixels unplaced pixels;virginmap hidden;virginmap shown;hide virginmap;show virginmap"
 
-#: resources/public/pebble_templates/index.html:234:186
+#: resources/public/pebble_templates/index.html
 msgid "<kbd>X</kbd> to toggle virginmap"
 msgstr "<kbd>X</kbd> to toggle virginmap"
 
-#: resources/public/pebble_templates/index.html:235:42
+#: resources/public/pebble_templates/index.html
 msgid "overlays;user activity;pixels placed pixels;wipe;clean;"
 msgstr "overlays;user activity;pixels placed pixels;wipe;clean;"
 
-#: resources/public/pebble_templates/index.html:235:133
+#: resources/public/pebble_templates/index.html
 msgid "<kbd>O</kbd> to clear heatmap"
 msgstr "<kbd>O</kbd> to clear heatmap"
 
-#: resources/public/pebble_templates/index.html:236:42
+#: resources/public/pebble_templates/index.html
 msgid "overlays;user activity;pixels unplaced pixels;wipe;clean;"
 msgstr "overlays;user activity;pixels unplaced pixels;wipe;clean;"
 
-#: resources/public/pebble_templates/index.html:236:135
+#: resources/public/pebble_templates/index.html
 msgid "<kbd>U</kbd> to clear virginmap"
 msgstr "<kbd>U</kbd> to clear virginmap"
 
-#: resources/public/pebble_templates/index.html:237:42
+#: resources/public/pebble_templates/index.html
 msgid "next color;previous color"
 msgstr "next color;previous color"
 
-#: resources/public/pebble_templates/index.html:237:103
+#: resources/public/pebble_templates/index.html
 msgid "<kbd>J</kbd>/<kbd>K</kbd> to cycle through palette colors"
 msgstr "<kbd>J</kbd>/<kbd>K</kbd> to cycle through palette colors"
 
-#: resources/public/pebble_templates/index.html:238:42
+#: resources/public/pebble_templates/index.html
 msgid "current coordinates;coords"
 msgstr "current coordinates;coords"
 
-#: resources/public/pebble_templates/index.html:238:104
+#: resources/public/pebble_templates/index.html
 msgid "<kbd>C</kbd> to copy link of moused-over coordinates"
 msgstr "<kbd>C</kbd> to copy link of moused-over coordinates"
 
-#: resources/public/pebble_templates/index.html:239:42
+#: resources/public/pebble_templates/index.html
 msgid "cancel selection"
 msgstr "cancel selection"
 
-#: resources/public/pebble_templates/index.html:239:94
+#: resources/public/pebble_templates/index.html
 msgid "<kbd>ESC</kbd> to deselect current pixel"
 msgstr "<kbd>ESC</kbd> to deselect current pixel"
 
-#: resources/public/pebble_templates/index.html:240:42
+#: resources/public/pebble_templates/index.html
 msgid "recenter;jump;center on template;guides;focus"
 msgstr "recenter;jump;center on template;guides;focus"
 
-#: resources/public/pebble_templates/index.html:240:123
+#: resources/public/pebble_templates/index.html
 msgid "<kbd>R</kbd> to center the board on the current template"
 msgstr "<kbd>R</kbd> to center the board on the current template"
 
-#: resources/public/pebble_templates/index.html:243:44
+#: resources/public/pebble_templates/index.html
 msgid "templates;guides"
 msgstr "templates;guides"
 
-#: resources/public/pebble_templates/index.html:244:28
-#: resources/public/pebble_templates/index.html:579:24
+#: resources/public/pebble_templates/index.html
 msgid "Template"
 msgstr "Template"
 
-#: resources/public/pebble_templates/index.html:245:42
-#: resources/public/pebble_templates/index.html:246:42
+#: resources/public/pebble_templates/index.html
 msgid "transparency"
 msgstr "transparency"
 
-#: resources/public/pebble_templates/index.html:245:90
+#: resources/public/pebble_templates/index.html
 msgid "<kbd>Page Up</kbd> to increase opacity"
 msgstr "<kbd>Page Up</kbd> to increase opacity"
 
-#: resources/public/pebble_templates/index.html:246:90
+#: resources/public/pebble_templates/index.html
 msgid "<kbd>Page Down</kbd> to decrease opacity"
 msgstr "<kbd>Page Down</kbd> to decrease opacity"
 
-#: resources/public/pebble_templates/index.html:247:42
+#: resources/public/pebble_templates/index.html
 msgid "hidden;shown;hide;show"
 msgstr "hidden;shown;hide;show"
 
-#: resources/public/pebble_templates/index.html:247:100
+#: resources/public/pebble_templates/index.html
 msgid "<kbd>V</kbd> to toggle visibility"
 msgstr "<kbd>V</kbd> to toggle visibility"
 
-#: resources/public/pebble_templates/index.html:252:24
+#: resources/public/pebble_templates/index.html
 msgid "Note: These values are based on QWERTY keyboards. For other layouts, use the keys corresponding to the same position on a QWERTY keyboard."
 msgstr "Note: These values are based on QWERTY keyboards. For other layouts, use the keys corresponding to the same position on a QWERTY keyboard."
 
-#: resources/public/pebble_templates/index.html:256:36
+#: resources/public/pebble_templates/index.html
 msgid "ui;interface"
 msgstr "ui;interface"
 
-#: resources/public/pebble_templates/index.html:258:24
+#: resources/public/pebble_templates/index.html
 msgid "UI Settings"
 msgstr "UI Settings"
 
-#: resources/public/pebble_templates/index.html:262:44
+#: resources/public/pebble_templates/index.html
 msgid "themes;look;stylesheets;visuals"
 msgstr "themes;look;stylesheets;visuals"
 
-#: resources/public/pebble_templates/index.html:264:57
+#: resources/public/pebble_templates/index.html
 msgid "Theme:"
 msgstr "Theme:"
 
-#: resources/public/pebble_templates/index.html:266:64
+#: resources/public/pebble_templates/index.html
 msgid "Default"
 msgstr "Default"
 
-#: resources/public/pebble_templates/index.html:270:44
+#: resources/public/pebble_templates/index.html
 msgid "hide reticule;hide reticle;reticule shown reticle shown;reticule hidden;reticle hidden"
 msgstr "hide reticule;hide reticle;reticule shown reticle shown;reticule hidden;reticle hidden"
 
-#: resources/public/pebble_templates/index.html:273:57
+#: resources/public/pebble_templates/index.html
 msgid "Show reticule"
 msgstr "Show reticule"
 
-#: resources/public/pebble_templates/index.html:276:44
+#: resources/public/pebble_templates/index.html
 msgid "hide cursor;cursor shown;cursor hidden"
 msgstr "hide cursor;cursor shown;cursor hidden"
 
-#: resources/public/pebble_templates/index.html:279:57
+#: resources/public/pebble_templates/index.html
 msgid "Show cursor"
 msgstr "Show cursor"
 
-#: resources/public/pebble_templates/index.html:282:44
+#: resources/public/pebble_templates/index.html
 msgid "darkness filter"
 msgstr "darkness filter"
 
-#: resources/public/pebble_templates/index.html:285:57
+#: resources/public/pebble_templates/index.html
 msgid "Enable color brightness"
 msgstr "Enable color brightness"
 
-#: resources/public/pebble_templates/index.html:288:76
+#: resources/public/pebble_templates/index.html
 msgid "Warning: Known to cause fuzziness in Chrome on some Mac/Linux installs"
 msgstr "Warning: Known to cause fuzziness in Chrome on some Mac/Linux installs"
 
-#: resources/public/pebble_templates/index.html:291:57
+#: resources/public/pebble_templates/index.html
 msgid "Color brightness:"
 msgstr "Color brightness:"
 
-#: resources/public/pebble_templates/index.html:295:44
+#: resources/public/pebble_templates/index.html
 msgid "keep current selected;keep curent color;place"
 msgstr "keep current selected;keep curent color;place"
 
-#: resources/public/pebble_templates/index.html:298:57
+#: resources/public/pebble_templates/index.html
 msgid "Deselect color after placing"
 msgstr "Deselect color after placing"
 
-#: resources/public/pebble_templates/index.html:301:44
+#: resources/public/pebble_templates/index.html
 msgid "mousewheel;palette scrolling"
 msgstr "mousewheel;palette scrolling"
 
-#: resources/public/pebble_templates/index.html:304:57
+#: resources/public/pebble_templates/index.html
 msgid "Enable scrolling on the palette to switch colors"
 msgstr "Enable scrolling on the palette to switch colors"
 
-#: resources/public/pebble_templates/index.html:306:68
+#: resources/public/pebble_templates/index.html
 msgid "reverse scrolling;mousewheel;palette scrolling;enable scrolling on the palette to switch colors"
 msgstr "reverse scrolling;mousewheel;palette scrolling;enable scrolling on the palette to switch colors"
 
-#: resources/public/pebble_templates/index.html:309:61
+#: resources/public/pebble_templates/index.html
 msgid "Invert scroll direction"
 msgstr "Invert scroll direction"
 
-#: resources/public/pebble_templates/index.html:313:44
+#: resources/public/pebble_templates/index.html
 msgid "indexed colors;palette indicies"
 msgstr "indexed colors;palette indicies"
 
-#: resources/public/pebble_templates/index.html:316:57
+#: resources/public/pebble_templates/index.html
 msgid "Add numbers to palette entries"
 msgstr "Add numbers to palette entries"
 
-#: resources/public/pebble_templates/index.html:319:44
+#: resources/public/pebble_templates/index.html
 msgid "scrollbar;palette scrolling"
 msgstr "scrollbar;palette scrolling"
 
-#: resources/public/pebble_templates/index.html:322:57
+#: resources/public/pebble_templates/index.html
 msgid "Enable thin scrollbar"
 msgstr "Enable thin scrollbar"
 
-#: resources/public/pebble_templates/index.html:325:44
+#: resources/public/pebble_templates/index.html
 msgid "scrollbar;palette scrolling;palette stack"
 msgstr "scrollbar;palette scrolling;palette stack"
 
-#: resources/public/pebble_templates/index.html:328:57
+#: resources/public/pebble_templates/index.html
 msgid "Enable palette stacking"
 msgstr "Enable palette stacking"
 
-#: resources/public/pebble_templates/index.html:331:44
+#: resources/public/pebble_templates/index.html
 msgid "floating bubble location"
 msgstr "floating bubble location"
 
-#: resources/public/pebble_templates/index.html:333:57
+#: resources/public/pebble_templates/index.html
 msgid "Bubble position:"
 msgstr "Bubble position:"
 
-#: resources/public/pebble_templates/index.html:335:61
+#: resources/public/pebble_templates/index.html
 msgid "Top left"
 msgstr "Top left"
 
-#: resources/public/pebble_templates/index.html:336:62
+#: resources/public/pebble_templates/index.html
 msgid "Top right"
 msgstr "Top right"
 
-#: resources/public/pebble_templates/index.html:337:73
+#: resources/public/pebble_templates/index.html
 msgid "Bottom left"
 msgstr "Bottom left"
 
-#: resources/public/pebble_templates/index.html:338:65
+#: resources/public/pebble_templates/index.html
 msgid "Bottom right"
 msgstr "Bottom right"
 
-#: resources/public/pebble_templates/index.html:342:44
+#: resources/public/pebble_templates/index.html
 msgid "broken;offset workaround"
 msgstr "broken;offset workaround"
 
-#: resources/public/pebble_templates/index.html:345:57
+#: resources/public/pebble_templates/index.html
 msgid "Attempt to fix canvas displacement bug in Chrome 78+"
 msgstr "Attempt to fix canvas displacement bug in Chrome 78+"
 
-#: resources/public/pebble_templates/index.html:351:36
+#: resources/public/pebble_templates/index.html
 msgid "chat;message;ping sound"
 msgstr "chat;message;ping sound"
 
-#: resources/public/pebble_templates/index.html:353:24
+#: resources/public/pebble_templates/index.html
 msgid "Chat Settings"
 msgstr "Chat Settings"
 
-#: resources/public/pebble_templates/index.html:356:44
+#: resources/public/pebble_templates/index.html
 msgid "username;color;colour"
 msgstr "username;color;colour"
 
-#: resources/public/pebble_templates/index.html:359:57
+#: resources/public/pebble_templates/index.html
 msgid "Username Color:"
 msgstr "Username Color:"
 
-#: resources/public/pebble_templates/index.html:365:44
+#: resources/public/pebble_templates/index.html
 msgid "chat message;chat ui"
 msgstr "chat message;chat ui"
 
-#: resources/public/pebble_templates/index.html:366:28
+#: resources/public/pebble_templates/index.html
 msgid "Interface"
 msgstr "Interface"
 
-#: resources/public/pebble_templates/index.html:367:44
+#: resources/public/pebble_templates/index.html
 msgid "chat size;chat font"
 msgstr "chat size;chat font"
 
-#: resources/public/pebble_templates/index.html:369:57
+#: resources/public/pebble_templates/index.html
 msgid "Font Size:"
 msgstr "Font Size:"
 
-#: resources/public/pebble_templates/index.html:373:44
+#: resources/public/pebble_templates/index.html
 msgid "time;timestamps"
 msgstr "time;timestamps"
 
-#: resources/public/pebble_templates/index.html:376:57
+#: resources/public/pebble_templates/index.html
 msgid "24 Hour Timestamps"
 msgstr "24 Hour Timestamps"
 
-#: resources/public/pebble_templates/index.html:379:44
+#: resources/public/pebble_templates/index.html
 msgid "badges;pixel count;pixels placed"
 msgstr "badges;pixel count;pixels placed"
 
-#: resources/public/pebble_templates/index.html:382:57
+#: resources/public/pebble_templates/index.html
 msgid "Show pixel-placed badges"
 msgstr "Show pixel-placed badges"
 
-#: resources/public/pebble_templates/index.html:385:44
+#: resources/public/pebble_templates/index.html
 msgid "badges;factions"
 msgstr "badges;factions"
 
-#: resources/public/pebble_templates/index.html:388:57
+#: resources/public/pebble_templates/index.html
 msgid "Show faction tags"
 msgstr "Show faction tags"
 
-#: resources/public/pebble_templates/index.html:391:44
+#: resources/public/pebble_templates/index.html
 msgid "template urls;template links;template name"
 msgstr "template urls;template links;template name"
 
-#: resources/public/pebble_templates/index.html:394:57
+#: resources/public/pebble_templates/index.html
 msgid "Replace template titles with URLs in chat where applicable"
 msgstr "Replace template titles with URLs in chat where applicable"
 
-#: resources/public/pebble_templates/index.html:397:44
+#: resources/public/pebble_templates/index.html
 msgid "chat orientation;chat position"
 msgstr "chat orientation;chat position"
 
-#: resources/public/pebble_templates/index.html:400:57
+#: resources/public/pebble_templates/index.html
 msgid "Enable horizontal chat"
 msgstr "Enable horizontal chat"
 
-#: resources/public/pebble_templates/index.html:403:44
+#: resources/public/pebble_templates/index.html
 msgid "banner;animation"
 msgstr "banner;animation"
 
-#: resources/public/pebble_templates/index.html:406:57
+#: resources/public/pebble_templates/index.html
 msgid "Enable the rotating banner under chat"
 msgstr "Enable the rotating banner under chat"
 
-#: resources/public/pebble_templates/index.html:409:44
+#: resources/public/pebble_templates/index.html
 msgid "max;messages;truncate"
 msgstr "max;messages;truncate"
 
-#: resources/public/pebble_templates/index.html:411:57
+#: resources/public/pebble_templates/index.html
 msgid "Maximum amount of chat messages:"
 msgstr "Maximum amount of chat messages:"
 
-#: resources/public/pebble_templates/index.html:415:44
+#: resources/public/pebble_templates/index.html
 msgid "link;url;behaviour"
 msgstr "link;url;behaviour"
 
-#: resources/public/pebble_templates/index.html:417:57
+#: resources/public/pebble_templates/index.html
 msgid "Default internal link action click:"
 msgstr "Default internal link action click:"
 
-#: resources/public/pebble_templates/index.html:422:44
+#: resources/public/pebble_templates/index.html
 msgid "ignored;ignores;unignore;blocked;blocking;unblock"
 msgstr "ignored;ignores;unignore;blocked;blocking;unblock"
 
-#: resources/public/pebble_templates/index.html:423:28
+#: resources/public/pebble_templates/index.html
 msgid "Ignores"
 msgstr "Ignores"
 
-#: resources/public/pebble_templates/index.html:424:44
+#: resources/public/pebble_templates/index.html
 msgid "unignore;unblock"
 msgstr "unignore;unblock"
 
-#: resources/public/pebble_templates/index.html:429:85
+#: resources/public/pebble_templates/index.html
 msgid "Unignore"
 msgstr "Unignore"
 
-#: resources/public/pebble_templates/index.html:436:36
+#: resources/public/pebble_templates/index.html
 msgid "overlays;virginmap;heatmap;grid"
 msgstr "overlays;virginmap;heatmap;grid"
 
-#: resources/public/pebble_templates/index.html:438:24
+#: resources/public/pebble_templates/index.html
 msgid "Overlay Settings"
 msgstr "Overlay Settings"
 
-#: resources/public/pebble_templates/index.html:441:44
+#: resources/public/pebble_templates/index.html
 msgid "heatmap;heatmap opacity;clear heatmap"
 msgstr "heatmap;heatmap opacity;clear heatmap"
 
-#: resources/public/pebble_templates/index.html:442:28
+#: resources/public/pebble_templates/index.html
 msgid "Heatmap"
 msgstr "Heatmap"
 
-#: resources/public/pebble_templates/index.html:446:57
+#: resources/public/pebble_templates/index.html
 msgid "Turn on heatmap"
 msgstr "Turn on heatmap"
 
-#: resources/public/pebble_templates/index.html:448:70
+#: resources/public/pebble_templates/index.html
 msgid "(toggle with <kbd>H</kbd>)"
 msgstr "(toggle with <kbd>H</kbd>)"
 
-#: resources/public/pebble_templates/index.html:450:44
+#: resources/public/pebble_templates/index.html
 msgid "overlays;activity;pixels placed pixels;wipe;clean"
 msgstr "overlays;activity;pixels placed pixels;wipe;clean"
 
-#: resources/public/pebble_templates/index.html:451:71
+#: resources/public/pebble_templates/index.html
 msgid "Clear heatmap"
 msgstr "Clear heatmap"
 
-#: resources/public/pebble_templates/index.html:452:51
+#: resources/public/pebble_templates/index.html
 msgid "(hotkey: <kbd>O</kbd>)"
 msgstr "(hotkey: <kbd>O</kbd>)"
 
-#: resources/public/pebble_templates/index.html:454:44
+#: resources/public/pebble_templates/index.html
 msgid "overlays;user activity;pixels placed pixels;transparency"
 msgstr "overlays;user activity;pixels placed pixels;transparency"
 
-#: resources/public/pebble_templates/index.html:456:57
+#: resources/public/pebble_templates/index.html
 msgid "Heatmap background opacity:"
 msgstr "Heatmap background opacity:"
 
-#: resources/public/pebble_templates/index.html:461:44
+#: resources/public/pebble_templates/index.html
 msgid "virginmap;virginmap opacity;clear virginmap"
 msgstr "virginmap;virginmap opacity;clear virginmap"
 
-#: resources/public/pebble_templates/index.html:462:28
+#: resources/public/pebble_templates/index.html
 msgid "Virginmap"
 msgstr "Virginmap"
 
-#: resources/public/pebble_templates/index.html:466:57
+#: resources/public/pebble_templates/index.html
 msgid "Turn on virginmap"
 msgstr "Turn on virginmap"
 
-#: resources/public/pebble_templates/index.html:468:72
+#: resources/public/pebble_templates/index.html
 msgid "(toggle with <kbd>X</kbd>)"
 msgstr "(toggle with <kbd>X</kbd>)"
 
-#: resources/public/pebble_templates/index.html:470:44
+#: resources/public/pebble_templates/index.html
 msgid "overlays;user activity;pixels unplaced pixels;transparency"
 msgstr "overlays;user activity;pixels unplaced pixels;transparency"
 
-#: resources/public/pebble_templates/index.html:472:57
+#: resources/public/pebble_templates/index.html
 msgid "Virginmap background opacity:"
 msgstr "Virginmap background opacity:"
 
-#: resources/public/pebble_templates/index.html:476:44
+#: resources/public/pebble_templates/index.html
 msgid "overlays;activity;pixels unplaced pixels;wipe;clean"
 msgstr "overlays;activity;pixels unplaced pixels;wipe;clean"
 
-#: resources/public/pebble_templates/index.html:477:71
+#: resources/public/pebble_templates/index.html
 msgid "Clear virginmap"
 msgstr "Clear virginmap"
 
-#: resources/public/pebble_templates/index.html:478:51
+#: resources/public/pebble_templates/index.html
 msgid "(hotkey: <kbd>U</kbd>)"
 msgstr "(hotkey: <kbd>U</kbd>)"
 
-#: resources/public/pebble_templates/index.html:483:57
+#: resources/public/pebble_templates/index.html
 msgid "Layer template underneath heatmap"
 msgstr "Layer template underneath heatmap"
 
-#: resources/public/pebble_templates/index.html:487:44
+#: resources/public/pebble_templates/index.html
 msgid "grid;toggle grid"
 msgstr "grid;toggle grid"
 
-#: resources/public/pebble_templates/index.html:488:28
+#: resources/public/pebble_templates/index.html
 msgid "Grid"
 msgstr "Grid"
 
-#: resources/public/pebble_templates/index.html:492:57
+#: resources/public/pebble_templates/index.html
 msgid "Turn on grid"
 msgstr "Turn on grid"
 
-#: resources/public/pebble_templates/index.html:494:67
+#: resources/public/pebble_templates/index.html
 msgid "(toggle with <kbd>G</kbd>)"
 msgstr "(toggle with <kbd>G</kbd>)"
 
-#: resources/public/pebble_templates/index.html:499:36
+#: resources/public/pebble_templates/index.html
 msgid "controls;zooming;panning;movement"
 msgstr "controls;zooming;panning;movement"
 
-#: resources/public/pebble_templates/index.html:501:24
+#: resources/public/pebble_templates/index.html
 msgid "Control Settings"
 msgstr "Control Settings"
 
-#: resources/public/pebble_templates/index.html:504:44
+#: resources/public/pebble_templates/index.html
 msgid "zooming;scrolling;scale;scaling"
 msgstr "zooming;scrolling;scale;scaling"
 
-#: resources/public/pebble_templates/index.html:505:28
+#: resources/public/pebble_templates/index.html
 msgid "Zooming"
 msgstr "Zooming"
 
-#: resources/public/pebble_templates/index.html:506:44
+#: resources/public/pebble_templates/index.html
 msgid "scrolling sensitivity;zooming sensitivity;mousewheel sensitivity"
 msgstr "scrolling sensitivity;zooming sensitivity;mousewheel sensitivity"
 
-#: resources/public/pebble_templates/index.html:508:57
+#: resources/public/pebble_templates/index.html
 msgid "Zoom sensitivity:"
 msgstr "Zoom sensitivity:"
 
-#: resources/public/pebble_templates/index.html:512:44
+#: resources/public/pebble_templates/index.html
 msgid "zooming limit;scrolling limit;mousewheel;zooming minimum;zooming maximum"
 msgstr "zooming limit;scrolling limit;mousewheel;zooming minimum;zooming maximum"
 
-#: resources/public/pebble_templates/index.html:514:57
+#: resources/public/pebble_templates/index.html
 msgid "Minimum scale:"
 msgstr "Minimum scale:"
 
-#: resources/public/pebble_templates/index.html:518:57
+#: resources/public/pebble_templates/index.html
 msgid "Maximum scale:"
 msgstr "Maximum scale:"
 
-#: resources/public/pebble_templates/index.html:522:44
+#: resources/public/pebble_templates/index.html
 msgid "rounding;zooming;scrolling;mousewheel;integer;decimal"
 msgstr "rounding;zooming;scrolling;mousewheel;integer;decimal"
 
-#: resources/public/pebble_templates/index.html:525:57
+#: resources/public/pebble_templates/index.html
 msgid "Round zoom values to nearest whole number"
 msgstr "Round zoom values to nearest whole number"
 
-#: resources/public/pebble_templates/index.html:529:44
+#: resources/public/pebble_templates/index.html
 msgid "controls;miscellaneous"
 msgstr "controls;miscellaneous"
 
-#: resources/public/pebble_templates/index.html:534:57
+#: resources/public/pebble_templates/index.html
 msgid "Lock the canvas (disallow canvas drag/zoom with mouse/fingers)"
 msgstr "Lock the canvas (disallow canvas drag/zoom with mouse/fingers)"
 
-#: resources/public/pebble_templates/index.html:537:44
+#: resources/public/pebble_templates/index.html
 msgid "MMB picker;mouse picker;selection;palette picker"
 msgstr "MMB picker;mouse picker;selection;palette picker"
 
-#: resources/public/pebble_templates/index.html:540:57
+#: resources/public/pebble_templates/index.html
 msgid "Enable middle mouse button selecting color from board"
 msgstr "Enable middle mouse button selecting color from board"
 
-#: resources/public/pebble_templates/index.html:543:44
+#: resources/public/pebble_templates/index.html
 msgid "right click action"
 msgstr "right click action"
 
-#: resources/public/pebble_templates/index.html:545:57
+#: resources/public/pebble_templates/index.html
 msgid "Right-click action:"
 msgstr "Right-click action:"
 
-#: resources/public/pebble_templates/index.html:547:60
+#: resources/public/pebble_templates/index.html
 msgid "Nothing"
 msgstr "Nothing"
 
-#: resources/public/pebble_templates/index.html:548:58
+#: resources/public/pebble_templates/index.html
 msgid "Clear color"
 msgstr "Clear color"
 
-#: resources/public/pebble_templates/index.html:549:57
+#: resources/public/pebble_templates/index.html
 msgid "Copy color"
 msgstr "Copy color"
 
-#: resources/public/pebble_templates/index.html:550:59
+#: resources/public/pebble_templates/index.html
 msgid "Lookup"
 msgstr "Lookup"
 
-#: resources/public/pebble_templates/index.html:551:64
+#: resources/public/pebble_templates/index.html
 msgid "Clear color + Lookup"
 msgstr "Clear color + Lookup"
 
-#: resources/public/pebble_templates/index.html:558:36
+#: resources/public/pebble_templates/index.html
 msgid "snapshots;screenshot;download;picture;canvas"
 msgstr "snapshots;screenshot;download;picture;canvas"
 
-#: resources/public/pebble_templates/index.html:560:24
+#: resources/public/pebble_templates/index.html
 msgid "Snapshot Settings"
 msgstr "Snapshot Settings"
 
-#: resources/public/pebble_templates/index.html:563:44
+#: resources/public/pebble_templates/index.html
 msgid "screenshot;snapshot;download;board;canvas"
 msgstr "screenshot;snapshot;download;board;canvas"
 
-#: resources/public/pebble_templates/index.html:564:44
+#: resources/public/pebble_templates/index.html
 msgid "take screenshot;image;download format;picture;canvas;board"
 msgstr "take screenshot;image;download format;picture;canvas;board"
 
-#: resources/public/pebble_templates/index.html:566:57
+#: resources/public/pebble_templates/index.html
 msgid "Snapshot image format:"
 msgstr "Snapshot image format:"
 
-#: resources/public/pebble_templates/index.html:568:71
+#: resources/public/pebble_templates/index.html
 msgid "PNG"
 msgstr "PNG"
 
-#: resources/public/pebble_templates/index.html:569:63
+#: resources/public/pebble_templates/index.html
 msgid "JPEG"
 msgstr "JPEG"
 
-#: resources/public/pebble_templates/index.html:570:63
+#: resources/public/pebble_templates/index.html
 msgid "WEBP (Chrome only)"
 msgstr "WEBP (Chrome only)"
 
-#: resources/public/pebble_templates/index.html:577:36
+#: resources/public/pebble_templates/index.html
 msgid "templates;overlays;guides"
 msgstr "templates;overlays;guides"
 
-#: resources/public/pebble_templates/index.html:582:44
+#: resources/public/pebble_templates/index.html
 msgid "templates;overlays;image;pixel art"
 msgstr "templates;overlays;image;pixel art"
 
-#: resources/public/pebble_templates/index.html:583:44
+#: resources/public/pebble_templates/index.html
 msgid "template enabled;template disabled;show template;hide template;template shown;template hidden"
 msgstr "template enabled;template disabled;show template;hide template;template shown;template hidden"
 
-#: resources/public/pebble_templates/index.html:586:57
+#: resources/public/pebble_templates/index.html
 msgid "Use template"
 msgstr "Use template"
 
-#: resources/public/pebble_templates/index.html:589:27
+#: resources/public/pebble_templates/index.html
 msgid "Hold down <kbd>Ctrl</kbd> (or <kbd>Option</kbd> on mac) to drag the template around"
 msgstr "Hold down <kbd>Ctrl</kbd> (or <kbd>Option</kbd> on mac) to drag the template around"
 
-#: resources/public/pebble_templates/index.html:590:44
+#: resources/public/pebble_templates/index.html
 msgid "template title;template name;tab name;tab title;title="
 msgstr "template title;template name;tab name;tab title;title="
 
-#: resources/public/pebble_templates/index.html:592:57
+#: resources/public/pebble_templates/index.html
 msgid "Title:"
 msgstr "Title:"
 
-#: resources/public/pebble_templates/index.html:596:44
+#: resources/public/pebble_templates/index.html
 msgid "template location source;template source URL;template URL;template="
 msgstr "template location source;template source URL;template URL;template="
 
-#: resources/public/pebble_templates/index.html:598:57
+#: resources/public/pebble_templates/index.html
 msgid "URL:"
 msgstr "URL:"
 
-#: resources/public/pebble_templates/index.html:603:44
+#: resources/public/pebble_templates/index.html
 msgid "template position;template x;template y;template location; template vertical; template horizontal;ox=;oy="
 msgstr "template position;template x;template y;template location; template vertical; template horizontal;ox=;oy="
 
-#: resources/public/pebble_templates/index.html:605:57
+#: resources/public/pebble_templates/index.html
 msgid "Horizontal position:"
 msgstr "Horizontal position:"
 
-#: resources/public/pebble_templates/index.html:609:57
+#: resources/public/pebble_templates/index.html
 msgid "Vertical position:"
 msgstr "Vertical position:"
 
-#: resources/public/pebble_templates/index.html:613:44
+#: resources/public/pebble_templates/index.html
 msgid "template width;tw="
 msgstr "template width;tw="
 
-#: resources/public/pebble_templates/index.html:615:57
+#: resources/public/pebble_templates/index.html
 msgid "Width:"
 msgstr "Width:"
 
-#: resources/public/pebble_templates/index.html:618:82
-#: resources/public/pebble_templates/index.html:688:79
+#: resources/public/pebble_templates/index.html
 msgid "Reset"
 msgstr "Reset"
 
-#: resources/public/pebble_templates/index.html:620:44
+#: resources/public/pebble_templates/index.html
 msgid "template style;custom template"
 msgstr "template style;custom template"
 
-#: resources/public/pebble_templates/index.html:622:57
+#: resources/public/pebble_templates/index.html
 msgid "Style:"
 msgstr "Style:"
 
-#: resources/public/pebble_templates/index.html:624:53
+#: resources/public/pebble_templates/index.html
 msgid "Use Source Style"
 msgstr "Use Source Style"
 
-#: resources/public/pebble_templates/index.html:625:239
+#: resources/public/pebble_templates/index.html
 msgid "Dotted (Small, 1:2)"
 msgstr "Dotted (Small, 1:2)"
 
-#: resources/public/pebble_templates/index.html:626:271
+#: resources/public/pebble_templates/index.html
 msgid "Dotted (Big, 2:2)"
 msgstr "Dotted (Big, 2:2)"
 
-#: resources/public/pebble_templates/index.html:627:1803
+#: resources/public/pebble_templates/index.html
 msgid "Numbers"
 msgstr "Numbers"
 
-#: resources/public/pebble_templates/index.html:628:85
+#: resources/public/pebble_templates/index.html
 msgid "Custom…"
 msgstr "Custom…"
 
-#: resources/public/pebble_templates/index.html:632:44
+#: resources/public/pebble_templates/index.html
 msgid "template style source;template style URL;custom style URL;custom template"
 msgstr "template style source;template style URL;custom style URL;custom template"
 
-#: resources/public/pebble_templates/index.html:634:57
+#: resources/public/pebble_templates/index.html
 msgid "Custom style URL:"
 msgstr "Custom style URL:"
 
-#: resources/public/pebble_templates/index.html:639:44
+#: resources/public/pebble_templates/index.html
 msgid "template conversion;template palette conversion;convert to palette"
 msgstr "template conversion;template palette conversion;convert to palette"
 
-#: resources/public/pebble_templates/index.html:641:57
+#: resources/public/pebble_templates/index.html
 msgid "Color Conversion Mode:"
 msgstr "Color Conversion Mode:"
 
-#: resources/public/pebble_templates/index.html:643:64
+#: resources/public/pebble_templates/index.html
 msgid "Unconverted"
 msgstr "Unconverted"
 
-#: resources/public/pebble_templates/index.html:644:66
+#: resources/public/pebble_templates/index.html
 msgid "Nearest Custom"
 msgstr "Nearest Custom"
 
-#: resources/public/pebble_templates/index.html:648:44
+#: resources/public/pebble_templates/index.html
 msgid "template transparency;template opacity;oo="
 msgstr "template transparency;template opacity;oo="
 
-#: resources/public/pebble_templates/index.html:650:57
+#: resources/public/pebble_templates/index.html
 msgid "Opacity:"
 msgstr "Opacity:"
 
-#: resources/public/pebble_templates/index.html:658:36
+#: resources/public/pebble_templates/index.html
 msgid "sound;notification;alert;notify;ping"
 msgstr "sound;notification;alert;notify;ping"
 
-#: resources/public/pebble_templates/index.html:660:24
+#: resources/public/pebble_templates/index.html
 msgid "Sound and Notification Settings"
 msgstr "Sound and Notification Settings"
 
-#: resources/public/pebble_templates/index.html:665:44
+#: resources/public/pebble_templates/index.html
 msgid "audio;mute;noise;volume"
 msgstr "audio;mute;noise;volume"
 
-#: resources/public/pebble_templates/index.html:668:57
+#: resources/public/pebble_templates/index.html
 msgid "Enable sound"
 msgstr "Enable sound"
 
-#: resources/public/pebble_templates/index.html:671:44
+#: resources/public/pebble_templates/index.html
 msgid "notifs;notify;pixel notification"
 msgstr "notifs;notify;pixel notification"
 
-#: resources/public/pebble_templates/index.html:674:57
+#: resources/public/pebble_templates/index.html
 msgid "Enable pixel available notification"
 msgstr "Enable pixel available notification"
 
-#: resources/public/pebble_templates/index.html:678:44
+#: resources/public/pebble_templates/index.html
 msgid "notification;pixel ready;alert"
 msgstr "notification;pixel ready;alert"
 
-#: resources/public/pebble_templates/index.html:679:28
+#: resources/public/pebble_templates/index.html
 msgid "Pixel Ready Notification"
 msgstr "Pixel Ready Notification"
 
-#: resources/public/pebble_templates/index.html:680:44
+#: resources/public/pebble_templates/index.html
 msgid "alert source;notify url;notify source;notification url;notification source"
 msgstr "alert source;notify url;notify source;notification url;notification source"
 
-#: resources/public/pebble_templates/index.html:682:57
+#: resources/public/pebble_templates/index.html
 msgid "Alert URL:"
 msgstr "Alert URL:"
 
-#: resources/public/pebble_templates/index.html:686:85
+#: resources/public/pebble_templates/index.html
 msgid "Update"
 msgstr "Update"
 
-#: resources/public/pebble_templates/index.html:687:83
+#: resources/public/pebble_templates/index.html
 msgid "Test"
 msgstr "Test"
 
-#: resources/public/pebble_templates/index.html:691:44
+#: resources/public/pebble_templates/index.html
 msgid "sound level;audio level;mute audio;mute sound"
 msgstr "sound level;audio level;mute audio;mute sound"
 
-#: resources/public/pebble_templates/index.html:693:57
+#: resources/public/pebble_templates/index.html
 msgid "Volume:"
 msgstr "Volume:"
 
-#: resources/public/pebble_templates/index.html:698:44
+#: resources/public/pebble_templates/index.html
 msgid "alert forewarning;alert delay; notification delay; notification forewarning"
 msgstr "alert forewarning;alert delay; notification delay; notification forewarning"
 
-#: resources/public/pebble_templates/index.html:700:57
+#: resources/public/pebble_templates/index.html
 msgid "Delay (seconds):"
 msgstr "Delay (seconds):"
 
-#: resources/public/pebble_templates/index.html:705:44
+#: resources/public/pebble_templates/index.html
 msgid "chat mentions;chat pings;chat sound"
 msgstr "chat mentions;chat pings;chat sound"
 
-#: resources/public/pebble_templates/index.html:706:28
+#: resources/public/pebble_templates/index.html
 msgid "Chat Pings"
 msgstr "Chat Pings"
 
-#: resources/public/pebble_templates/index.html:710:57
+#: resources/public/pebble_templates/index.html
 msgid "Enable pings"
 msgstr "Enable pings"
 
-#: resources/public/pebble_templates/index.html:713:44
+#: resources/public/pebble_templates/index.html
 msgid "mention sound"
 msgstr "mention sound"
 
-#: resources/public/pebble_templates/index.html:715:57
+#: resources/public/pebble_templates/index.html
 msgid "Play sound on ping:"
 msgstr "Play sound on ping:"
 
-#: resources/public/pebble_templates/index.html:717:56
-#: resources/public/include/chat.js:1937:100
+#: resources/public/pebble_templates/index.html
+#: resources/public/include/chat.js
 msgid "Off"
 msgstr "Off"
 
-#: resources/public/pebble_templates/index.html:718:61
+#: resources/public/pebble_templates/index.html
 msgid "Only when necessary"
 msgstr "Only when necessary"
 
-#: resources/public/pebble_templates/index.html:719:59
+#: resources/public/pebble_templates/index.html
 msgid "Always"
 msgstr "Always"
 
-#: resources/public/pebble_templates/index.html:723:44
+#: resources/public/pebble_templates/index.html
 msgid "mention sound volume"
 msgstr "mention sound volume"
 
-#: resources/public/pebble_templates/index.html:725:57
+#: resources/public/pebble_templates/index.html
 msgid "Ping sound volume:"
 msgstr "Ping sound volume:"
 
-#: resources/public/pebble_templates/index.html:733:36
+#: resources/public/pebble_templates/index.html
 msgid "personal account"
 msgstr "personal account"
 
-#: resources/public/pebble_templates/index.html:735:24
+#: resources/public/pebble_templates/index.html
 msgid "Account Settings"
 msgstr "Account Settings"
 
-#: resources/public/pebble_templates/index.html:741:57
+#: resources/public/pebble_templates/index.html
 msgid "Public Discord name:"
 msgstr "Public Discord name:"
 
-#: resources/public/pebble_templates/index.html:745:83
-#: resources/public/include/chat.js:1939:92
-#: resources/public/include/chat.js:2003:92
+#: resources/public/pebble_templates/index.html
+#: resources/public/include/chat.js
 msgid "Set"
 msgstr "Set"
 
-#: resources/public/pebble_templates/index.html:746:86
+#: resources/public/pebble_templates/index.html
 msgid "Remove"
 msgstr "Remove"
 
 #. FAQ panel
-#: resources/public/pebble_templates/index.html:759:65
+#: resources/public/pebble_templates/index.html
 msgid "Help"
 msgstr "Help"
 
-#: resources/public/pebble_templates/index.html:772:54
+#: resources/public/pebble_templates/index.html
 msgid "Notifications"
 msgstr "Notifications"
 
-#: resources/public/pebble_templates/faq.html:3:16
+#: resources/public/pebble_templates/faq.html
 msgid "FAQ"
 msgstr "FAQ"
 
-#: resources/public/pebble_templates/faq.html:7:20
+#: resources/public/pebble_templates/faq.html
 msgid "Why is the cooldown as long as it is?"
 msgstr "Why is the cooldown as long as it is?"
 
-#: resources/public/pebble_templates/faq.html:8:20
+#: resources/public/pebble_templates/faq.html
 msgid "The time it takes to get a pixel is dynamic, and changes based on how many people are online. The cooldown time is longer when more users are online."
 msgstr "The time it takes to get a pixel is dynamic, and changes based on how many people are online. The cooldown time is longer when more users are online."
 
-#: resources/public/pebble_templates/faq.html:9:20
+#: resources/public/pebble_templates/faq.html
 msgid "Why does it say 0/6 pixels?"
 msgstr "Why does it say 0/6 pixels?"
 
-#: resources/public/pebble_templates/faq.html:10:20
+#: resources/public/pebble_templates/faq.html
 msgid "This means that you are waiting for your next pixel. When you place a pixel, there is a cooldown for when you can place the next one. Over time, you can gain up to 6 \"stacked\" pixels to place at once."
 msgstr "This means that you are waiting for your next pixel. When you place a pixel, there is a cooldown for when you can place the next one. Over time, you can gain up to 6 \"stacked\" pixels to place at once."
 
-#: resources/public/pebble_templates/faq.html:11:20
+#: resources/public/pebble_templates/faq.html
 msgid "Why does it take so long to \"stack\" pixels?"
 msgstr "Why does it take so long to \"stack\" pixels?"
 
-#: resources/public/pebble_templates/faq.html:12:20
+#: resources/public/pebble_templates/faq.html
 msgid "This is by design. It is better to place a pixel as soon as you get one. Pixel \"stacking\" is meant to give you a bump if you go AFK for a bit. It takes around 40 minutes to get a full 6/6 pixels, but it only takes around 3 minutes to place 6 pixels if you place them as soon as possible."
 msgstr "This is by design. It is better to place a pixel as soon as you get one. Pixel \"stacking\" is meant to give you a bump if you go AFK for a bit. It takes around 40 minutes to get a full 6/6 pixels, but it only takes around 3 minutes to place 6 pixels if you place them as soon as possible."
 
-#: resources/public/pebble_templates/faq.html:13:20
+#: resources/public/pebble_templates/faq.html
 msgid "How do I appeal a ban?"
 msgstr "How do I appeal a ban?"
 
-#: resources/public/pebble_templates/faq.html:14:20
+#: resources/public/pebble_templates/faq.html
 msgid "Contact us on <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord</a> or send an appeal to our <a href=\"https://pxls.space/appeal\" target=\"_blank\">Google form</a> after reading the rules in the site's info panel."
 msgstr "Contact us on <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord</a> or send an appeal to our <a href=\"https://pxls.space/appeal\" target=\"_blank\">Google form</a> after reading the rules in the site's info panel."
 
-#: resources/public/pebble_templates/faq.html:15:20
+#: resources/public/pebble_templates/faq.html
 msgid "How do I make a template?"
 msgstr "How do I make a template?"
 
-#: resources/public/pebble_templates/faq.html:16:20
+#: resources/public/pebble_templates/faq.html
 msgid "A template is an image link that is posted in the template textbox in the settings panel so you can place over it on the canvas. You may use a regular image link to your pixel art, but many people use the 3rd party tool <a href=\"https://pxlsfiddle.com\" target=\"_blank\">PxlsFiddle</a> to turn pixel art into a fancier link. If you need to make pixel art yourself, you can use <a href=\"https://www.piskelapp.com/p/create\" target=\"_blank\">Piskel</a> to create art to put into PxlsFiddle."
 msgstr "A template is an image link that is posted in the template textbox in the settings panel so you can place over it on the canvas. You may use a regular image link to your pixel art, but many people use the 3rd party tool <a href=\"https://pxlsfiddle.com\" target=\"_blank\">PxlsFiddle</a> to turn pixel art into a fancier link. If you need to make pixel art yourself, you can use <a href=\"https://www.piskelapp.com/p/create\" target=\"_blank\">Piskel</a> to create art to put into PxlsFiddle."
 
-#: resources/public/pebble_templates/faq.html:17:20
+#: resources/public/pebble_templates/faq.html
 msgid "How do I move a template?"
 msgstr "How do I move a template?"
 
-#: resources/public/pebble_templates/faq.html:18:20
+#: resources/public/pebble_templates/faq.html
 msgid "Hold <kbd>CTRL</kbd> (or <kbd>OPTION</kbd> on macOS) and click and drag to move it around. On mobile, you can tap and hold where you want to move the template and click \"Move Template Here\" in the pop-up."
 msgstr "Hold <kbd>CTRL</kbd> (or <kbd>OPTION</kbd> on macOS) and click and drag to move it around. On mobile, you can tap and hold where you want to move the template and click \"Move Template Here\" in the pop-up."
 
-#: resources/public/pebble_templates/faq.html:19:20
+#: resources/public/pebble_templates/faq.html
 msgid "Does the canvas reset? When?"
 msgstr "Does the canvas reset? When?"
 
-#: resources/public/pebble_templates/faq.html:20:20
+#: resources/public/pebble_templates/faq.html
 msgid "Yes. The canvas resets when it is completely full. A reset date is not usually decided until the canvas is full, but the average canvas life-span is around 1 month. Updates are posted in our <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a> when a reset date is set."
 msgstr "Yes. The canvas resets when it is completely full. A reset date is not usually decided until the canvas is full, but the average canvas life-span is around 1 month. Updates are posted in our <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a> when a reset date is set."
 
-#: resources/public/pebble_templates/faq.html:21:20
+#: resources/public/pebble_templates/faq.html
 msgid "Where can I see the past canvases?"
 msgstr "Where can I see the past canvases?"
 
-#: resources/public/pebble_templates/faq.html:22:20
+#: resources/public/pebble_templates/faq.html
 msgid "The past canvases are featured on our <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a>, or the 3rd party website <a href=\"https://pxlsfiddle.com\" target=\"_blank\">PxlsFiddle</a>, which records timelapses and a lot of useful information on each canvas."
 msgstr "The past canvases are featured on our <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a>, or the 3rd party website <a href=\"https://pxlsfiddle.com\" target=\"_blank\">PxlsFiddle</a>, which records timelapses and a lot of useful information on each canvas."
 
-#: resources/public/pebble_templates/faq.html:23:20
+#: resources/public/pebble_templates/faq.html
 msgid "How do I see who placed a pixel?"
 msgstr "How do I see who placed a pixel?"
 
-#: resources/public/pebble_templates/faq.html:24:20
+#: resources/public/pebble_templates/faq.html
 msgid "By shift-clicking (or tap and hold on mobile) a pixel, you can see who placed a pixel, how many pixels they have placed, and when they placed it."
 msgstr "By shift-clicking (or tap and hold on mobile) a pixel, you can see who placed a pixel, how many pixels they have placed, and when they placed it."
 
-#: resources/public/pebble_templates/faq.html:25:20
+#: resources/public/pebble_templates/faq.html
 msgid "How do I report someone?"
 msgstr "How do I report someone?"
 
-#: resources/public/pebble_templates/faq.html:26:20
+#: resources/public/pebble_templates/faq.html
 msgid "Shift-click (or tap and hold on mobile) on a pixel, and click the Report button."
 msgstr "Shift-click (or tap and hold on mobile) on a pixel, and click the Report button."
 
-#: resources/public/pebble_templates/faq.html:27:20
+#: resources/public/pebble_templates/faq.html
 msgid "How do I change the color of my name in the chat?"
 msgstr "How do I change the color of my name in the chat?"
 
-#: resources/public/pebble_templates/faq.html:28:20
+#: resources/public/pebble_templates/faq.html
 msgid "There is a \"Username Color\" option near the bottom of the settings panel."
 msgstr "There is a \"Username Color\" option near the bottom of the settings panel."
 
-#: resources/public/pebble_templates/faq.html:29:20
+#: resources/public/pebble_templates/faq.html
 msgid "What is a \"virginmap\"?"
 msgstr "What is a \"virginmap\"?"
 
-#: resources/public/pebble_templates/faq.html:30:20
+#: resources/public/pebble_templates/faq.html
 msgid "The virginmap shows which pixels have not yet been placed on (or “virgin” pixels)."
 msgstr "The virginmap shows which pixels have not yet been placed on (or “virgin” pixels)."
 
-#: resources/public/pebble_templates/faq.html:31:20
+#: resources/public/pebble_templates/faq.html
 msgid "How do I report bugs?"
 msgstr "How do I report bugs?"
 
-#: resources/public/pebble_templates/faq.html:32:20
+#: resources/public/pebble_templates/faq.html
 msgid "Submit bugs to the #dev-and-bugs channel in the <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a>. If you have found an exploit, please message one of the staff members privately (through DMs)."
 msgstr "Submit bugs to the #dev-and-bugs channel in the <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a>. If you have found an exploit, please message one of the staff members privately (through DMs)."
 
-#: resources/public/pebble_templates/faq.html:33:20
+#: resources/public/pebble_templates/faq.html
 msgid "How do I get more info or contact staff?"
 msgstr "How do I get more info or contact staff?"
 
-#: resources/public/pebble_templates/faq.html:34:20
+#: resources/public/pebble_templates/faq.html
 msgid "Check the info panel (the icon on the top left) for more details and links, or join our <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a>, where a staff member will gladly respond."
 msgstr "Check the info panel (the icon on the top left) for more details and links, or join our <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a>, where a staff member will gladly respond."
 
-#: resources/public/pebble_templates/info.html:3:10
+#: resources/public/pebble_templates/info.html
 msgid "Welcome!"
 msgstr "Welcome!"
 
-#: resources/public/pebble_templates/info.html:6:9
+#: resources/public/pebble_templates/info.html
 msgid "Welcome to pxls.space! Pxls is a multiplayer online collaborative canvas that allows you to create anything you can imagine, one pixel at a time. Join hundreds of other players in the Pxls community and create amazing works of art together as a team, or solo."
 msgstr "Welcome to pxls.space! Pxls is a multiplayer online collaborative canvas that allows you to create anything you can imagine, one pixel at a time. Join hundreds of other players in the Pxls community and create amazing works of art together as a team, or solo."
 
-#: resources/public/pebble_templates/info.html:7:9
+#: resources/public/pebble_templates/info.html
 msgid "The best place to reach staff and fellow community is in the discord!"
 msgstr "The best place to reach staff and fellow community is in the discord!"
 
-#: resources/public/pebble_templates/info.html:8:9
+#: resources/public/pebble_templates/info.html
 msgid "Check out our social media pages, and please take the time to read the rules below. Have fun creating (or changing) art!"
 msgstr "Check out our social media pages, and please take the time to read the rules below. Have fun creating (or changing) art!"
 
-#: resources/public/pebble_templates/info.html:13:27
+#: resources/public/pebble_templates/info.html
 msgid "Canvas Rules"
 msgstr "Canvas Rules"
 
-#: resources/public/pebble_templates/info.html:16:9
+#: resources/public/pebble_templates/info.html
 msgid "We pride ourselves on trying to keep an open canvas for all free from outside interference on our end, and especially censorship. However, for the good of the community and on accounts of our own beliefs, please acknowledge and obey the following guidelines:"
 msgstr "We pride ourselves on trying to keep an open canvas for all free from outside interference on our end, and especially censorship. However, for the good of the community and on accounts of our own beliefs, please acknowledge and obey the following guidelines:"
 
-#: resources/public/pebble_templates/info.html:18:11
+#: resources/public/pebble_templates/info.html
 msgid "No hateful imagery or derogatory speech. This includes but is not limited to words such as <i>faggot</i>, <i>nigger</i>, etc; as well as the Swastika, Hammer and Sickle, and any symbols of terrorism."
 msgstr "No hateful imagery or derogatory speech. This includes but is not limited to words such as <i>faggot</i>, <i>nigger</i>, etc; as well as the Swastika, Hammer and Sickle, and any symbols of terrorism."
 
-#: resources/public/pebble_templates/info.html:19:11
+#: resources/public/pebble_templates/info.html
 msgid "No NSFW or NSFL content."
 msgstr "No NSFW or NSFL content."
 
-#: resources/public/pebble_templates/info.html:21:13
+#: resources/public/pebble_templates/info.html
 msgid "No nudity or otherwise sexually explicit content"
 msgstr "No nudity or otherwise sexually explicit content"
 
-#: resources/public/pebble_templates/info.html:23:15
+#: resources/public/pebble_templates/info.html
 msgid "No female-presenting nipples/bare breasts, genitalia, sexual fluids"
 msgstr "No female-presenting nipples/bare breasts, genitalia, sexual fluids"
 
-#: resources/public/pebble_templates/info.html:26:13
+#: resources/public/pebble_templates/info.html
 msgid "No sexual imagery/erotica"
 msgstr "No sexual imagery/erotica"
 
-#: resources/public/pebble_templates/info.html:27:13
+#: resources/public/pebble_templates/info.html
 msgid "No excessive blood or otherwise obscene/shocking content"
 msgstr "No excessive blood or otherwise obscene/shocking content"
 
-#: resources/public/pebble_templates/info.html:30:11
+#: resources/public/pebble_templates/info.html
 msgid "No more than <b>one</b> account per user, no exceptions. Multiple account users will be banned from creating art on the canvas."
 msgstr "No more than <b>one</b> account per user, no exceptions. Multiple account users will be banned from creating art on the canvas."
 
-#: resources/public/pebble_templates/info.html:31:11
+#: resources/public/pebble_templates/info.html
 msgid "No auto-placement tools of any kind, you must place the pixels manually."
 msgstr "No auto-placement tools of any kind, you must place the pixels manually."
 
-#: resources/public/pebble_templates/info.html:32:11
+#: resources/public/pebble_templates/info.html
 msgid "Do not abuse site functionality, such as reports or lookups. (e.g. automated reporting/lookups, etc.)"
 msgstr "Do not abuse site functionality, such as reports or lookups. (e.g. automated reporting/lookups, etc.)"
 
-#: resources/public/pebble_templates/info.html:33:11
+#: resources/public/pebble_templates/info.html
 msgid "Any automated aggregation of data from user lookups is not allowed, and will result in a ban."
 msgstr "Any automated aggregation of data from user lookups is not allowed, and will result in a ban."
 
-#: resources/public/pebble_templates/info.html:34:11
-#: resources/public/pebble_templates/info.html:62:11
+#: resources/public/pebble_templates/info.html
 msgid "Staff have final say in any rule disputes"
 msgstr "Staff have final say in any rule disputes"
 
-#: resources/public/pebble_templates/info.html:35:12
-#: resources/public/pebble_templates/info.html:64:13
+#: resources/public/pebble_templates/info.html
 msgid "If you feel a moderator has acted inappropriately, please report it to an administrator."
 msgstr "If you feel a moderator has acted inappropriately, please report it to an administrator."
 
-#: resources/public/pebble_templates/info.html:38:9
+#: resources/public/pebble_templates/info.html
 msgid "If you believe you have been falsely banned you may contact a moderator or administrator."
 msgstr "If you believe you have been falsely banned you may contact a moderator or administrator."
 
-#: resources/public/pebble_templates/info.html:43:27
+#: resources/public/pebble_templates/info.html
 msgid "Chat Rules"
 msgstr "Chat Rules"
 
-#: resources/public/pebble_templates/info.html:47:11
+#: resources/public/pebble_templates/info.html
 msgid "Keep chat civil. No harassment or homophobic/transphobic/disablist language."
 msgstr "Keep chat civil. No harassment or homophobic/transphobic/disablist language."
 
-#: resources/public/pebble_templates/info.html:48:11
+#: resources/public/pebble_templates/info.html
 msgid "No hate speech. This includes emoji/symbols/ASCII art."
 msgstr "No hate speech. This includes emoji/symbols/ASCII art."
 
-#: resources/public/pebble_templates/info.html:50:13
+#: resources/public/pebble_templates/info.html
 msgid "Normal swearing/etc is allowed"
 msgstr "Normal swearing/etc is allowed"
 
-#: resources/public/pebble_templates/info.html:53:11
+#: resources/public/pebble_templates/info.html
 msgid "No spamming"
 msgstr "No spamming"
 
-#: resources/public/pebble_templates/info.html:55:13
+#: resources/public/pebble_templates/info.html
 msgid "This includes excessive ASCII art/emojis/symbols/whitespace"
 msgstr "This includes excessive ASCII art/emojis/symbols/whitespace"
 
-#: resources/public/pebble_templates/info.html:58:11
+#: resources/public/pebble_templates/info.html
 msgid "No \"copy pasta\"s"
 msgstr "No \"copy pasta\"s"
 
-#: resources/public/pebble_templates/info.html:59:11
+#: resources/public/pebble_templates/info.html
 msgid "No links to sites that actively break the canvas or chat rules (e.g. porn sites)"
 msgstr "No links to sites that actively break the canvas or chat rules (e.g. porn sites)"
 
-#: resources/public/pebble_templates/info.html:60:11
+#: resources/public/pebble_templates/info.html
 msgid "No symbology which break the canvas or chat rules (e.g. NSFW ASCII art)"
 msgstr "No symbology which break the canvas or chat rules (e.g. NSFW ASCII art)"
 
-#: resources/public/pebble_templates/info.html:61:16
+#: resources/public/pebble_templates/info.html
 msgid "No personal information"
 msgstr "No personal information"
 
-#: resources/public/pebble_templates/info.html:72:10
+#: resources/public/pebble_templates/info.html
 msgid "Links"
 msgstr "Links"
 
-#: resources/public/pebble_templates/info.html:76:64
+#: resources/public/pebble_templates/info.html
 msgid "Discord (main hub)"
 msgstr "Discord (main hub)"
 
-#: resources/public/pebble_templates/info.html:77:68
+#: resources/public/pebble_templates/info.html
 msgid "Subreddit"
 msgstr "Subreddit"
 
-#: resources/public/pebble_templates/info.html:78:68
+#: resources/public/pebble_templates/info.html
 msgid "Twitter"
 msgstr "Twitter"
 
-#: resources/public/pebble_templates/info.html:79:66
+#: resources/public/pebble_templates/info.html
 msgid "GitHub"
 msgstr "GitHub"
 
 #. link to piskelapp.com
-#: resources/public/pebble_templates/info.html:81:71
+#: resources/public/pebble_templates/info.html
 msgid "Single-player mode"
 msgstr "Single-player mode"
 
-#: resources/public/pebble_templates/info.html:84:62
+#: resources/public/pebble_templates/info.html
 msgid "Statistics"
 msgstr "Statistics"
 
-#: resources/public/pebble_templates/info.html:85:64
+#: resources/public/pebble_templates/info.html
 msgid "Profile (user info, factions, etc.)"
 msgstr "Profile (user info, factions, etc.)"
 
 #. link to pxlsfiddle.com
-#: resources/public/pebble_templates/info.html:87:68
+#: resources/public/pebble_templates/info.html
 msgid "Template generator, archives, timelapses, and other utilities"
 msgstr "Template generator, archives, timelapses, and other utilities"
 
 #. link to pxlsfiddle.com
-#: resources/public/pebble_templates/info.html:87:165
+#: resources/public/pebble_templates/info.html
 msgid "PxlsFiddle (templates, archives, etc.)"
 msgstr "PxlsFiddle (templates, archives, etc.)"
 
-#: resources/public/pebble_templates/info.html:93:10
+#: resources/public/pebble_templates/info.html
 msgid "Donate"
 msgstr "Donate"
 
-#: resources/public/pebble_templates/info.html:96:9
+#: resources/public/pebble_templates/info.html
 msgid "Donations are not accepted at this time, but this panel will be updated when they're open again!"
 msgstr "Donations are not accepted at this time, but this panel will be updated when they're open again!"
 
 #. eg "Alice's profile". Double singlequote is a java thing - needed if a replacement (such as this) contains a singlequote.
-#: resources/public/pebble_templates/profile.html:31:66
-#: resources/public/pebble_templates/profile.html:50:131
+#: resources/public/pebble_templates/profile.html
 msgid "{0}''s Profile"
 msgstr "{0}''s Profile"
 
-#: resources/public/pebble_templates/profile.html:41:84
-#: resources/public/pebble_templates/40x.html:28:84
-#: resources/public/pebble_templates/40x.html:45:100
-#: resources/public/pebble_templates/40x.html:62:100
+#: resources/public/pebble_templates/profile.html
+#: resources/public/pebble_templates/40x.html
 msgid "My Profile"
 msgstr "My Profile"
 
-#: resources/public/pebble_templates/profile.html:42:85
-#: resources/public/pebble_templates/40x.html:29:85
+#: resources/public/pebble_templates/profile.html
+#: resources/public/pebble_templates/40x.html
 msgid "My Factions"
 msgstr "My Factions"
 
-#: resources/public/pebble_templates/profile.html:60:93
-#: resources/public/pebble_templates/profile.html:126:56
+#: resources/public/pebble_templates/profile.html
 msgid "Reports"
 msgstr "Reports"
 
-#: resources/public/pebble_templates/profile.html:63:94
+#: resources/public/pebble_templates/profile.html
 msgid "Factions"
 msgstr "Factions"
 
-#: resources/public/pebble_templates/profile.html:71:68
+#: resources/public/pebble_templates/profile.html
 msgid "You must be logged in to view your profile."
 msgstr "You must be logged in to view your profile."
 
-#: resources/public/pebble_templates/profile.html:77:72
+#: resources/public/pebble_templates/profile.html
 msgid "Registration Date"
 msgstr "Registration Date"
 
-#: resources/public/pebble_templates/profile.html:82:72
-#: resources/public/include/lookup.js:280:21
+#: resources/public/pebble_templates/profile.html
+#: resources/public/include/lookup.js
 msgid "Alltime Pixels"
 msgstr "Alltime Pixels"
 
-#: resources/public/pebble_templates/profile.html:86:72
+#: resources/public/pebble_templates/profile.html
 msgid "Current Canvas Pixels"
 msgstr "Current Canvas Pixels"
 
-#: resources/public/pebble_templates/profile.html:91:72
+#: resources/public/pebble_templates/profile.html
 msgid "Discord Tag"
 msgstr "Discord Tag"
 
-#: resources/public/pebble_templates/profile.html:95:72
-#: resources/public/include/lookup.js:235:21
+#: resources/public/pebble_templates/profile.html
+#: resources/public/include/lookup.js
 msgid "Faction"
 msgstr "Faction"
 
-#: resources/public/pebble_templates/profile.html:96:259
+#: resources/public/pebble_templates/profile.html
 msgid "None"
 msgstr "None"
 
-#: resources/public/pebble_templates/profile.html:99:72
-#: resources/public/admin/admin.js:198:16
+#: resources/public/pebble_templates/profile.html
+#: resources/public/admin/admin.js
 msgid "Roles"
 msgstr "Roles"
 
-#: resources/public/pebble_templates/profile.html:104:72
+#: resources/public/pebble_templates/profile.html
 msgid "Canvas Ban Expiry"
 msgstr "Canvas Ban Expiry"
 
-#: resources/public/pebble_templates/profile.html:105:101
-#: resources/public/pebble_templates/profile.html:111:105
+#: resources/public/pebble_templates/profile.html
 msgid "Never"
 msgstr "Never"
 
-#: resources/public/pebble_templates/profile.html:110:72
+#: resources/public/pebble_templates/profile.html
 msgid "Chat Ban Expiry"
 msgstr "Chat Ban Expiry"
 
-#: resources/public/pebble_templates/profile.html:117:36
+#: resources/public/pebble_templates/profile.html
 msgid "View rankings and other stats <a href=\"/stats\">here</a>."
 msgstr "View rankings and other stats <a href=\"/stats\">here</a>."
 
-#: resources/public/pebble_templates/profile.html:124:68
+#: resources/public/pebble_templates/profile.html
 msgid "You must be logged in to view your reports."
 msgstr "You must be logged in to view your reports."
 
-#: resources/public/pebble_templates/profile.html:130:64
+#: resources/public/pebble_templates/profile.html
 msgid "Canvas Reports ({0}/{1} open)"
 msgstr "Canvas Reports ({0}/{1} open)"
 
 #. eg "Report on Bob (closed)
-#: resources/public/pebble_templates/profile.html:142:56
-#: resources/public/pebble_templates/profile.html:177:56
+#: resources/public/pebble_templates/profile.html
 msgid "Report on {0} (closed)"
 msgstr "Report on {0} (closed)"
 
 #. eg "Report on Bob (open)
-#: resources/public/pebble_templates/profile.html:145:56
-#: resources/public/pebble_templates/profile.html:179:56
+#: resources/public/pebble_templates/profile.html
 msgid "Report on {0} (open)"
 msgstr "Report on {0} (open)"
 
 #. eg "Reported Bob on Jan 1, 1970, 00:00:00 AM (UTC)
-#: resources/public/pebble_templates/profile.html:152:60
-#: resources/public/pebble_templates/profile.html:185:60
+#: resources/public/pebble_templates/profile.html
 msgid "Reported {0} on {1}"
 msgstr "Reported {0} on {1}"
 
-#: resources/public/pebble_templates/profile.html:158:47
+#: resources/public/pebble_templates/profile.html
 msgid "There are no canvas reports to show."
 msgstr "There are no canvas reports to show."
 
-#: resources/public/pebble_templates/profile.html:166:64
+#: resources/public/pebble_templates/profile.html
 msgid "Chat Reports ({0}/{1} open)"
 msgstr "Chat Reports ({0}/{1} open)"
 
-#: resources/public/pebble_templates/profile.html:191:47
+#: resources/public/pebble_templates/profile.html
 msgid "There are no chat reports to show."
 msgstr "There are no chat reports to show."
 
-#: resources/public/pebble_templates/profile.html:200:68
+#: resources/public/pebble_templates/profile.html
 msgid "You must be logged in to manage your factions."
 msgstr "You must be logged in to manage your factions."
 
-#: resources/public/pebble_templates/profile.html:205:36
+#: resources/public/pebble_templates/profile.html
 msgid "You are faction restricted and cannot create new factions. If you believe this is an error, please contact a moderator."
 msgstr "You are faction restricted and cannot create new factions. If you believe this is an error, please contact a moderator."
 
-#: resources/public/pebble_templates/profile.html:207:36
+#: resources/public/pebble_templates/profile.html
 msgid "You are canvas banned and cannot create new factions. If you believe this is an error, please contact a moderator."
 msgstr "You are canvas banned and cannot create new factions. If you believe this is an error, please contact a moderator."
 
-#: resources/public/pebble_templates/profile.html:212:76
+#: resources/public/pebble_templates/profile.html
 msgid "You must have at least {0} all-time pixels to create a faction."
 msgstr "You must have at least {0} all-time pixels to create a faction."
 
-#: resources/public/pebble_templates/profile.html:215:300
+#: resources/public/pebble_templates/profile.html
 msgid "Create"
 msgstr "Create"
 
-#: resources/public/pebble_templates/profile.html:216:191
+#: resources/public/pebble_templates/profile.html
 msgid "Join"
 msgstr "Join"
 
-#: resources/public/pebble_templates/profile.html:225:118
+#: resources/public/pebble_templates/profile.html
 msgid "This is your currently displayed faction."
 msgstr "This is your currently displayed faction."
 
 #. eg "Pixelers (members: 100, ID: 1)"
-#: resources/public/pebble_templates/profile.html:228:44
+#: resources/public/pebble_templates/profile.html
 msgid "{0} (members: {1}, ID: {2}"
 msgstr "{0} (members: {1}, ID: {2}"
 
-#: resources/public/pebble_templates/profile.html:231:69
+#: resources/public/pebble_templates/profile.html
 msgid "Owner: {0}"
 msgstr "Owner: {0}"
 
 #. makes the faction no longer the one displayed for the current user
-#: resources/public/pebble_templates/profile.html:236:175
+#: resources/public/pebble_templates/profile.html
 msgid "Remove Displayed"
 msgstr "Remove Displayed"
 
 #. makes the faction the one displayed for the current user
-#: resources/public/pebble_templates/profile.html:239:172
+#: resources/public/pebble_templates/profile.html
 msgid "Set Displayed"
 msgstr "Set Displayed"
 
-#: resources/public/pebble_templates/profile.html:242:235
+#: resources/public/pebble_templates/profile.html
 msgid "Members"
 msgstr "Members"
 
-#: resources/public/pebble_templates/profile.html:243:169
+#: resources/public/pebble_templates/profile.html
 msgid "Edit"
 msgstr "Edit"
 
-#: resources/public/pebble_templates/profile.html:244:168
-#: resources/public/include/chat.js:1462:24
+#: resources/public/pebble_templates/profile.html
+#: resources/public/include/chat.js
 msgid "Delete"
 msgstr "Delete"
 
-#: resources/public/pebble_templates/profile.html:246:174
+#: resources/public/pebble_templates/profile.html
 msgid "Leave"
 msgstr "Leave"
 
-#: resources/public/pebble_templates/profile.html:253:68
+#: resources/public/pebble_templates/profile.html
 msgid "You are not in any factions yet!"
 msgstr "You are not in any factions yet!"
 
-#: resources/public/pebble_templates/profile.html:269:52
+#: resources/public/pebble_templates/profile.html
 msgid "Members of {0} ([{1}])"
 msgstr "Members of {0} ([{1}])"
 
-#: resources/public/pebble_templates/profile.html:270:97
-#: resources/public/pebble_templates/profile.html:329:97
-#: resources/public/pebble_templates/profile.html:342:97
-#: resources/public/pebble_templates/profile.html:366:97
+#: resources/public/pebble_templates/profile.html
 msgid "Close"
 msgstr "Close"
 
-#: resources/public/pebble_templates/profile.html:278:60
+#: resources/public/pebble_templates/profile.html
 msgid "Faction Members"
 msgstr "Faction Members"
 
-#: resources/public/pebble_templates/profile.html:292:128
+#: resources/public/pebble_templates/profile.html
 msgid "Transfer Ownership"
 msgstr "Transfer Ownership"
 
 #. bans a user from the faction
-#: resources/public/pebble_templates/profile.html:294:122
-#: resources/public/include/chat.js:1733:60
+#: resources/public/pebble_templates/profile.html
+#: resources/public/include/chat.js
 msgid "Ban"
 msgstr "Ban"
 
-#: resources/public/pebble_templates/profile.html:300:79
-#: resources/public/pebble_templates/profile.html:322:79
+#: resources/public/pebble_templates/profile.html
 msgid "Nothing to see here!"
 msgstr "Nothing to see here!"
 
-#: resources/public/pebble_templates/profile.html:308:60
+#: resources/public/pebble_templates/profile.html
 msgid "Faction Bans"
 msgstr "Faction Bans"
 
-#: resources/public/pebble_templates/profile.html:318:125
-#: resources/public/include/chat.js:1629:36
-#: resources/public/include/chat.js:1733:46
-#: resources/public/admin/admin.js:320:88
-#: resources/public/admin/admin.js:347:52
+#: resources/public/pebble_templates/profile.html
+#: resources/public/include/chat.js resources/public/admin/admin.js
 msgid "Unban"
 msgstr "Unban"
 
-#: resources/public/pebble_templates/profile.html:341:52
+#: resources/public/pebble_templates/profile.html
 msgid "Find A Faction"
 msgstr "Find A Faction"
 
-#: resources/public/pebble_templates/profile.html:351:99
+#: resources/public/pebble_templates/profile.html
 msgid "Search:"
 msgstr "Search:"
 
-#: resources/public/pebble_templates/profile.html:361:66
+#: resources/public/pebble_templates/profile.html
 msgid "Enter a search term to get started."
 msgstr "Enter a search term to get started."
 
-#: resources/public/pebble_templates/profile.html:363:116
+#: resources/public/pebble_templates/profile.html
 msgid "Load More"
 msgstr "Load More"
 
 #. HTTP status code name
-#: resources/public/pebble_templates/40x.html:39:24
+#: resources/public/pebble_templates/40x.html
 msgid "Not Found"
 msgstr "Not Found"
 
-#: resources/public/pebble_templates/40x.html:41:23
+#: resources/public/pebble_templates/40x.html
 msgid "The content you requested could not be found at this URL. If you believe this is an error, please contact a developer."
 msgstr "The content you requested could not be found at this URL. If you believe this is an error, please contact a developer."
 
 #. links to the homepage (the app itself)
-#: resources/public/pebble_templates/40x.html:44:99
-#: resources/public/pebble_templates/40x.html:53:99
-#: resources/public/pebble_templates/40x.html:61:99
+#: resources/public/pebble_templates/40x.html
 msgid "Back to Pxls"
 msgstr "Back to Pxls"
 
 #. HTTP status code name
-#: resources/public/pebble_templates/40x.html:49:24
+#: resources/public/pebble_templates/40x.html
 msgid "Not Authenticated"
 msgstr "Not Authenticated"
 
-#: resources/public/pebble_templates/40x.html:51:23
+#: resources/public/pebble_templates/40x.html
 msgid "You must be logged in to access this data. Please go back to pxls and go through the authentication process."
 msgstr "You must be logged in to access this data. Please go back to pxls and go through the authentication process."
 
 #. HTTP status code name
-#: resources/public/pebble_templates/40x.html:57:24
+#: resources/public/pebble_templates/40x.html
 msgid "Not Allowed"
 msgstr "Not Allowed"
 
-#: resources/public/pebble_templates/40x.html:59:23
+#: resources/public/pebble_templates/40x.html
 msgid "The action you attempted to perform is not allowed or resulted in an error. Please ensure you have access to the endpoint and try again later."
 msgstr "The action you attempted to perform is not allowed or resulted in an error. Please ensure you have access to the endpoint and try again later."
 
-#: resources/public/pxls.js:134:38
+#: resources/public/pxls.js
 msgid "Alert"
 msgstr "Alert"
 
 #. Snapshot save name
-#: resources/public/include/board.js:806:100
+#: resources/public/include/board.js
 msgid "pxls canvas"
 msgstr "pxls canvas"
 
 #. template link action
-#: resources/public/include/chat.js:80:21
+#: resources/public/include/chat.js
 msgid "Ask"
 msgstr "Ask"
 
-#: resources/public/include/chat.js:84:21
+#: resources/public/include/chat.js
 msgid "Open in a new tab"
 msgstr "Open in a new tab"
 
-#: resources/public/include/chat.js:88:21
+#: resources/public/include/chat.js
 msgid "Open in current tab (replacing template)"
 msgstr "Open in current tab (replacing template)"
 
-#: resources/public/include/chat.js:92:21
+#: resources/public/include/chat.js
 msgid "Jump to coordinates without replacing template"
 msgstr "Jump to coordinates without replacing template"
 
-#: resources/public/include/chat.js:437:55
-#: resources/public/include/chat.js:956:53
+#: resources/public/include/chat.js
 msgid "You must be logged in to chat."
 msgstr "You must be logged in to chat."
 
-#: resources/public/include/chat.js:1260:42
-#: resources/public/include/chat.js:1753:27
+#: resources/public/include/chat.js
 msgid "none provided"
 msgstr "none provided"
 
-#: resources/public/include/chat.js:1261:38
+#: resources/public/include/chat.js
 msgid "Purged by ${purge.initiator} with reason: ${reason}"
 msgstr "Purged by ${purge.initiator} with reason: ${reason}"
 
-#: resources/public/include/chat.js:1279:26
+#: resources/public/include/chat.js
 msgid "template:"
 msgstr "template:"
 
-#: resources/public/include/chat.js:1331:56
-#: resources/public/include/chat.js:2057:56
+#: resources/public/include/chat.js
 msgid "Open Failed"
 msgstr "Open Failed"
 
-#: resources/public/include/chat.js:1333:32
-#: resources/public/include/chat.js:2059:32
+#: resources/public/include/chat.js
 msgid "Failed to automatically open in a new tab"
 msgstr "Failed to automatically open in a new tab"
 
-#: resources/public/include/chat.js:1337:24
-#: resources/public/include/chat.js:2063:24
+#: resources/public/include/chat.js
 msgid "Click here to open in a new tab instead"
 msgstr "Click here to open in a new tab instead"
 
-#: resources/public/include/chat.js:1351:52
+#: resources/public/include/chat.js
 msgid "Open Template"
 msgstr "Open Template"
 
-#: resources/public/include/chat.js:1353:54
+#: resources/public/include/chat.js
 msgid "This link will overwrite your current template. What would you like to do?"
 msgstr "This link will overwrite your current template. What would you like to do?"
 
-#: resources/public/include/chat.js:1364:55
+#: resources/public/include/chat.js
 msgid "Note: You can set a default action in the settings menu which bypasses this popup completely."
 msgstr "Note: You can set a default action in the settings menu which bypasses this popup completely."
 
-#: resources/public/include/chat.js:1455:24
-#: resources/public/include/chat.js:1534:18
-#: resources/public/include/lookup.js:18:90
+#: resources/public/include/chat.js resources/public/include/lookup.js
 msgid "Report"
 msgstr "Report"
 
-#: resources/public/include/chat.js:1456:24
+#: resources/public/include/chat.js
 msgid "Mention"
 msgstr "Mention"
 
-#: resources/public/include/chat.js:1457:24
+#: resources/public/include/chat.js
 msgid "Ignore"
 msgstr "Ignore"
 
-#: resources/public/include/chat.js:1458:102
-#: resources/public/admin/admin.js:193:16
+#: resources/public/include/chat.js resources/public/admin/admin.js
 msgid "Profile"
 msgstr "Profile"
 
-#: resources/public/include/chat.js:1459:24
+#: resources/public/include/chat.js
 msgid "Chat (un)ban"
 msgstr "Chat (un)ban"
 
-#: resources/public/include/chat.js:1461:43
-#: resources/public/include/chat.js:1911:54
+#: resources/public/include/chat.js
 msgid "Purge User"
 msgstr "Purge User"
 
-#: resources/public/include/chat.js:1463:24
+#: resources/public/include/chat.js
 msgid "Mod Lookup"
 msgstr "Mod Lookup"
 
-#: resources/public/include/chat.js:1464:24
+#: resources/public/include/chat.js
 msgid "Chat Lookup"
 msgstr "Chat Lookup"
 
-#: resources/public/include/chat.js:1536:30
+#: resources/public/include/chat.js
 msgid "Enter a reason for your report"
 msgstr "Enter a reason for your report"
 
-#: resources/public/include/chat.js:1565:26
-#: resources/public/include/chat.js:1686:18
-#: resources/public/include/chat.js:1845:22
-#: resources/public/include/chat.js:1893:22
-#: resources/public/include/chat.js:1961:22
-#: resources/public/include/chat.js:2021:22
-#: resources/public/include/lookup.js:64:91
-#: resources/public/include/user.js:73:87
-#: resources/public/admin/admin.js:334:20
+#: resources/public/include/chat.js resources/public/include/lookup.js
+#: resources/public/include/user.js resources/public/admin/admin.js
 msgid "Cancel"
 msgstr "Cancel"
 
-#: resources/public/include/chat.js:1580:34
-#: resources/public/include/lookup.js:45:30
+#: resources/public/include/chat.js resources/public/include/lookup.js
 msgid "Error sending report."
 msgstr "Error sending report."
 
-#: resources/public/include/chat.js:1585:54
+#: resources/public/include/chat.js
 msgid "Report User"
 msgstr "Report User"
 
-#: resources/public/include/chat.js:1599:34
+#: resources/public/include/chat.js
 msgid "User ignored. You can unignore from chat settings."
 msgstr "User ignored. You can unignore from chat settings."
 
-#: resources/public/include/chat.js:1601:34
+#: resources/public/include/chat.js
 msgid "Failed to ignore user. Either they\\'re already ignored, or an error occurred. If the problem persists, contact a developer."
 msgstr "Failed to ignore user. Either they\\'re already ignored, or an error occurred. If the problem persists, contact a developer."
 
-#: resources/public/include/chat.js:1629:55
+#: resources/public/include/chat.js
 msgid "Permanent"
 msgstr "Permanent"
 
-#: resources/public/include/chat.js:1629:78
+#: resources/public/include/chat.js
 msgid "Temporary"
 msgstr "Temporary"
 
-#: resources/public/include/chat.js:1656:32
+#: resources/public/include/chat.js
 msgid "Rule 3: Spam"
 msgstr "Rule 3: Spam"
 
-#: resources/public/include/chat.js:1657:32
+#: resources/public/include/chat.js
 msgid "Rule 1: Chat civility"
 msgstr "Rule 1: Chat civility"
 
-#: resources/public/include/chat.js:1658:32
+#: resources/public/include/chat.js
 msgid "Rule 2: Hate Speech"
 msgstr "Rule 2: Hate Speech"
 
-#: resources/public/include/chat.js:1659:32
+#: resources/public/include/chat.js
 msgid "Rule 5: NSFW"
 msgstr "Rule 5: NSFW"
 
-#: resources/public/include/chat.js:1660:32
-#: resources/public/include/chat.js:1738:58
-#: resources/public/include/chat.js:1759:45
+#: resources/public/include/chat.js
 msgid "Custom"
 msgstr "Custom"
 
-#: resources/public/include/chat.js:1693:33
+#: resources/public/include/chat.js
 msgid "Banning:"
 msgstr "Banning:"
 
-#: resources/public/include/chat.js:1693:50
+#: resources/public/include/chat.js
 msgid "Message:"
 msgstr "Message:"
 
-#: resources/public/include/chat.js:1695:26
+#: resources/public/include/chat.js
 msgid "Ban Length"
 msgstr "Ban Length"
 
-#: resources/public/include/chat.js:1702:28
+#: resources/public/include/chat.js
 msgid "Reason"
 msgstr "Reason"
 
-#: resources/public/include/chat.js:1707:28
+#: resources/public/include/chat.js
 msgid "Purge Messages"
 msgstr "Purge Messages"
 
-#: resources/public/include/chat.js:1711:27
+#: resources/public/include/chat.js
 msgid "Purging all messages is disabled during snip mode"
 msgstr "Purging all messages is disabled during snip mode"
 
-#: resources/public/include/chat.js:1714:79
-#: resources/public/include/user.js:174:22
-#: resources/public/admin/admin.js:185:41
-#: resources/public/admin/admin.js:187:94
+#: resources/public/include/chat.js resources/public/include/user.js
+#: resources/public/admin/admin.js
 msgid "Yes"
 msgstr "Yes"
 
-#: resources/public/include/chat.js:1715:78
-#: resources/public/include/user.js:178:22
-#: resources/public/admin/admin.js:185:53
-#: resources/public/admin/admin.js:187:106
+#: resources/public/include/chat.js resources/public/include/user.js
+#: resources/public/admin/admin.js
 msgid "No"
 msgstr "No"
 
-#: resources/public/include/chat.js:1739:63
+#: resources/public/include/chat.js
 msgid "Custom reason"
 msgstr "Custom reason"
 
-#: resources/public/include/chat.js:1739:85
-#: resources/public/include/lookup.js:59:30
+#: resources/public/include/chat.js resources/public/include/lookup.js
 msgid "Additional information (if applicable)"
 msgstr "Additional information (if applicable)"
 
-#: resources/public/include/chat.js:1764:45
+#: resources/public/include/chat.js
 msgid "Additional information:"
 msgstr "Additional information:"
 
-#: resources/public/include/chat.js:1786:34
+#: resources/public/include/chat.js
 msgid "Error occurred while chatbanning"
 msgstr "Error occurred while chatbanning"
 
-#: resources/public/include/chat.js:1790:54
+#: resources/public/include/chat.js
 msgid "Chatban"
 msgstr "Chatban"
 
-#: resources/public/include/chat.js:1810:32
+#: resources/public/include/chat.js
 msgid "Failed to delete"
 msgstr "Failed to delete"
 
-#: resources/public/include/chat.js:1821:32
-#: resources/public/include/chat.js:1863:32
+#: resources/public/include/chat.js
 msgid "ID: "
 msgstr "ID: "
 
-#: resources/public/include/chat.js:1825:32
-#: resources/public/include/chat.js:1873:32
+#: resources/public/include/chat.js
 msgid "User: "
 msgstr "User: "
 
-#: resources/public/include/chat.js:1829:32
-#: resources/public/include/chat.js:1867:32
+#: resources/public/include/chat.js
 msgid "Message: "
 msgstr "Message: "
 
-#: resources/public/include/chat.js:1833:32
+#: resources/public/include/chat.js
 msgid "Reason: "
 msgstr "Reason: "
 
-#: resources/public/include/chat.js:1850:54
+#: resources/public/include/chat.js
 msgid "Delete Message"
 msgstr "Delete Message"
 
-#: resources/public/include/chat.js:1858:106
+#: resources/public/include/chat.js
 msgid "Purge"
 msgstr "Purge"
 
-#: resources/public/include/chat.js:1879:28
+#: resources/public/include/chat.js
 msgid "Selected Message"
 msgstr "Selected Message"
 
-#: resources/public/include/chat.js:1882:30
+#: resources/public/include/chat.js
 msgid "Purge Reason"
 msgstr "Purge Reason"
 
-#: resources/public/include/chat.js:1907:34
+#: resources/public/include/chat.js
 msgid "Error sending purge."
 msgstr "Error sending purge."
 
-#: resources/public/include/chat.js:1936:98
+#: resources/public/include/chat.js
 msgid "On"
 msgstr "On"
 
-#: resources/public/include/chat.js:1949:28
+#: resources/public/include/chat.js
 msgid "Toggle Rename Request"
 msgstr "Toggle Rename Request"
 
-#: resources/public/include/chat.js:1950:27
+#: resources/public/include/chat.js
 msgid "Select one of the options below to set the current rename request state."
 msgstr "Select one of the options below to set the current rename request state."
 
-#: resources/public/include/chat.js:1975:30
-#: resources/public/include/chat.js:2034:30
+#: resources/public/include/chat.js
 msgid "An unknown error occurred. Please contact a developer"
 msgstr "An unknown error occurred. Please contact a developer"
 
-#: resources/public/include/chat.js:2001:52
+#: resources/public/include/chat.js
 msgid "New Name: "
 msgstr "New Name: "
 
-#: resources/public/include/chat.js:2011:27
+#: resources/public/include/chat.js
 msgid "Enter the new name for the user below. Please note that if you\\'re trying to change the caps, you\\'ll have to rename to something else first."
 msgstr "Enter the new name for the user below. Please note that if you\\'re trying to change the caps, you\\'ll have to rename to something else first."
 
-#: resources/public/include/chat.js:2049:54
+#: resources/public/include/chat.js
 msgid "Force Rename"
 msgstr "Force Rename"
 
-#: resources/public/include/chat.js:2088:118
+#: resources/public/include/chat.js
 msgid "You cannot use chat while canvas banned."
 msgstr "You cannot use chat while canvas banned."
 
-#: resources/public/include/lookup.js:21:32
+#: resources/public/include/lookup.js
 msgid "Sending..."
 msgstr "Sending..."
 
-#: resources/public/include/lookup.js:28:32
+#: resources/public/include/lookup.js
 msgid "You must specify the details."
 msgstr "You must specify the details."
 
-#: resources/public/include/lookup.js:33:27
+#: resources/public/include/lookup.js
 msgid "additional information:"
 msgstr "additional information:"
 
-#: resources/public/include/lookup.js:49:50
+#: resources/public/include/lookup.js
 msgid "Report Pixel"
 msgstr "Report Pixel"
 
-#: resources/public/include/lookup.js:52:32
+#: resources/public/include/lookup.js
 msgid "Rule #1: Hateful/derogatory speech or symbols"
 msgstr "Rule #1: Hateful/derogatory speech or symbols"
 
-#: resources/public/include/lookup.js:53:32
+#: resources/public/include/lookup.js
 msgid "Rule #2: Nudity, genitalia, or non-PG-13 content"
 msgstr "Rule #2: Nudity, genitalia, or non-PG-13 content"
 
-#: resources/public/include/lookup.js:54:32
+#: resources/public/include/lookup.js
 msgid "Rule #3: Multi-account"
 msgstr "Rule #3: Multi-account"
 
-#: resources/public/include/lookup.js:55:32
+#: resources/public/include/lookup.js
 msgid "Rule #4: Botting"
 msgstr "Rule #4: Botting"
 
-#: resources/public/include/lookup.js:56:52
+#: resources/public/include/lookup.js
 msgid "Other (specify below)"
 msgstr "Other (specify below)"
 
-#: resources/public/include/lookup.js:168:62
+#: resources/public/include/lookup.js
 msgid "Hide sensitive information"
 msgstr "Hide sensitive information"
 
-#: resources/public/include/lookup.js:207:120
+#: resources/public/include/lookup.js
 msgid "An error occurred, either you aren't logged in or you may be attempting to look up users too fast. Please try again in 60 seconds"
 msgstr "An error occurred, either you aren't logged in or you may be attempting to look up users too fast. Please try again in 60 seconds"
 
-#: resources/public/include/lookup.js:218:21
+#: resources/public/include/lookup.js
 msgid "Coords"
 msgstr "Coords"
 
-#: resources/public/include/lookup.js:223:21
-#: resources/public/admin/admin.js:189:16
+#: resources/public/include/lookup.js resources/public/admin/admin.js
 msgid "Username"
 msgstr "Username"
 
-#: resources/public/include/lookup.js:229:28
+#: resources/public/include/lookup.js
 msgid "View Profile"
 msgstr "View Profile"
 
-#: resources/public/include/lookup.js:239:21
+#: resources/public/include/lookup.js
 msgid "Origin"
 msgstr "Origin"
 
-#: resources/public/include/lookup.js:243:28
+#: resources/public/include/lookup.js
 msgid "Part of a nuke"
 msgstr "Part of a nuke"
 
-#: resources/public/include/lookup.js:245:28
+#: resources/public/include/lookup.js
 msgid "Placed by a staff member using placement overrides"
 msgstr "Placed by a staff member using placement overrides"
 
-#: resources/public/include/lookup.js:252:21
+#: resources/public/include/lookup.js
 msgid "Time"
 msgstr "Time"
 
-#: resources/public/include/lookup.js:263:36
+#: resources/public/include/lookup.js
 msgid "just now"
 msgstr "just now"
 
-#: resources/public/include/lookup.js:271:36
+#: resources/public/include/lookup.js
 msgid "${hoursStr}:${minuteStr}:${secsStr} ago"
 msgstr "${hoursStr}:${minuteStr}:${secsStr} ago"
 
-#: resources/public/include/lookup.js:284:21
+#: resources/public/include/lookup.js
 msgid "Discord"
 msgstr "Discord"
 
-#: resources/public/include/notifications.js:60:58
+#: resources/public/include/notifications.js
 msgid "Posted by ${notification.who}"
 msgstr "Posted by ${notification.who}"
 
-#: resources/public/include/notifications.js:63:111
+#: resources/public/include/notifications.js
 msgid "Expires ${expiry}"
 msgstr "Expires ${expiry}"
 
-#: resources/public/include/template.js:440:50
+#: resources/public/include/template.js
 msgid "There was an error getting the image"
 msgstr "There was an error getting the image"
 
-#: resources/public/include/timer.js:42:53
+#: resources/public/include/timer.js
 msgid "Your next pixel will be available in ${delay} seconds!"
 msgstr "Your next pixel will be available in ${delay} seconds!"
 
-#: resources/public/include/timer.js:87:61
+#: resources/public/include/timer.js
 msgid "Your next pixel has been available for ${alertDelay} seconds!"
 msgstr "Your next pixel has been available for ${alertDelay} seconds!"
 
-#: resources/public/include/timer.js:101:59
+#: resources/public/include/timer.js
 msgid "Your next pixel is available!"
 msgstr "Your next pixel is available!"
 
 #. theme name
-#: resources/public/include/uiHelper.js:48:19
+#: resources/public/include/uiHelper.js
 msgid "Dark"
 msgstr "Dark"
 
 #. theme name
-#: resources/public/include/uiHelper.js:54:19
+#: resources/public/include/uiHelper.js
 msgid "Darker"
 msgstr "Darker"
 
 #. theme name
-#: resources/public/include/uiHelper.js:60:19
+#: resources/public/include/uiHelper.js
 msgid "Blue"
 msgstr "Blue"
 
 #. theme name
-#: resources/public/include/uiHelper.js:66:19
+#: resources/public/include/uiHelper.js
 msgid "Purple"
 msgstr "Purple"
 
 #. theme name
-#: resources/public/include/uiHelper.js:72:19
+#: resources/public/include/uiHelper.js
 msgid "Green"
 msgstr "Green"
 
 #. theme name
-#: resources/public/include/uiHelper.js:78:19
+#: resources/public/include/uiHelper.js
 msgid "Matte"
 msgstr "Matte"
 
 #. theme name
-#: resources/public/include/uiHelper.js:84:19
+#: resources/public/include/uiHelper.js
 msgid "Terminal"
 msgstr "Terminal"
 
 #. theme name
-#: resources/public/include/uiHelper.js:90:19
+#: resources/public/include/uiHelper.js
 msgid "Red"
 msgstr "Red"
 
-#: resources/public/include/uiHelper.js:467:30
+#: resources/public/include/uiHelper.js
 msgid "Discord name updated successfully"
 msgstr "Discord name updated successfully"
 
-#: resources/public/include/uiHelper.js:474:32
+#: resources/public/include/uiHelper.js
 msgid "Couldn\\'t change discord name: "
 msgstr "Couldn\\'t change discord name: "
 
-#: resources/public/include/user.js:81:28
+#: resources/public/include/user.js
 msgid "Sign in with..."
 msgstr "Sign in with..."
 
-#: resources/public/include/user.js:94:149
+#: resources/public/include/user.js
 msgid "New Accounts Disabled"
 msgstr "New Accounts Disabled"
 
-#: resources/public/include/user.js:167:52
+#: resources/public/include/user.js
 msgid "Sign Out"
 msgstr "Sign Out"
 
-#: resources/public/include/user.js:169:27
+#: resources/public/include/user.js
 msgid "Are you sure you want to sign out?"
 msgstr "Are you sure you want to sign out?"
 
-#: resources/public/include/user.js:223:39
+#: resources/public/include/user.js
 msgid "You are permanently banned."
 msgstr "You are permanently banned."
 
-#: resources/public/include/user.js:227:39
+#: resources/public/include/user.js
 msgid "You are temporarily banned and will not be allowed to place until ${timestamp}"
 msgstr "You are temporarily banned and will not be allowed to place until ${timestamp}"
 
-#: resources/public/include/user.js:255:27
+#: resources/public/include/user.js
 msgid "If you think this was an error, please contact us using one of the links in the info tab."
 msgstr "If you think this was an error, please contact us using one of the links in the info tab."
 
-#: resources/public/include/user.js:256:27
+#: resources/public/include/user.js
 msgid "Ban reason:"
 msgstr "Ban reason:"
 
-#: resources/public/include/user.js:260:28
-#: resources/public/admin/admin.js:203:16
+#: resources/public/include/user.js resources/public/admin/admin.js
 msgid "Banned"
 msgstr "Banned"
 
-#: resources/public/include/user.js:330:23
+#: resources/public/include/user.js
 msgid "Staff have required you to change your username, this usually means your name breaks one of our rules."
 msgstr "Staff have required you to change your username, this usually means your name breaks one of our rules."
 
-#: resources/public/include/user.js:331:23
+#: resources/public/include/user.js
 msgid "If you disagree, please contact us on Discord (link in the info panel)."
 msgstr "If you disagree, please contact us on Discord (link in the info panel)."
 
-#: resources/public/include/user.js:332:27
+#: resources/public/include/user.js
 msgid "New Username:"
 msgstr "New Username:"
 
-#: resources/public/include/user.js:345:89
+#: resources/public/include/user.js
 msgid "Not now"
 msgstr "Not now"
 
-#: resources/public/include/user.js:346:86
+#: resources/public/include/user.js
 msgid "Change"
 msgstr "Change"
 
-#: resources/public/include/user.js:350:50
-#: resources/public/admin/admin.js:201:16
+#: resources/public/include/user.js resources/public/admin/admin.js
 msgid "Rename Requested"
 msgstr "Rename Requested"
 
-#: resources/public/admin/admin.js:101:38
+#: resources/public/admin/admin.js
 msgid "Something went wrong! Perhaps insufficient permissions?"
 msgstr "Something went wrong! Perhaps insufficient permissions?"
 
-#: resources/public/admin/admin.js:106:45
+#: resources/public/admin/admin.js
 msgid "Shadowban user"
 msgstr "Shadowban user"
 
-#: resources/public/admin/admin.js:106:67
+#: resources/public/admin/admin.js
 msgid "Shadowbanned user"
 msgstr "Shadowbanned user"
 
-#: resources/public/admin/admin.js:109:45
+#: resources/public/admin/admin.js
 msgid "Permaban user"
 msgstr "Permaban user"
 
-#: resources/public/admin/admin.js:109:66
+#: resources/public/admin/admin.js
 msgid "Permabanned user"
 msgstr "Permabanned user"
 
-#: resources/public/admin/admin.js:112:45
+#: resources/public/admin/admin.js
 msgid "Ban user"
 msgstr "Ban user"
 
-#: resources/public/admin/admin.js:112:61
+#: resources/public/admin/admin.js
 msgid "Banned user"
 msgstr "Banned user"
 
-#: resources/public/admin/admin.js:126:36
+#: resources/public/admin/admin.js
 msgid "Unbanned user ${username}"
 msgstr "Unbanned user ${username}"
 
 #. Context: ban type
-#: resources/public/admin/admin.js:179:27
+#: resources/public/admin/admin.js
 msgid "shadow"
 msgstr "shadow"
 
-#: resources/public/admin/admin.js:180:29
-#: resources/public/admin/admin.js:183:29
+#: resources/public/admin/admin.js
 msgid "never"
 msgstr "never"
 
-#: resources/public/admin/admin.js:182:27
+#: resources/public/admin/admin.js
 msgid "permanent"
 msgstr "permanent"
 
-#: resources/public/admin/admin.js:187:51
+#: resources/public/admin/admin.js
 msgid "Yes (permanent)"
 msgstr "Yes (permanent)"
 
-#: resources/public/admin/admin.js:194:16
-#: resources/public/admin/admin.js:454:21
+#: resources/public/admin/admin.js
 msgid "Logins"
 msgstr "Logins"
 
-#: resources/public/admin/admin.js:200:16
+#: resources/public/admin/admin.js
 msgid "All Time Pixels"
 msgstr "All Time Pixels"
 
-#: resources/public/admin/admin.js:202:16
+#: resources/public/admin/admin.js
 msgid "Discord Name"
 msgstr "Discord Name"
 
-#: resources/public/admin/admin.js:204:16
+#: resources/public/admin/admin.js
 msgid "Chatbanned"
 msgstr "Chatbanned"
 
-#: resources/public/admin/admin.js:207:27
+#: resources/public/admin/admin.js
 msgid "Ban Reason"
 msgstr "Ban Reason"
 
-#: resources/public/admin/admin.js:208:27
+#: resources/public/admin/admin.js
 msgid "Ban Expiracy"
 msgstr "Ban Expiracy"
 
-#: resources/public/admin/admin.js:211:27
+#: resources/public/admin/admin.js
 msgid "Chatban Reason"
 msgstr "Chatban Reason"
 
-#: resources/public/admin/admin.js:211:102
+#: resources/public/admin/admin.js
 msgid "(canvas ban)"
 msgstr "(canvas ban)"
 
-#: resources/public/admin/admin.js:213:97
+#: resources/public/admin/admin.js
 msgid "when canvas ban ends"
 msgstr "when canvas ban ends"
 
-#: resources/public/admin/admin.js:214:29
+#: resources/public/admin/admin.js
 msgid "Chatban Expires"
 msgstr "Chatban Expires"
 
 #. Admin check. Example: type = 'username', arg = 'pxlsuser94'
-#: resources/public/admin/admin.js:316:36
+#: resources/public/admin/admin.js
 msgid "${type} ${arg} not found."
 msgstr "${type} ${arg} not found."
 
-#: resources/public/admin/admin.js:322:50
+#: resources/public/admin/admin.js
 msgid "Unban Reason:"
 msgstr "Unban Reason:"
 
-#: resources/public/admin/admin.js:327:25
+#: resources/public/admin/admin.js
 msgid "Unbanning ${username}"
 msgstr "Unbanning ${username}"
 
-#: resources/public/admin/admin.js:449:20
+#: resources/public/admin/admin.js
 msgid "profile"
 msgstr "profile"
 
-#: resources/public/admin/admin.js:473:21
+#: resources/public/admin/admin.js
 msgid "User Agent"
 msgstr "User Agent"
 
-#: resources/public/admin/admin.js:478:21
+#: resources/public/admin/admin.js
 msgid "Send Alert"
 msgstr "Send Alert"
 
-#: resources/public/admin/admin.js:483:21
+#: resources/public/admin/admin.js
 msgid "Mod Actions"
 msgstr "Mod Actions"

--- a/po/Localization.pot
+++ b/po/Localization.pot
@@ -1,2245 +1,2245 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Pxls\n"
-"POT-Creation-Date: 2021-11-23T21:32:45.968Z\n"
+"POT-Creation-Date: 2021-12-03T07:36:36.932Z\n"
 "Language: \n"
 "Content-Type: text/plain; charset=UTF-8\n"
 
 #. Site description
-#: resources/public/pebble_templates/index.html:8:42
+#: resources/public/pebble_templates/index.html
 msgid "Place pixels with people to create art"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:56:27
+#: resources/public/pebble_templates/index.html
 msgid "Lost connection to server, reconnecting..."
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:71:76
+#: resources/public/pebble_templates/index.html
 msgid "Loading Heatmap (press <kbd>H</kbd> to cancel)"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:72:78
+#: resources/public/pebble_templates/index.html
 msgid "Loading Virginmap (press <kbd>X</kbd> to cancel)"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:80:67
+#: resources/public/pebble_templates/index.html
 msgid "Logout"
 msgstr ""
 
 #. Canvas pixel count
-#: resources/public/pebble_templates/index.html:86:38
+#: resources/public/pebble_templates/index.html
 msgid "Canvas:"
 msgstr ""
 
 #. Canvas pixel count
 #. All time pixel count
-#: resources/public/pebble_templates/index.html:86:118
-#: resources/public/pebble_templates/index.html:88:120
-#: resources/public/pebble_templates/index.html:100:51
-#: resources/public/pebble_templates/index.html:126:123
+#: resources/public/pebble_templates/index.html
+#: resources/public/pebble_templates/index.html
+#: resources/public/pebble_templates/index.html
+#: resources/public/pebble_templates/index.html
 msgid "N/A"
 msgstr ""
 
 #. All time pixel count
-#: resources/public/pebble_templates/index.html:88:38
+#: resources/public/pebble_templates/index.html
 msgid "All Time:"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:93:48
+#: resources/public/pebble_templates/index.html
 msgid "Loading online user count&hellip;"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:101:30
-#: resources/public/include/lookup.js:276:21
-#: resources/public/admin/admin.js:199:16
+#: resources/public/pebble_templates/index.html
+#: resources/public/include/lookup.js
+#: resources/public/admin/admin.js
 msgid "Pixels"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:112:54
+#: resources/public/pebble_templates/index.html
 msgid "Undo"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:114:20
+#: resources/public/pebble_templates/index.html
 msgid "You are not signed in.&nbsp;<a href=\"#\">Sign in with...</a>"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:124:28
+#: resources/public/pebble_templates/index.html
 msgid "Loading..."
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:132:14
-#: resources/public/pebble_templates/index.html:142:67
+#: resources/public/pebble_templates/index.html
+#: resources/public/pebble_templates/index.html
 msgid "Sign up"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:133:14
+#: resources/public/pebble_templates/index.html
 msgid "Pick a username"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:136:43
+#: resources/public/pebble_templates/index.html
 msgid "Username:"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:154:65
-#: resources/public/pebble_templates/profile.html:56:96
+#: resources/public/pebble_templates/index.html
+#: resources/public/pebble_templates/profile.html
 msgid "Info"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:168:66
-#: resources/public/pebble_templates/index.html:206:66
-#: resources/public/pebble_templates/index.html:761:66
-#: resources/public/pebble_templates/index.html:774:66
+#: resources/public/pebble_templates/index.html
+#: resources/public/pebble_templates/index.html
+#: resources/public/pebble_templates/index.html
+#: resources/public/pebble_templates/index.html
 msgid "Close Panel"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:170:61
+#: resources/public/pebble_templates/index.html
 msgid "Chat"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:172:45
+#: resources/public/pebble_templates/index.html
 msgid "Pings"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:173:45
-#: resources/public/pebble_templates/index.html:209:58
+#: resources/public/pebble_templates/index.html
+#: resources/public/pebble_templates/index.html
 msgid "Settings"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:186:30
+#: resources/public/pebble_templates/index.html
 msgid "Jump To Bottom"
 msgstr ""
 
 #. Open emoji picker
-#: resources/public/pebble_templates/index.html:194:49
+#: resources/public/pebble_templates/index.html
 msgid "Emoji"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:214:73
+#: resources/public/pebble_templates/index.html
 msgid "Search"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:215:56
+#: resources/public/pebble_templates/index.html
 msgid "keybinds;keys;keyboard;hotkeys"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:217:24
+#: resources/public/pebble_templates/index.html
 msgid "Keybinds"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:220:44
+#: resources/public/pebble_templates/index.html
 msgid "general"
 msgstr ""
 
 #. General settings
-#: resources/public/pebble_templates/index.html:222:28
-#: resources/public/pebble_templates/index.html:664:28
+#: resources/public/pebble_templates/index.html
+#: resources/public/pebble_templates/index.html
 msgid "General"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:223:42
+#: resources/public/pebble_templates/index.html
 msgid "move;moving;panning;drag"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:223:102
+#: resources/public/pebble_templates/index.html
 msgid "Mouse/arrows/wasd to pan"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:224:42
+#: resources/public/pebble_templates/index.html
 msgid "mousewheel;zooming"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:224:96
+#: resources/public/pebble_templates/index.html
 msgid "Scroll/pinch to zoom"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:225:42
+#: resources/public/pebble_templates/index.html
 msgid "scroll;zooming"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:225:92
+#: resources/public/pebble_templates/index.html
 msgid "<kbd>+</kbd>/<kbd>-</kbd> or <kbd>Q</kbd>/<kbd>E</kbd> to zoom"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:226:42
+#: resources/public/pebble_templates/index.html
 msgid "lookups"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:226:85
+#: resources/public/pebble_templates/index.html
 msgid "<kbd>Shift</kbd> + Click/Hold touch to lookup pixel"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:227:42
-#: resources/public/pebble_templates/index.html:489:44
+#: resources/public/pebble_templates/index.html
+#: resources/public/pebble_templates/index.html
 msgid "overlays;alignment;grid hidden;grid shown;hide grid;show grid"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:227:139
+#: resources/public/pebble_templates/index.html
 msgid "<kbd>G</kbd> to toggle grid"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:228:42
+#: resources/public/pebble_templates/index.html
 msgid "close;information shown;information hidden;info shown;info hidden;hide information;show information"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:228:177
+#: resources/public/pebble_templates/index.html
 msgid "<kbd>I</kbd> to open info"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:229:42
+#: resources/public/pebble_templates/index.html
 msgid "close;settings hidden;settings shown;hide settings;show settings"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:229:142
+#: resources/public/pebble_templates/index.html
 msgid "<kbd>T</kbd> to open settings"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:230:42
+#: resources/public/pebble_templates/index.html
 msgid "close;chat hidden;chat shown;hide chat;show chat"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:230:126
+#: resources/public/pebble_templates/index.html
 msgid "<kbd>B</kbd> to open chat"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:231:42
+#: resources/public/pebble_templates/index.html
 msgid "canvas locked;move;moving;zoom;zooming"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:231:116
+#: resources/public/pebble_templates/index.html
 msgid "<kbd>L</kbd> to toggle locking panning of the canvas"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:232:42
+#: resources/public/pebble_templates/index.html
 msgid "take screenshot;image;download;picture;canvas"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:232:123
+#: resources/public/pebble_templates/index.html
 msgid "<kbd>P</kbd> to take a snapshot"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:233:42
-#: resources/public/pebble_templates/index.html:443:44
+#: resources/public/pebble_templates/index.html
+#: resources/public/pebble_templates/index.html
 msgid "overlays;user activity;pixels placed pixels;heatmap hidden;heatmap shown;hide heatmap;show heatmap"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:233:176
+#: resources/public/pebble_templates/index.html
 msgid "<kbd>H</kbd> to toggle heatmap"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:234:42
-#: resources/public/pebble_templates/index.html:463:44
+#: resources/public/pebble_templates/index.html
+#: resources/public/pebble_templates/index.html
 msgid "overlays;user activity;pixels unplaced pixels;virginmap hidden;virginmap shown;hide virginmap;show virginmap"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:234:186
+#: resources/public/pebble_templates/index.html
 msgid "<kbd>X</kbd> to toggle virginmap"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:235:42
+#: resources/public/pebble_templates/index.html
 msgid "overlays;user activity;pixels placed pixels;wipe;clean;"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:235:133
+#: resources/public/pebble_templates/index.html
 msgid "<kbd>O</kbd> to clear heatmap"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:236:42
+#: resources/public/pebble_templates/index.html
 msgid "overlays;user activity;pixels unplaced pixels;wipe;clean;"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:236:135
+#: resources/public/pebble_templates/index.html
 msgid "<kbd>U</kbd> to clear virginmap"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:237:42
+#: resources/public/pebble_templates/index.html
 msgid "next color;previous color"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:237:103
+#: resources/public/pebble_templates/index.html
 msgid "<kbd>J</kbd>/<kbd>K</kbd> to cycle through palette colors"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:238:42
+#: resources/public/pebble_templates/index.html
 msgid "current coordinates;coords"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:238:104
+#: resources/public/pebble_templates/index.html
 msgid "<kbd>C</kbd> to copy link of moused-over coordinates"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:239:42
+#: resources/public/pebble_templates/index.html
 msgid "cancel selection"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:239:94
+#: resources/public/pebble_templates/index.html
 msgid "<kbd>ESC</kbd> to deselect current pixel"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:240:42
+#: resources/public/pebble_templates/index.html
 msgid "recenter;jump;center on template;guides;focus"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:240:123
+#: resources/public/pebble_templates/index.html
 msgid "<kbd>R</kbd> to center the board on the current template"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:243:44
+#: resources/public/pebble_templates/index.html
 msgid "templates;guides"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:244:28
-#: resources/public/pebble_templates/index.html:579:24
+#: resources/public/pebble_templates/index.html
+#: resources/public/pebble_templates/index.html
 msgid "Template"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:245:42
-#: resources/public/pebble_templates/index.html:246:42
+#: resources/public/pebble_templates/index.html
+#: resources/public/pebble_templates/index.html
 msgid "transparency"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:245:90
+#: resources/public/pebble_templates/index.html
 msgid "<kbd>Page Up</kbd> to increase opacity"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:246:90
+#: resources/public/pebble_templates/index.html
 msgid "<kbd>Page Down</kbd> to decrease opacity"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:247:42
+#: resources/public/pebble_templates/index.html
 msgid "hidden;shown;hide;show"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:247:100
+#: resources/public/pebble_templates/index.html
 msgid "<kbd>V</kbd> to toggle visibility"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:252:24
+#: resources/public/pebble_templates/index.html
 msgid "Note: These values are based on QWERTY keyboards. For other layouts, use the keys corresponding to the same position on a QWERTY keyboard."
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:256:36
+#: resources/public/pebble_templates/index.html
 msgid "ui;interface"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:258:24
+#: resources/public/pebble_templates/index.html
 msgid "UI Settings"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:262:44
+#: resources/public/pebble_templates/index.html
 msgid "themes;look;stylesheets;visuals"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:264:57
+#: resources/public/pebble_templates/index.html
 msgid "Theme:"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:266:64
+#: resources/public/pebble_templates/index.html
 msgid "Default"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:270:44
+#: resources/public/pebble_templates/index.html
 msgid "hide reticule;hide reticle;reticule shown reticle shown;reticule hidden;reticle hidden"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:273:57
+#: resources/public/pebble_templates/index.html
 msgid "Show reticule"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:276:44
+#: resources/public/pebble_templates/index.html
 msgid "hide cursor;cursor shown;cursor hidden"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:279:57
+#: resources/public/pebble_templates/index.html
 msgid "Show cursor"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:282:44
+#: resources/public/pebble_templates/index.html
 msgid "darkness filter"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:285:57
+#: resources/public/pebble_templates/index.html
 msgid "Enable color brightness"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:288:76
+#: resources/public/pebble_templates/index.html
 msgid "Warning: Known to cause fuzziness in Chrome on some Mac/Linux installs"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:291:57
+#: resources/public/pebble_templates/index.html
 msgid "Color brightness:"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:295:44
+#: resources/public/pebble_templates/index.html
 msgid "keep current selected;keep curent color;place"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:298:57
+#: resources/public/pebble_templates/index.html
 msgid "Deselect color after placing"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:301:44
+#: resources/public/pebble_templates/index.html
 msgid "mousewheel;palette scrolling"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:304:57
+#: resources/public/pebble_templates/index.html
 msgid "Enable scrolling on the palette to switch colors"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:306:68
+#: resources/public/pebble_templates/index.html
 msgid "reverse scrolling;mousewheel;palette scrolling;enable scrolling on the palette to switch colors"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:309:61
+#: resources/public/pebble_templates/index.html
 msgid "Invert scroll direction"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:313:44
+#: resources/public/pebble_templates/index.html
 msgid "indexed colors;palette indicies"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:316:57
+#: resources/public/pebble_templates/index.html
 msgid "Add numbers to palette entries"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:319:44
+#: resources/public/pebble_templates/index.html
 msgid "scrollbar;palette scrolling"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:322:57
+#: resources/public/pebble_templates/index.html
 msgid "Enable thin scrollbar"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:325:44
+#: resources/public/pebble_templates/index.html
 msgid "scrollbar;palette scrolling;palette stack"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:328:57
+#: resources/public/pebble_templates/index.html
 msgid "Enable palette stacking"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:331:44
+#: resources/public/pebble_templates/index.html
 msgid "floating bubble location"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:333:57
+#: resources/public/pebble_templates/index.html
 msgid "Bubble position:"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:335:61
+#: resources/public/pebble_templates/index.html
 msgid "Top left"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:336:62
+#: resources/public/pebble_templates/index.html
 msgid "Top right"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:337:73
+#: resources/public/pebble_templates/index.html
 msgid "Bottom left"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:338:65
+#: resources/public/pebble_templates/index.html
 msgid "Bottom right"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:342:44
+#: resources/public/pebble_templates/index.html
 msgid "broken;offset workaround"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:345:57
+#: resources/public/pebble_templates/index.html
 msgid "Attempt to fix canvas displacement bug in Chrome 78+"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:351:36
+#: resources/public/pebble_templates/index.html
 msgid "chat;message;ping sound"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:353:24
+#: resources/public/pebble_templates/index.html
 msgid "Chat Settings"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:356:44
+#: resources/public/pebble_templates/index.html
 msgid "username;color;colour"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:359:57
+#: resources/public/pebble_templates/index.html
 msgid "Username Color:"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:365:44
+#: resources/public/pebble_templates/index.html
 msgid "chat message;chat ui"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:366:28
+#: resources/public/pebble_templates/index.html
 msgid "Interface"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:367:44
+#: resources/public/pebble_templates/index.html
 msgid "chat size;chat font"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:369:57
+#: resources/public/pebble_templates/index.html
 msgid "Font Size:"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:373:44
+#: resources/public/pebble_templates/index.html
 msgid "time;timestamps"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:376:57
+#: resources/public/pebble_templates/index.html
 msgid "24 Hour Timestamps"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:379:44
+#: resources/public/pebble_templates/index.html
 msgid "badges;pixel count;pixels placed"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:382:57
+#: resources/public/pebble_templates/index.html
 msgid "Show pixel-placed badges"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:385:44
+#: resources/public/pebble_templates/index.html
 msgid "badges;factions"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:388:57
+#: resources/public/pebble_templates/index.html
 msgid "Show faction tags"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:391:44
+#: resources/public/pebble_templates/index.html
 msgid "template urls;template links;template name"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:394:57
+#: resources/public/pebble_templates/index.html
 msgid "Replace template titles with URLs in chat where applicable"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:397:44
+#: resources/public/pebble_templates/index.html
 msgid "chat orientation;chat position"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:400:57
+#: resources/public/pebble_templates/index.html
 msgid "Enable horizontal chat"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:403:44
+#: resources/public/pebble_templates/index.html
 msgid "banner;animation"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:406:57
+#: resources/public/pebble_templates/index.html
 msgid "Enable the rotating banner under chat"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:409:44
+#: resources/public/pebble_templates/index.html
 msgid "max;messages;truncate"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:411:57
+#: resources/public/pebble_templates/index.html
 msgid "Maximum amount of chat messages:"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:415:44
+#: resources/public/pebble_templates/index.html
 msgid "link;url;behaviour"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:417:57
+#: resources/public/pebble_templates/index.html
 msgid "Default internal link action click:"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:422:44
+#: resources/public/pebble_templates/index.html
 msgid "ignored;ignores;unignore;blocked;blocking;unblock"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:423:28
+#: resources/public/pebble_templates/index.html
 msgid "Ignores"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:424:44
+#: resources/public/pebble_templates/index.html
 msgid "unignore;unblock"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:429:85
+#: resources/public/pebble_templates/index.html
 msgid "Unignore"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:436:36
+#: resources/public/pebble_templates/index.html
 msgid "overlays;virginmap;heatmap;grid"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:438:24
+#: resources/public/pebble_templates/index.html
 msgid "Overlay Settings"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:441:44
+#: resources/public/pebble_templates/index.html
 msgid "heatmap;heatmap opacity;clear heatmap"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:442:28
+#: resources/public/pebble_templates/index.html
 msgid "Heatmap"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:446:57
+#: resources/public/pebble_templates/index.html
 msgid "Turn on heatmap"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:448:70
+#: resources/public/pebble_templates/index.html
 msgid "(toggle with <kbd>H</kbd>)"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:450:44
+#: resources/public/pebble_templates/index.html
 msgid "overlays;activity;pixels placed pixels;wipe;clean"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:451:71
+#: resources/public/pebble_templates/index.html
 msgid "Clear heatmap"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:452:51
+#: resources/public/pebble_templates/index.html
 msgid "(hotkey: <kbd>O</kbd>)"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:454:44
+#: resources/public/pebble_templates/index.html
 msgid "overlays;user activity;pixels placed pixels;transparency"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:456:57
+#: resources/public/pebble_templates/index.html
 msgid "Heatmap background opacity:"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:461:44
+#: resources/public/pebble_templates/index.html
 msgid "virginmap;virginmap opacity;clear virginmap"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:462:28
+#: resources/public/pebble_templates/index.html
 msgid "Virginmap"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:466:57
+#: resources/public/pebble_templates/index.html
 msgid "Turn on virginmap"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:468:72
+#: resources/public/pebble_templates/index.html
 msgid "(toggle with <kbd>X</kbd>)"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:470:44
+#: resources/public/pebble_templates/index.html
 msgid "overlays;user activity;pixels unplaced pixels;transparency"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:472:57
+#: resources/public/pebble_templates/index.html
 msgid "Virginmap background opacity:"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:476:44
+#: resources/public/pebble_templates/index.html
 msgid "overlays;activity;pixels unplaced pixels;wipe;clean"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:477:71
+#: resources/public/pebble_templates/index.html
 msgid "Clear virginmap"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:478:51
+#: resources/public/pebble_templates/index.html
 msgid "(hotkey: <kbd>U</kbd>)"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:483:57
+#: resources/public/pebble_templates/index.html
 msgid "Layer template underneath heatmap"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:487:44
+#: resources/public/pebble_templates/index.html
 msgid "grid;toggle grid"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:488:28
+#: resources/public/pebble_templates/index.html
 msgid "Grid"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:492:57
+#: resources/public/pebble_templates/index.html
 msgid "Turn on grid"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:494:67
+#: resources/public/pebble_templates/index.html
 msgid "(toggle with <kbd>G</kbd>)"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:499:36
+#: resources/public/pebble_templates/index.html
 msgid "controls;zooming;panning;movement"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:501:24
+#: resources/public/pebble_templates/index.html
 msgid "Control Settings"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:504:44
+#: resources/public/pebble_templates/index.html
 msgid "zooming;scrolling;scale;scaling"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:505:28
+#: resources/public/pebble_templates/index.html
 msgid "Zooming"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:506:44
+#: resources/public/pebble_templates/index.html
 msgid "scrolling sensitivity;zooming sensitivity;mousewheel sensitivity"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:508:57
+#: resources/public/pebble_templates/index.html
 msgid "Zoom sensitivity:"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:512:44
+#: resources/public/pebble_templates/index.html
 msgid "zooming limit;scrolling limit;mousewheel;zooming minimum;zooming maximum"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:514:57
+#: resources/public/pebble_templates/index.html
 msgid "Minimum scale:"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:518:57
+#: resources/public/pebble_templates/index.html
 msgid "Maximum scale:"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:522:44
+#: resources/public/pebble_templates/index.html
 msgid "rounding;zooming;scrolling;mousewheel;integer;decimal"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:525:57
+#: resources/public/pebble_templates/index.html
 msgid "Round zoom values to nearest whole number"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:529:44
+#: resources/public/pebble_templates/index.html
 msgid "controls;miscellaneous"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:534:57
+#: resources/public/pebble_templates/index.html
 msgid "Lock the canvas (disallow canvas drag/zoom with mouse/fingers)"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:537:44
+#: resources/public/pebble_templates/index.html
 msgid "MMB picker;mouse picker;selection;palette picker"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:540:57
+#: resources/public/pebble_templates/index.html
 msgid "Enable middle mouse button selecting color from board"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:543:44
+#: resources/public/pebble_templates/index.html
 msgid "right click action"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:545:57
+#: resources/public/pebble_templates/index.html
 msgid "Right-click action:"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:547:60
+#: resources/public/pebble_templates/index.html
 msgid "Nothing"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:548:58
+#: resources/public/pebble_templates/index.html
 msgid "Clear color"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:549:57
+#: resources/public/pebble_templates/index.html
 msgid "Copy color"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:550:59
+#: resources/public/pebble_templates/index.html
 msgid "Lookup"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:551:64
+#: resources/public/pebble_templates/index.html
 msgid "Clear color + Lookup"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:558:36
+#: resources/public/pebble_templates/index.html
 msgid "snapshots;screenshot;download;picture;canvas"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:560:24
+#: resources/public/pebble_templates/index.html
 msgid "Snapshot Settings"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:563:44
+#: resources/public/pebble_templates/index.html
 msgid "screenshot;snapshot;download;board;canvas"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:564:44
+#: resources/public/pebble_templates/index.html
 msgid "take screenshot;image;download format;picture;canvas;board"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:566:57
+#: resources/public/pebble_templates/index.html
 msgid "Snapshot image format:"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:568:71
+#: resources/public/pebble_templates/index.html
 msgid "PNG"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:569:63
+#: resources/public/pebble_templates/index.html
 msgid "JPEG"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:570:63
+#: resources/public/pebble_templates/index.html
 msgid "WEBP (Chrome only)"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:577:36
+#: resources/public/pebble_templates/index.html
 msgid "templates;overlays;guides"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:582:44
+#: resources/public/pebble_templates/index.html
 msgid "templates;overlays;image;pixel art"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:583:44
+#: resources/public/pebble_templates/index.html
 msgid "template enabled;template disabled;show template;hide template;template shown;template hidden"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:586:57
+#: resources/public/pebble_templates/index.html
 msgid "Use template"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:589:27
+#: resources/public/pebble_templates/index.html
 msgid "Hold down <kbd>Ctrl</kbd> (or <kbd>Option</kbd> on mac) to drag the template around"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:590:44
+#: resources/public/pebble_templates/index.html
 msgid "template title;template name;tab name;tab title;title="
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:592:57
+#: resources/public/pebble_templates/index.html
 msgid "Title:"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:596:44
+#: resources/public/pebble_templates/index.html
 msgid "template location source;template source URL;template URL;template="
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:598:57
+#: resources/public/pebble_templates/index.html
 msgid "URL:"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:603:44
+#: resources/public/pebble_templates/index.html
 msgid "template position;template x;template y;template location; template vertical; template horizontal;ox=;oy="
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:605:57
+#: resources/public/pebble_templates/index.html
 msgid "Horizontal position:"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:609:57
+#: resources/public/pebble_templates/index.html
 msgid "Vertical position:"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:613:44
+#: resources/public/pebble_templates/index.html
 msgid "template width;tw="
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:615:57
+#: resources/public/pebble_templates/index.html
 msgid "Width:"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:618:82
-#: resources/public/pebble_templates/index.html:688:79
+#: resources/public/pebble_templates/index.html
+#: resources/public/pebble_templates/index.html
 msgid "Reset"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:620:44
+#: resources/public/pebble_templates/index.html
 msgid "template style;custom template"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:622:57
+#: resources/public/pebble_templates/index.html
 msgid "Style:"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:624:53
+#: resources/public/pebble_templates/index.html
 msgid "Use Source Style"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:625:239
+#: resources/public/pebble_templates/index.html
 msgid "Dotted (Small, 1:2)"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:626:271
+#: resources/public/pebble_templates/index.html
 msgid "Dotted (Big, 2:2)"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:627:1803
+#: resources/public/pebble_templates/index.html
 msgid "Numbers"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:628:85
+#: resources/public/pebble_templates/index.html
 msgid "Custom…"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:632:44
+#: resources/public/pebble_templates/index.html
 msgid "template style source;template style URL;custom style URL;custom template"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:634:57
+#: resources/public/pebble_templates/index.html
 msgid "Custom style URL:"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:639:44
+#: resources/public/pebble_templates/index.html
 msgid "template conversion;template palette conversion;convert to palette"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:641:57
+#: resources/public/pebble_templates/index.html
 msgid "Color Conversion Mode:"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:643:64
+#: resources/public/pebble_templates/index.html
 msgid "Unconverted"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:644:66
+#: resources/public/pebble_templates/index.html
 msgid "Nearest Custom"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:648:44
+#: resources/public/pebble_templates/index.html
 msgid "template transparency;template opacity;oo="
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:650:57
+#: resources/public/pebble_templates/index.html
 msgid "Opacity:"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:658:36
+#: resources/public/pebble_templates/index.html
 msgid "sound;notification;alert;notify;ping"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:660:24
+#: resources/public/pebble_templates/index.html
 msgid "Sound and Notification Settings"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:665:44
+#: resources/public/pebble_templates/index.html
 msgid "audio;mute;noise;volume"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:668:57
+#: resources/public/pebble_templates/index.html
 msgid "Enable sound"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:671:44
+#: resources/public/pebble_templates/index.html
 msgid "notifs;notify;pixel notification"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:674:57
+#: resources/public/pebble_templates/index.html
 msgid "Enable pixel available notification"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:678:44
+#: resources/public/pebble_templates/index.html
 msgid "notification;pixel ready;alert"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:679:28
+#: resources/public/pebble_templates/index.html
 msgid "Pixel Ready Notification"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:680:44
+#: resources/public/pebble_templates/index.html
 msgid "alert source;notify url;notify source;notification url;notification source"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:682:57
+#: resources/public/pebble_templates/index.html
 msgid "Alert URL:"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:686:85
+#: resources/public/pebble_templates/index.html
 msgid "Update"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:687:83
+#: resources/public/pebble_templates/index.html
 msgid "Test"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:691:44
+#: resources/public/pebble_templates/index.html
 msgid "sound level;audio level;mute audio;mute sound"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:693:57
+#: resources/public/pebble_templates/index.html
 msgid "Volume:"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:698:44
+#: resources/public/pebble_templates/index.html
 msgid "alert forewarning;alert delay; notification delay; notification forewarning"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:700:57
+#: resources/public/pebble_templates/index.html
 msgid "Delay (seconds):"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:705:44
+#: resources/public/pebble_templates/index.html
 msgid "chat mentions;chat pings;chat sound"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:706:28
+#: resources/public/pebble_templates/index.html
 msgid "Chat Pings"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:710:57
+#: resources/public/pebble_templates/index.html
 msgid "Enable pings"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:713:44
+#: resources/public/pebble_templates/index.html
 msgid "mention sound"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:715:57
+#: resources/public/pebble_templates/index.html
 msgid "Play sound on ping:"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:717:56
-#: resources/public/include/chat.js:1937:100
+#: resources/public/pebble_templates/index.html
+#: resources/public/include/chat.js
 msgid "Off"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:718:61
+#: resources/public/pebble_templates/index.html
 msgid "Only when necessary"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:719:59
+#: resources/public/pebble_templates/index.html
 msgid "Always"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:723:44
+#: resources/public/pebble_templates/index.html
 msgid "mention sound volume"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:725:57
+#: resources/public/pebble_templates/index.html
 msgid "Ping sound volume:"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:733:36
+#: resources/public/pebble_templates/index.html
 msgid "personal account"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:735:24
+#: resources/public/pebble_templates/index.html
 msgid "Account Settings"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:741:57
+#: resources/public/pebble_templates/index.html
 msgid "Public Discord name:"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:745:83
-#: resources/public/include/chat.js:1939:92
-#: resources/public/include/chat.js:2003:92
+#: resources/public/pebble_templates/index.html
+#: resources/public/include/chat.js
+#: resources/public/include/chat.js
 msgid "Set"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:746:86
+#: resources/public/pebble_templates/index.html
 msgid "Remove"
 msgstr ""
 
 #. FAQ panel
-#: resources/public/pebble_templates/index.html:759:65
+#: resources/public/pebble_templates/index.html
 msgid "Help"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:772:54
+#: resources/public/pebble_templates/index.html
 msgid "Notifications"
 msgstr ""
 
-#: resources/public/pebble_templates/faq.html:3:16
+#: resources/public/pebble_templates/faq.html
 msgid "FAQ"
 msgstr ""
 
-#: resources/public/pebble_templates/faq.html:7:20
+#: resources/public/pebble_templates/faq.html
 msgid "Why is the cooldown as long as it is?"
 msgstr ""
 
-#: resources/public/pebble_templates/faq.html:8:20
+#: resources/public/pebble_templates/faq.html
 msgid "The time it takes to get a pixel is dynamic, and changes based on how many people are online. The cooldown time is longer when more users are online."
 msgstr ""
 
-#: resources/public/pebble_templates/faq.html:9:20
+#: resources/public/pebble_templates/faq.html
 msgid "Why does it say 0/6 pixels?"
 msgstr ""
 
-#: resources/public/pebble_templates/faq.html:10:20
+#: resources/public/pebble_templates/faq.html
 msgid "This means that you are waiting for your next pixel. When you place a pixel, there is a cooldown for when you can place the next one. Over time, you can gain up to 6 \"stacked\" pixels to place at once."
 msgstr ""
 
-#: resources/public/pebble_templates/faq.html:11:20
+#: resources/public/pebble_templates/faq.html
 msgid "Why does it take so long to \"stack\" pixels?"
 msgstr ""
 
-#: resources/public/pebble_templates/faq.html:12:20
+#: resources/public/pebble_templates/faq.html
 msgid "This is by design. It is better to place a pixel as soon as you get one. Pixel \"stacking\" is meant to give you a bump if you go AFK for a bit. It takes around 40 minutes to get a full 6/6 pixels, but it only takes around 3 minutes to place 6 pixels if you place them as soon as possible."
 msgstr ""
 
-#: resources/public/pebble_templates/faq.html:13:20
+#: resources/public/pebble_templates/faq.html
 msgid "How do I appeal a ban?"
 msgstr ""
 
-#: resources/public/pebble_templates/faq.html:14:20
+#: resources/public/pebble_templates/faq.html
 msgid "Contact us on <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord</a> or send an appeal to our <a href=\"https://pxls.space/appeal\" target=\"_blank\">Google form</a> after reading the rules in the site's info panel."
 msgstr ""
 
-#: resources/public/pebble_templates/faq.html:15:20
+#: resources/public/pebble_templates/faq.html
 msgid "How do I make a template?"
 msgstr ""
 
-#: resources/public/pebble_templates/faq.html:16:20
+#: resources/public/pebble_templates/faq.html
 msgid "A template is an image link that is posted in the template textbox in the settings panel so you can place over it on the canvas. You may use a regular image link to your pixel art, but many people use the 3rd party tool <a href=\"https://pxlsfiddle.com\" target=\"_blank\">PxlsFiddle</a> to turn pixel art into a fancier link. If you need to make pixel art yourself, you can use <a href=\"https://www.piskelapp.com/p/create\" target=\"_blank\">Piskel</a> to create art to put into PxlsFiddle."
 msgstr ""
 
-#: resources/public/pebble_templates/faq.html:17:20
+#: resources/public/pebble_templates/faq.html
 msgid "How do I move a template?"
 msgstr ""
 
-#: resources/public/pebble_templates/faq.html:18:20
+#: resources/public/pebble_templates/faq.html
 msgid "Hold <kbd>CTRL</kbd> (or <kbd>OPTION</kbd> on macOS) and click and drag to move it around. On mobile, you can tap and hold where you want to move the template and click \"Move Template Here\" in the pop-up."
 msgstr ""
 
-#: resources/public/pebble_templates/faq.html:19:20
+#: resources/public/pebble_templates/faq.html
 msgid "Does the canvas reset? When?"
 msgstr ""
 
-#: resources/public/pebble_templates/faq.html:20:20
+#: resources/public/pebble_templates/faq.html
 msgid "Yes. The canvas resets when it is completely full. A reset date is not usually decided until the canvas is full, but the average canvas life-span is around 1 month. Updates are posted in our <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a> when a reset date is set."
 msgstr ""
 
-#: resources/public/pebble_templates/faq.html:21:20
+#: resources/public/pebble_templates/faq.html
 msgid "Where can I see the past canvases?"
 msgstr ""
 
-#: resources/public/pebble_templates/faq.html:22:20
+#: resources/public/pebble_templates/faq.html
 msgid "The past canvases are featured on our <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a>, or the 3rd party website <a href=\"https://pxlsfiddle.com\" target=\"_blank\">PxlsFiddle</a>, which records timelapses and a lot of useful information on each canvas."
 msgstr ""
 
-#: resources/public/pebble_templates/faq.html:23:20
+#: resources/public/pebble_templates/faq.html
 msgid "How do I see who placed a pixel?"
 msgstr ""
 
-#: resources/public/pebble_templates/faq.html:24:20
+#: resources/public/pebble_templates/faq.html
 msgid "By shift-clicking (or tap and hold on mobile) a pixel, you can see who placed a pixel, how many pixels they have placed, and when they placed it."
 msgstr ""
 
-#: resources/public/pebble_templates/faq.html:25:20
+#: resources/public/pebble_templates/faq.html
 msgid "How do I report someone?"
 msgstr ""
 
-#: resources/public/pebble_templates/faq.html:26:20
+#: resources/public/pebble_templates/faq.html
 msgid "Shift-click (or tap and hold on mobile) on a pixel, and click the Report button."
 msgstr ""
 
-#: resources/public/pebble_templates/faq.html:27:20
+#: resources/public/pebble_templates/faq.html
 msgid "How do I change the color of my name in the chat?"
 msgstr ""
 
-#: resources/public/pebble_templates/faq.html:28:20
+#: resources/public/pebble_templates/faq.html
 msgid "There is a \"Username Color\" option near the bottom of the settings panel."
 msgstr ""
 
-#: resources/public/pebble_templates/faq.html:29:20
+#: resources/public/pebble_templates/faq.html
 msgid "What is a \"virginmap\"?"
 msgstr ""
 
-#: resources/public/pebble_templates/faq.html:30:20
+#: resources/public/pebble_templates/faq.html
 msgid "The virginmap shows which pixels have not yet been placed on (or “virgin” pixels)."
 msgstr ""
 
-#: resources/public/pebble_templates/faq.html:31:20
+#: resources/public/pebble_templates/faq.html
 msgid "How do I report bugs?"
 msgstr ""
 
-#: resources/public/pebble_templates/faq.html:32:20
+#: resources/public/pebble_templates/faq.html
 msgid "Submit bugs to the #dev-and-bugs channel in the <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a>. If you have found an exploit, please message one of the staff members privately (through DMs)."
 msgstr ""
 
-#: resources/public/pebble_templates/faq.html:33:20
+#: resources/public/pebble_templates/faq.html
 msgid "How do I get more info or contact staff?"
 msgstr ""
 
-#: resources/public/pebble_templates/faq.html:34:20
+#: resources/public/pebble_templates/faq.html
 msgid "Check the info panel (the icon on the top left) for more details and links, or join our <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a>, where a staff member will gladly respond."
 msgstr ""
 
-#: resources/public/pebble_templates/info.html:3:10
+#: resources/public/pebble_templates/info.html
 msgid "Welcome!"
 msgstr ""
 
-#: resources/public/pebble_templates/info.html:6:9
+#: resources/public/pebble_templates/info.html
 msgid "Welcome to pxls.space! Pxls is a multiplayer online collaborative canvas that allows you to create anything you can imagine, one pixel at a time. Join hundreds of other players in the Pxls community and create amazing works of art together as a team, or solo."
 msgstr ""
 
-#: resources/public/pebble_templates/info.html:7:9
+#: resources/public/pebble_templates/info.html
 msgid "The best place to reach staff and fellow community is in the discord!"
 msgstr ""
 
-#: resources/public/pebble_templates/info.html:8:9
+#: resources/public/pebble_templates/info.html
 msgid "Check out our social media pages, and please take the time to read the rules below. Have fun creating (or changing) art!"
 msgstr ""
 
-#: resources/public/pebble_templates/info.html:13:27
+#: resources/public/pebble_templates/info.html
 msgid "Canvas Rules"
 msgstr ""
 
-#: resources/public/pebble_templates/info.html:16:9
+#: resources/public/pebble_templates/info.html
 msgid "We pride ourselves on trying to keep an open canvas for all free from outside interference on our end, and especially censorship. However, for the good of the community and on accounts of our own beliefs, please acknowledge and obey the following guidelines:"
 msgstr ""
 
-#: resources/public/pebble_templates/info.html:18:11
+#: resources/public/pebble_templates/info.html
 msgid "No hateful imagery or derogatory speech. This includes but is not limited to words such as <i>faggot</i>, <i>nigger</i>, etc; as well as the Swastika, Hammer and Sickle, and any symbols of terrorism."
 msgstr ""
 
-#: resources/public/pebble_templates/info.html:19:11
+#: resources/public/pebble_templates/info.html
 msgid "No NSFW or NSFL content."
 msgstr ""
 
-#: resources/public/pebble_templates/info.html:21:13
+#: resources/public/pebble_templates/info.html
 msgid "No nudity or otherwise sexually explicit content"
 msgstr ""
 
-#: resources/public/pebble_templates/info.html:23:15
+#: resources/public/pebble_templates/info.html
 msgid "No female-presenting nipples/bare breasts, genitalia, sexual fluids"
 msgstr ""
 
-#: resources/public/pebble_templates/info.html:26:13
+#: resources/public/pebble_templates/info.html
 msgid "No sexual imagery/erotica"
 msgstr ""
 
-#: resources/public/pebble_templates/info.html:27:13
+#: resources/public/pebble_templates/info.html
 msgid "No excessive blood or otherwise obscene/shocking content"
 msgstr ""
 
-#: resources/public/pebble_templates/info.html:30:11
+#: resources/public/pebble_templates/info.html
 msgid "No more than <b>one</b> account per user, no exceptions. Multiple account users will be banned from creating art on the canvas."
 msgstr ""
 
-#: resources/public/pebble_templates/info.html:31:11
+#: resources/public/pebble_templates/info.html
 msgid "No auto-placement tools of any kind, you must place the pixels manually."
 msgstr ""
 
-#: resources/public/pebble_templates/info.html:32:11
+#: resources/public/pebble_templates/info.html
 msgid "Do not abuse site functionality, such as reports or lookups. (e.g. automated reporting/lookups, etc.)"
 msgstr ""
 
-#: resources/public/pebble_templates/info.html:33:11
+#: resources/public/pebble_templates/info.html
 msgid "Any automated aggregation of data from user lookups is not allowed, and will result in a ban."
 msgstr ""
 
-#: resources/public/pebble_templates/info.html:34:11
-#: resources/public/pebble_templates/info.html:62:11
+#: resources/public/pebble_templates/info.html
+#: resources/public/pebble_templates/info.html
 msgid "Staff have final say in any rule disputes"
 msgstr ""
 
-#: resources/public/pebble_templates/info.html:35:12
-#: resources/public/pebble_templates/info.html:64:13
+#: resources/public/pebble_templates/info.html
+#: resources/public/pebble_templates/info.html
 msgid "If you feel a moderator has acted inappropriately, please report it to an administrator."
 msgstr ""
 
-#: resources/public/pebble_templates/info.html:38:9
+#: resources/public/pebble_templates/info.html
 msgid "If you believe you have been falsely banned you may contact a moderator or administrator."
 msgstr ""
 
-#: resources/public/pebble_templates/info.html:43:27
+#: resources/public/pebble_templates/info.html
 msgid "Chat Rules"
 msgstr ""
 
-#: resources/public/pebble_templates/info.html:47:11
+#: resources/public/pebble_templates/info.html
 msgid "Keep chat civil. No harassment or homophobic/transphobic/disablist language."
 msgstr ""
 
-#: resources/public/pebble_templates/info.html:48:11
+#: resources/public/pebble_templates/info.html
 msgid "No hate speech. This includes emoji/symbols/ASCII art."
 msgstr ""
 
-#: resources/public/pebble_templates/info.html:50:13
+#: resources/public/pebble_templates/info.html
 msgid "Normal swearing/etc is allowed"
 msgstr ""
 
-#: resources/public/pebble_templates/info.html:53:11
+#: resources/public/pebble_templates/info.html
 msgid "No spamming"
 msgstr ""
 
-#: resources/public/pebble_templates/info.html:55:13
+#: resources/public/pebble_templates/info.html
 msgid "This includes excessive ASCII art/emojis/symbols/whitespace"
 msgstr ""
 
-#: resources/public/pebble_templates/info.html:58:11
+#: resources/public/pebble_templates/info.html
 msgid "No \"copy pasta\"s"
 msgstr ""
 
-#: resources/public/pebble_templates/info.html:59:11
+#: resources/public/pebble_templates/info.html
 msgid "No links to sites that actively break the canvas or chat rules (e.g. porn sites)"
 msgstr ""
 
-#: resources/public/pebble_templates/info.html:60:11
+#: resources/public/pebble_templates/info.html
 msgid "No symbology which break the canvas or chat rules (e.g. NSFW ASCII art)"
 msgstr ""
 
-#: resources/public/pebble_templates/info.html:61:16
+#: resources/public/pebble_templates/info.html
 msgid "No personal information"
 msgstr ""
 
-#: resources/public/pebble_templates/info.html:72:10
+#: resources/public/pebble_templates/info.html
 msgid "Links"
 msgstr ""
 
-#: resources/public/pebble_templates/info.html:76:64
+#: resources/public/pebble_templates/info.html
 msgid "Discord (main hub)"
 msgstr ""
 
-#: resources/public/pebble_templates/info.html:77:68
+#: resources/public/pebble_templates/info.html
 msgid "Subreddit"
 msgstr ""
 
-#: resources/public/pebble_templates/info.html:78:68
+#: resources/public/pebble_templates/info.html
 msgid "Twitter"
 msgstr ""
 
-#: resources/public/pebble_templates/info.html:79:66
+#: resources/public/pebble_templates/info.html
 msgid "GitHub"
 msgstr ""
 
 #. link to piskelapp.com
-#: resources/public/pebble_templates/info.html:81:71
+#: resources/public/pebble_templates/info.html
 msgid "Single-player mode"
 msgstr ""
 
-#: resources/public/pebble_templates/info.html:84:62
+#: resources/public/pebble_templates/info.html
 msgid "Statistics"
 msgstr ""
 
-#: resources/public/pebble_templates/info.html:85:64
+#: resources/public/pebble_templates/info.html
 msgid "Profile (user info, factions, etc.)"
 msgstr ""
 
 #. link to pxlsfiddle.com
-#: resources/public/pebble_templates/info.html:87:68
+#: resources/public/pebble_templates/info.html
 msgid "Template generator, archives, timelapses, and other utilities"
 msgstr ""
 
 #. link to pxlsfiddle.com
-#: resources/public/pebble_templates/info.html:87:165
+#: resources/public/pebble_templates/info.html
 msgid "PxlsFiddle (templates, archives, etc.)"
 msgstr ""
 
-#: resources/public/pebble_templates/info.html:93:10
+#: resources/public/pebble_templates/info.html
 msgid "Donate"
 msgstr ""
 
-#: resources/public/pebble_templates/info.html:96:9
+#: resources/public/pebble_templates/info.html
 msgid "Donations are not accepted at this time, but this panel will be updated when they're open again!"
 msgstr ""
 
 #. eg "Alice's profile". Double singlequote is a java thing - needed if a replacement (such as this) contains a singlequote.
-#: resources/public/pebble_templates/profile.html:31:66
-#: resources/public/pebble_templates/profile.html:50:131
+#: resources/public/pebble_templates/profile.html
+#: resources/public/pebble_templates/profile.html
 msgid "{0}''s Profile"
 msgstr ""
 
-#: resources/public/pebble_templates/profile.html:41:84
-#: resources/public/pebble_templates/40x.html:28:84
-#: resources/public/pebble_templates/40x.html:45:100
-#: resources/public/pebble_templates/40x.html:62:100
+#: resources/public/pebble_templates/profile.html
+#: resources/public/pebble_templates/40x.html
+#: resources/public/pebble_templates/40x.html
+#: resources/public/pebble_templates/40x.html
 msgid "My Profile"
 msgstr ""
 
-#: resources/public/pebble_templates/profile.html:42:85
-#: resources/public/pebble_templates/40x.html:29:85
+#: resources/public/pebble_templates/profile.html
+#: resources/public/pebble_templates/40x.html
 msgid "My Factions"
 msgstr ""
 
-#: resources/public/pebble_templates/profile.html:60:93
-#: resources/public/pebble_templates/profile.html:126:56
+#: resources/public/pebble_templates/profile.html
+#: resources/public/pebble_templates/profile.html
 msgid "Reports"
 msgstr ""
 
-#: resources/public/pebble_templates/profile.html:63:94
+#: resources/public/pebble_templates/profile.html
 msgid "Factions"
 msgstr ""
 
-#: resources/public/pebble_templates/profile.html:71:68
+#: resources/public/pebble_templates/profile.html
 msgid "You must be logged in to view your profile."
 msgstr ""
 
-#: resources/public/pebble_templates/profile.html:77:72
+#: resources/public/pebble_templates/profile.html
 msgid "Registration Date"
 msgstr ""
 
-#: resources/public/pebble_templates/profile.html:82:72
-#: resources/public/include/lookup.js:280:21
+#: resources/public/pebble_templates/profile.html
+#: resources/public/include/lookup.js
 msgid "Alltime Pixels"
 msgstr ""
 
-#: resources/public/pebble_templates/profile.html:86:72
+#: resources/public/pebble_templates/profile.html
 msgid "Current Canvas Pixels"
 msgstr ""
 
-#: resources/public/pebble_templates/profile.html:91:72
+#: resources/public/pebble_templates/profile.html
 msgid "Discord Tag"
 msgstr ""
 
-#: resources/public/pebble_templates/profile.html:95:72
-#: resources/public/include/lookup.js:235:21
+#: resources/public/pebble_templates/profile.html
+#: resources/public/include/lookup.js
 msgid "Faction"
 msgstr ""
 
-#: resources/public/pebble_templates/profile.html:96:259
+#: resources/public/pebble_templates/profile.html
 msgid "None"
 msgstr ""
 
-#: resources/public/pebble_templates/profile.html:99:72
-#: resources/public/admin/admin.js:198:16
+#: resources/public/pebble_templates/profile.html
+#: resources/public/admin/admin.js
 msgid "Roles"
 msgstr ""
 
-#: resources/public/pebble_templates/profile.html:104:72
+#: resources/public/pebble_templates/profile.html
 msgid "Canvas Ban Expiry"
 msgstr ""
 
-#: resources/public/pebble_templates/profile.html:105:101
-#: resources/public/pebble_templates/profile.html:111:105
+#: resources/public/pebble_templates/profile.html
+#: resources/public/pebble_templates/profile.html
 msgid "Never"
 msgstr ""
 
-#: resources/public/pebble_templates/profile.html:110:72
+#: resources/public/pebble_templates/profile.html
 msgid "Chat Ban Expiry"
 msgstr ""
 
-#: resources/public/pebble_templates/profile.html:117:36
+#: resources/public/pebble_templates/profile.html
 msgid "View rankings and other stats <a href=\"/stats\">here</a>."
 msgstr ""
 
-#: resources/public/pebble_templates/profile.html:124:68
+#: resources/public/pebble_templates/profile.html
 msgid "You must be logged in to view your reports."
 msgstr ""
 
-#: resources/public/pebble_templates/profile.html:130:64
+#: resources/public/pebble_templates/profile.html
 msgid "Canvas Reports ({0}/{1} open)"
 msgstr ""
 
 #. eg "Report on Bob (closed)
-#: resources/public/pebble_templates/profile.html:142:56
-#: resources/public/pebble_templates/profile.html:177:56
+#: resources/public/pebble_templates/profile.html
+#: resources/public/pebble_templates/profile.html
 msgid "Report on {0} (closed)"
 msgstr ""
 
 #. eg "Report on Bob (open)
-#: resources/public/pebble_templates/profile.html:145:56
-#: resources/public/pebble_templates/profile.html:179:56
+#: resources/public/pebble_templates/profile.html
+#: resources/public/pebble_templates/profile.html
 msgid "Report on {0} (open)"
 msgstr ""
 
 #. eg "Reported Bob on Jan 1, 1970, 00:00:00 AM (UTC)
-#: resources/public/pebble_templates/profile.html:152:60
-#: resources/public/pebble_templates/profile.html:185:60
+#: resources/public/pebble_templates/profile.html
+#: resources/public/pebble_templates/profile.html
 msgid "Reported {0} on {1}"
 msgstr ""
 
-#: resources/public/pebble_templates/profile.html:158:47
+#: resources/public/pebble_templates/profile.html
 msgid "There are no canvas reports to show."
 msgstr ""
 
-#: resources/public/pebble_templates/profile.html:166:64
+#: resources/public/pebble_templates/profile.html
 msgid "Chat Reports ({0}/{1} open)"
 msgstr ""
 
-#: resources/public/pebble_templates/profile.html:191:47
+#: resources/public/pebble_templates/profile.html
 msgid "There are no chat reports to show."
 msgstr ""
 
-#: resources/public/pebble_templates/profile.html:200:68
+#: resources/public/pebble_templates/profile.html
 msgid "You must be logged in to manage your factions."
 msgstr ""
 
-#: resources/public/pebble_templates/profile.html:205:36
+#: resources/public/pebble_templates/profile.html
 msgid "You are faction restricted and cannot create new factions. If you believe this is an error, please contact a moderator."
 msgstr ""
 
-#: resources/public/pebble_templates/profile.html:207:36
+#: resources/public/pebble_templates/profile.html
 msgid "You are canvas banned and cannot create new factions. If you believe this is an error, please contact a moderator."
 msgstr ""
 
-#: resources/public/pebble_templates/profile.html:212:76
+#: resources/public/pebble_templates/profile.html
 msgid "You must have at least {0} all-time pixels to create a faction."
 msgstr ""
 
-#: resources/public/pebble_templates/profile.html:215:300
+#: resources/public/pebble_templates/profile.html
 msgid "Create"
 msgstr ""
 
-#: resources/public/pebble_templates/profile.html:216:191
+#: resources/public/pebble_templates/profile.html
 msgid "Join"
 msgstr ""
 
-#: resources/public/pebble_templates/profile.html:225:118
+#: resources/public/pebble_templates/profile.html
 msgid "This is your currently displayed faction."
 msgstr ""
 
 #. eg "Pixelers (members: 100, ID: 1)"
-#: resources/public/pebble_templates/profile.html:228:44
+#: resources/public/pebble_templates/profile.html
 msgid "{0} (members: {1}, ID: {2}"
 msgstr ""
 
-#: resources/public/pebble_templates/profile.html:231:69
+#: resources/public/pebble_templates/profile.html
 msgid "Owner: {0}"
 msgstr ""
 
 #. makes the faction no longer the one displayed for the current user
-#: resources/public/pebble_templates/profile.html:236:175
+#: resources/public/pebble_templates/profile.html
 msgid "Remove Displayed"
 msgstr ""
 
 #. makes the faction the one displayed for the current user
-#: resources/public/pebble_templates/profile.html:239:172
+#: resources/public/pebble_templates/profile.html
 msgid "Set Displayed"
 msgstr ""
 
-#: resources/public/pebble_templates/profile.html:242:235
+#: resources/public/pebble_templates/profile.html
 msgid "Members"
 msgstr ""
 
-#: resources/public/pebble_templates/profile.html:243:169
+#: resources/public/pebble_templates/profile.html
 msgid "Edit"
 msgstr ""
 
-#: resources/public/pebble_templates/profile.html:244:168
-#: resources/public/include/chat.js:1462:24
+#: resources/public/pebble_templates/profile.html
+#: resources/public/include/chat.js
 msgid "Delete"
 msgstr ""
 
-#: resources/public/pebble_templates/profile.html:246:174
+#: resources/public/pebble_templates/profile.html
 msgid "Leave"
 msgstr ""
 
-#: resources/public/pebble_templates/profile.html:253:68
+#: resources/public/pebble_templates/profile.html
 msgid "You are not in any factions yet!"
 msgstr ""
 
-#: resources/public/pebble_templates/profile.html:269:52
+#: resources/public/pebble_templates/profile.html
 msgid "Members of {0} ([{1}])"
 msgstr ""
 
-#: resources/public/pebble_templates/profile.html:270:97
-#: resources/public/pebble_templates/profile.html:329:97
-#: resources/public/pebble_templates/profile.html:342:97
-#: resources/public/pebble_templates/profile.html:366:97
+#: resources/public/pebble_templates/profile.html
+#: resources/public/pebble_templates/profile.html
+#: resources/public/pebble_templates/profile.html
+#: resources/public/pebble_templates/profile.html
 msgid "Close"
 msgstr ""
 
-#: resources/public/pebble_templates/profile.html:278:60
+#: resources/public/pebble_templates/profile.html
 msgid "Faction Members"
 msgstr ""
 
-#: resources/public/pebble_templates/profile.html:292:128
+#: resources/public/pebble_templates/profile.html
 msgid "Transfer Ownership"
 msgstr ""
 
 #. bans a user from the faction
-#: resources/public/pebble_templates/profile.html:294:122
-#: resources/public/include/chat.js:1733:60
+#: resources/public/pebble_templates/profile.html
+#: resources/public/include/chat.js
 msgid "Ban"
 msgstr ""
 
-#: resources/public/pebble_templates/profile.html:300:79
-#: resources/public/pebble_templates/profile.html:322:79
+#: resources/public/pebble_templates/profile.html
+#: resources/public/pebble_templates/profile.html
 msgid "Nothing to see here!"
 msgstr ""
 
-#: resources/public/pebble_templates/profile.html:308:60
+#: resources/public/pebble_templates/profile.html
 msgid "Faction Bans"
 msgstr ""
 
-#: resources/public/pebble_templates/profile.html:318:125
-#: resources/public/include/chat.js:1629:36
-#: resources/public/include/chat.js:1733:46
-#: resources/public/admin/admin.js:320:88
-#: resources/public/admin/admin.js:347:52
+#: resources/public/pebble_templates/profile.html
+#: resources/public/include/chat.js
+#: resources/public/include/chat.js
+#: resources/public/admin/admin.js
+#: resources/public/admin/admin.js
 msgid "Unban"
 msgstr ""
 
-#: resources/public/pebble_templates/profile.html:341:52
+#: resources/public/pebble_templates/profile.html
 msgid "Find A Faction"
 msgstr ""
 
-#: resources/public/pebble_templates/profile.html:351:99
+#: resources/public/pebble_templates/profile.html
 msgid "Search:"
 msgstr ""
 
-#: resources/public/pebble_templates/profile.html:361:66
+#: resources/public/pebble_templates/profile.html
 msgid "Enter a search term to get started."
 msgstr ""
 
-#: resources/public/pebble_templates/profile.html:363:116
+#: resources/public/pebble_templates/profile.html
 msgid "Load More"
 msgstr ""
 
 #. HTTP status code name
-#: resources/public/pebble_templates/40x.html:39:24
+#: resources/public/pebble_templates/40x.html
 msgid "Not Found"
 msgstr ""
 
-#: resources/public/pebble_templates/40x.html:41:23
+#: resources/public/pebble_templates/40x.html
 msgid "The content you requested could not be found at this URL. If you believe this is an error, please contact a developer."
 msgstr ""
 
 #. links to the homepage (the app itself)
-#: resources/public/pebble_templates/40x.html:44:99
-#: resources/public/pebble_templates/40x.html:53:99
-#: resources/public/pebble_templates/40x.html:61:99
+#: resources/public/pebble_templates/40x.html
+#: resources/public/pebble_templates/40x.html
+#: resources/public/pebble_templates/40x.html
 msgid "Back to Pxls"
 msgstr ""
 
 #. HTTP status code name
-#: resources/public/pebble_templates/40x.html:49:24
+#: resources/public/pebble_templates/40x.html
 msgid "Not Authenticated"
 msgstr ""
 
-#: resources/public/pebble_templates/40x.html:51:23
+#: resources/public/pebble_templates/40x.html
 msgid "You must be logged in to access this data. Please go back to pxls and go through the authentication process."
 msgstr ""
 
 #. HTTP status code name
-#: resources/public/pebble_templates/40x.html:57:24
+#: resources/public/pebble_templates/40x.html
 msgid "Not Allowed"
 msgstr ""
 
-#: resources/public/pebble_templates/40x.html:59:23
+#: resources/public/pebble_templates/40x.html
 msgid "The action you attempted to perform is not allowed or resulted in an error. Please ensure you have access to the endpoint and try again later."
 msgstr ""
 
-#: resources/public/pxls.js:134:38
+#: resources/public/pxls.js
 msgid "Alert"
 msgstr ""
 
 #. Snapshot save name
-#: resources/public/include/board.js:806:100
+#: resources/public/include/board.js
 msgid "pxls canvas"
 msgstr ""
 
 #. template link action
-#: resources/public/include/chat.js:80:21
+#: resources/public/include/chat.js
 msgid "Ask"
 msgstr ""
 
-#: resources/public/include/chat.js:84:21
+#: resources/public/include/chat.js
 msgid "Open in a new tab"
 msgstr ""
 
-#: resources/public/include/chat.js:88:21
+#: resources/public/include/chat.js
 msgid "Open in current tab (replacing template)"
 msgstr ""
 
-#: resources/public/include/chat.js:92:21
+#: resources/public/include/chat.js
 msgid "Jump to coordinates without replacing template"
 msgstr ""
 
-#: resources/public/include/chat.js:437:55
-#: resources/public/include/chat.js:956:53
+#: resources/public/include/chat.js
+#: resources/public/include/chat.js
 msgid "You must be logged in to chat."
 msgstr ""
 
-#: resources/public/include/chat.js:1260:42
-#: resources/public/include/chat.js:1753:27
+#: resources/public/include/chat.js
+#: resources/public/include/chat.js
 msgid "none provided"
 msgstr ""
 
-#: resources/public/include/chat.js:1261:38
+#: resources/public/include/chat.js
 msgid "Purged by ${purge.initiator} with reason: ${reason}"
 msgstr ""
 
-#: resources/public/include/chat.js:1279:26
+#: resources/public/include/chat.js
 msgid "template:"
 msgstr ""
 
-#: resources/public/include/chat.js:1331:56
-#: resources/public/include/chat.js:2057:56
+#: resources/public/include/chat.js
+#: resources/public/include/chat.js
 msgid "Open Failed"
 msgstr ""
 
-#: resources/public/include/chat.js:1333:32
-#: resources/public/include/chat.js:2059:32
+#: resources/public/include/chat.js
+#: resources/public/include/chat.js
 msgid "Failed to automatically open in a new tab"
 msgstr ""
 
-#: resources/public/include/chat.js:1337:24
-#: resources/public/include/chat.js:2063:24
+#: resources/public/include/chat.js
+#: resources/public/include/chat.js
 msgid "Click here to open in a new tab instead"
 msgstr ""
 
-#: resources/public/include/chat.js:1351:52
+#: resources/public/include/chat.js
 msgid "Open Template"
 msgstr ""
 
-#: resources/public/include/chat.js:1353:54
+#: resources/public/include/chat.js
 msgid "This link will overwrite your current template. What would you like to do?"
 msgstr ""
 
-#: resources/public/include/chat.js:1364:55
+#: resources/public/include/chat.js
 msgid "Note: You can set a default action in the settings menu which bypasses this popup completely."
 msgstr ""
 
-#: resources/public/include/chat.js:1455:24
-#: resources/public/include/chat.js:1534:18
-#: resources/public/include/lookup.js:18:90
+#: resources/public/include/chat.js
+#: resources/public/include/chat.js
+#: resources/public/include/lookup.js
 msgid "Report"
 msgstr ""
 
-#: resources/public/include/chat.js:1456:24
+#: resources/public/include/chat.js
 msgid "Mention"
 msgstr ""
 
-#: resources/public/include/chat.js:1457:24
+#: resources/public/include/chat.js
 msgid "Ignore"
 msgstr ""
 
-#: resources/public/include/chat.js:1458:102
-#: resources/public/admin/admin.js:193:16
+#: resources/public/include/chat.js
+#: resources/public/admin/admin.js
 msgid "Profile"
 msgstr ""
 
-#: resources/public/include/chat.js:1459:24
+#: resources/public/include/chat.js
 msgid "Chat (un)ban"
 msgstr ""
 
-#: resources/public/include/chat.js:1461:43
-#: resources/public/include/chat.js:1911:54
+#: resources/public/include/chat.js
+#: resources/public/include/chat.js
 msgid "Purge User"
 msgstr ""
 
-#: resources/public/include/chat.js:1463:24
+#: resources/public/include/chat.js
 msgid "Mod Lookup"
 msgstr ""
 
-#: resources/public/include/chat.js:1464:24
+#: resources/public/include/chat.js
 msgid "Chat Lookup"
 msgstr ""
 
-#: resources/public/include/chat.js:1536:30
+#: resources/public/include/chat.js
 msgid "Enter a reason for your report"
 msgstr ""
 
-#: resources/public/include/chat.js:1565:26
-#: resources/public/include/chat.js:1686:18
-#: resources/public/include/chat.js:1845:22
-#: resources/public/include/chat.js:1893:22
-#: resources/public/include/chat.js:1961:22
-#: resources/public/include/chat.js:2021:22
-#: resources/public/include/lookup.js:64:91
-#: resources/public/include/user.js:73:87
-#: resources/public/admin/admin.js:334:20
+#: resources/public/include/chat.js
+#: resources/public/include/chat.js
+#: resources/public/include/chat.js
+#: resources/public/include/chat.js
+#: resources/public/include/chat.js
+#: resources/public/include/chat.js
+#: resources/public/include/lookup.js
+#: resources/public/include/user.js
+#: resources/public/admin/admin.js
 msgid "Cancel"
 msgstr ""
 
-#: resources/public/include/chat.js:1580:34
-#: resources/public/include/lookup.js:45:30
+#: resources/public/include/chat.js
+#: resources/public/include/lookup.js
 msgid "Error sending report."
 msgstr ""
 
-#: resources/public/include/chat.js:1585:54
+#: resources/public/include/chat.js
 msgid "Report User"
 msgstr ""
 
-#: resources/public/include/chat.js:1599:34
+#: resources/public/include/chat.js
 msgid "User ignored. You can unignore from chat settings."
 msgstr ""
 
-#: resources/public/include/chat.js:1601:34
+#: resources/public/include/chat.js
 msgid "Failed to ignore user. Either they\\'re already ignored, or an error occurred. If the problem persists, contact a developer."
 msgstr ""
 
-#: resources/public/include/chat.js:1629:55
+#: resources/public/include/chat.js
 msgid "Permanent"
 msgstr ""
 
-#: resources/public/include/chat.js:1629:78
+#: resources/public/include/chat.js
 msgid "Temporary"
 msgstr ""
 
-#: resources/public/include/chat.js:1656:32
+#: resources/public/include/chat.js
 msgid "Rule 3: Spam"
 msgstr ""
 
-#: resources/public/include/chat.js:1657:32
+#: resources/public/include/chat.js
 msgid "Rule 1: Chat civility"
 msgstr ""
 
-#: resources/public/include/chat.js:1658:32
+#: resources/public/include/chat.js
 msgid "Rule 2: Hate Speech"
 msgstr ""
 
-#: resources/public/include/chat.js:1659:32
+#: resources/public/include/chat.js
 msgid "Rule 5: NSFW"
 msgstr ""
 
-#: resources/public/include/chat.js:1660:32
-#: resources/public/include/chat.js:1738:58
-#: resources/public/include/chat.js:1759:45
+#: resources/public/include/chat.js
+#: resources/public/include/chat.js
+#: resources/public/include/chat.js
 msgid "Custom"
 msgstr ""
 
-#: resources/public/include/chat.js:1693:33
+#: resources/public/include/chat.js
 msgid "Banning:"
 msgstr ""
 
-#: resources/public/include/chat.js:1693:50
+#: resources/public/include/chat.js
 msgid "Message:"
 msgstr ""
 
-#: resources/public/include/chat.js:1695:26
+#: resources/public/include/chat.js
 msgid "Ban Length"
 msgstr ""
 
-#: resources/public/include/chat.js:1702:28
+#: resources/public/include/chat.js
 msgid "Reason"
 msgstr ""
 
-#: resources/public/include/chat.js:1707:28
+#: resources/public/include/chat.js
 msgid "Purge Messages"
 msgstr ""
 
-#: resources/public/include/chat.js:1711:27
+#: resources/public/include/chat.js
 msgid "Purging all messages is disabled during snip mode"
 msgstr ""
 
-#: resources/public/include/chat.js:1714:79
-#: resources/public/include/user.js:174:22
-#: resources/public/admin/admin.js:185:41
-#: resources/public/admin/admin.js:187:94
+#: resources/public/include/chat.js
+#: resources/public/include/user.js
+#: resources/public/admin/admin.js
+#: resources/public/admin/admin.js
 msgid "Yes"
 msgstr ""
 
-#: resources/public/include/chat.js:1715:78
-#: resources/public/include/user.js:178:22
-#: resources/public/admin/admin.js:185:53
-#: resources/public/admin/admin.js:187:106
+#: resources/public/include/chat.js
+#: resources/public/include/user.js
+#: resources/public/admin/admin.js
+#: resources/public/admin/admin.js
 msgid "No"
 msgstr ""
 
-#: resources/public/include/chat.js:1739:63
+#: resources/public/include/chat.js
 msgid "Custom reason"
 msgstr ""
 
-#: resources/public/include/chat.js:1739:85
-#: resources/public/include/lookup.js:59:30
+#: resources/public/include/chat.js
+#: resources/public/include/lookup.js
 msgid "Additional information (if applicable)"
 msgstr ""
 
-#: resources/public/include/chat.js:1764:45
+#: resources/public/include/chat.js
 msgid "Additional information:"
 msgstr ""
 
-#: resources/public/include/chat.js:1786:34
+#: resources/public/include/chat.js
 msgid "Error occurred while chatbanning"
 msgstr ""
 
-#: resources/public/include/chat.js:1790:54
+#: resources/public/include/chat.js
 msgid "Chatban"
 msgstr ""
 
-#: resources/public/include/chat.js:1810:32
+#: resources/public/include/chat.js
 msgid "Failed to delete"
 msgstr ""
 
-#: resources/public/include/chat.js:1821:32
-#: resources/public/include/chat.js:1863:32
+#: resources/public/include/chat.js
+#: resources/public/include/chat.js
 msgid "ID: "
 msgstr ""
 
-#: resources/public/include/chat.js:1825:32
-#: resources/public/include/chat.js:1873:32
+#: resources/public/include/chat.js
+#: resources/public/include/chat.js
 msgid "User: "
 msgstr ""
 
-#: resources/public/include/chat.js:1829:32
-#: resources/public/include/chat.js:1867:32
+#: resources/public/include/chat.js
+#: resources/public/include/chat.js
 msgid "Message: "
 msgstr ""
 
-#: resources/public/include/chat.js:1833:32
+#: resources/public/include/chat.js
 msgid "Reason: "
 msgstr ""
 
-#: resources/public/include/chat.js:1850:54
+#: resources/public/include/chat.js
 msgid "Delete Message"
 msgstr ""
 
-#: resources/public/include/chat.js:1858:106
+#: resources/public/include/chat.js
 msgid "Purge"
 msgstr ""
 
-#: resources/public/include/chat.js:1879:28
+#: resources/public/include/chat.js
 msgid "Selected Message"
 msgstr ""
 
-#: resources/public/include/chat.js:1882:30
+#: resources/public/include/chat.js
 msgid "Purge Reason"
 msgstr ""
 
-#: resources/public/include/chat.js:1907:34
+#: resources/public/include/chat.js
 msgid "Error sending purge."
 msgstr ""
 
-#: resources/public/include/chat.js:1936:98
+#: resources/public/include/chat.js
 msgid "On"
 msgstr ""
 
-#: resources/public/include/chat.js:1949:28
+#: resources/public/include/chat.js
 msgid "Toggle Rename Request"
 msgstr ""
 
-#: resources/public/include/chat.js:1950:27
+#: resources/public/include/chat.js
 msgid "Select one of the options below to set the current rename request state."
 msgstr ""
 
-#: resources/public/include/chat.js:1975:30
-#: resources/public/include/chat.js:2034:30
+#: resources/public/include/chat.js
+#: resources/public/include/chat.js
 msgid "An unknown error occurred. Please contact a developer"
 msgstr ""
 
-#: resources/public/include/chat.js:2001:52
+#: resources/public/include/chat.js
 msgid "New Name: "
 msgstr ""
 
-#: resources/public/include/chat.js:2011:27
+#: resources/public/include/chat.js
 msgid "Enter the new name for the user below. Please note that if you\\'re trying to change the caps, you\\'ll have to rename to something else first."
 msgstr ""
 
-#: resources/public/include/chat.js:2049:54
+#: resources/public/include/chat.js
 msgid "Force Rename"
 msgstr ""
 
-#: resources/public/include/chat.js:2088:118
+#: resources/public/include/chat.js
 msgid "You cannot use chat while canvas banned."
 msgstr ""
 
-#: resources/public/include/lookup.js:21:32
+#: resources/public/include/lookup.js
 msgid "Sending..."
 msgstr ""
 
-#: resources/public/include/lookup.js:28:32
+#: resources/public/include/lookup.js
 msgid "You must specify the details."
 msgstr ""
 
-#: resources/public/include/lookup.js:33:27
+#: resources/public/include/lookup.js
 msgid "additional information:"
 msgstr ""
 
-#: resources/public/include/lookup.js:49:50
+#: resources/public/include/lookup.js
 msgid "Report Pixel"
 msgstr ""
 
-#: resources/public/include/lookup.js:52:32
+#: resources/public/include/lookup.js
 msgid "Rule #1: Hateful/derogatory speech or symbols"
 msgstr ""
 
-#: resources/public/include/lookup.js:53:32
+#: resources/public/include/lookup.js
 msgid "Rule #2: Nudity, genitalia, or non-PG-13 content"
 msgstr ""
 
-#: resources/public/include/lookup.js:54:32
+#: resources/public/include/lookup.js
 msgid "Rule #3: Multi-account"
 msgstr ""
 
-#: resources/public/include/lookup.js:55:32
+#: resources/public/include/lookup.js
 msgid "Rule #4: Botting"
 msgstr ""
 
-#: resources/public/include/lookup.js:56:52
+#: resources/public/include/lookup.js
 msgid "Other (specify below)"
 msgstr ""
 
-#: resources/public/include/lookup.js:168:62
+#: resources/public/include/lookup.js
 msgid "Hide sensitive information"
 msgstr ""
 
-#: resources/public/include/lookup.js:207:120
+#: resources/public/include/lookup.js
 msgid "An error occurred, either you aren't logged in or you may be attempting to look up users too fast. Please try again in 60 seconds"
 msgstr ""
 
-#: resources/public/include/lookup.js:218:21
+#: resources/public/include/lookup.js
 msgid "Coords"
 msgstr ""
 
-#: resources/public/include/lookup.js:223:21
-#: resources/public/admin/admin.js:189:16
+#: resources/public/include/lookup.js
+#: resources/public/admin/admin.js
 msgid "Username"
 msgstr ""
 
-#: resources/public/include/lookup.js:229:28
+#: resources/public/include/lookup.js
 msgid "View Profile"
 msgstr ""
 
-#: resources/public/include/lookup.js:239:21
+#: resources/public/include/lookup.js
 msgid "Origin"
 msgstr ""
 
-#: resources/public/include/lookup.js:243:28
+#: resources/public/include/lookup.js
 msgid "Part of a nuke"
 msgstr ""
 
-#: resources/public/include/lookup.js:245:28
+#: resources/public/include/lookup.js
 msgid "Placed by a staff member using placement overrides"
 msgstr ""
 
-#: resources/public/include/lookup.js:252:21
+#: resources/public/include/lookup.js
 msgid "Time"
 msgstr ""
 
-#: resources/public/include/lookup.js:263:36
+#: resources/public/include/lookup.js
 msgid "just now"
 msgstr ""
 
-#: resources/public/include/lookup.js:271:36
+#: resources/public/include/lookup.js
 msgid "${hoursStr}:${minuteStr}:${secsStr} ago"
 msgstr ""
 
-#: resources/public/include/lookup.js:284:21
+#: resources/public/include/lookup.js
 msgid "Discord"
 msgstr ""
 
-#: resources/public/include/notifications.js:60:58
+#: resources/public/include/notifications.js
 msgid "Posted by ${notification.who}"
 msgstr ""
 
-#: resources/public/include/notifications.js:63:111
+#: resources/public/include/notifications.js
 msgid "Expires ${expiry}"
 msgstr ""
 
-#: resources/public/include/template.js:440:50
+#: resources/public/include/template.js
 msgid "There was an error getting the image"
 msgstr ""
 
-#: resources/public/include/timer.js:42:53
+#: resources/public/include/timer.js
 msgid "Your next pixel will be available in ${delay} seconds!"
 msgstr ""
 
-#: resources/public/include/timer.js:87:61
+#: resources/public/include/timer.js
 msgid "Your next pixel has been available for ${alertDelay} seconds!"
 msgstr ""
 
-#: resources/public/include/timer.js:101:59
+#: resources/public/include/timer.js
 msgid "Your next pixel is available!"
 msgstr ""
 
 #. theme name
-#: resources/public/include/uiHelper.js:48:19
+#: resources/public/include/uiHelper.js
 msgid "Dark"
 msgstr ""
 
 #. theme name
-#: resources/public/include/uiHelper.js:54:19
+#: resources/public/include/uiHelper.js
 msgid "Darker"
 msgstr ""
 
 #. theme name
-#: resources/public/include/uiHelper.js:60:19
+#: resources/public/include/uiHelper.js
 msgid "Blue"
 msgstr ""
 
 #. theme name
-#: resources/public/include/uiHelper.js:66:19
+#: resources/public/include/uiHelper.js
 msgid "Purple"
 msgstr ""
 
 #. theme name
-#: resources/public/include/uiHelper.js:72:19
+#: resources/public/include/uiHelper.js
 msgid "Green"
 msgstr ""
 
 #. theme name
-#: resources/public/include/uiHelper.js:78:19
+#: resources/public/include/uiHelper.js
 msgid "Matte"
 msgstr ""
 
 #. theme name
-#: resources/public/include/uiHelper.js:84:19
+#: resources/public/include/uiHelper.js
 msgid "Terminal"
 msgstr ""
 
 #. theme name
-#: resources/public/include/uiHelper.js:90:19
+#: resources/public/include/uiHelper.js
 msgid "Red"
 msgstr ""
 
-#: resources/public/include/uiHelper.js:467:30
+#: resources/public/include/uiHelper.js
 msgid "Discord name updated successfully"
 msgstr ""
 
-#: resources/public/include/uiHelper.js:474:32
+#: resources/public/include/uiHelper.js
 msgid "Couldn\\'t change discord name: "
 msgstr ""
 
-#: resources/public/include/user.js:81:28
+#: resources/public/include/user.js
 msgid "Sign in with..."
 msgstr ""
 
-#: resources/public/include/user.js:94:149
+#: resources/public/include/user.js
 msgid "New Accounts Disabled"
 msgstr ""
 
-#: resources/public/include/user.js:167:52
+#: resources/public/include/user.js
 msgid "Sign Out"
 msgstr ""
 
-#: resources/public/include/user.js:169:27
+#: resources/public/include/user.js
 msgid "Are you sure you want to sign out?"
 msgstr ""
 
-#: resources/public/include/user.js:223:39
+#: resources/public/include/user.js
 msgid "You are permanently banned."
 msgstr ""
 
-#: resources/public/include/user.js:227:39
+#: resources/public/include/user.js
 msgid "You are temporarily banned and will not be allowed to place until ${timestamp}"
 msgstr ""
 
-#: resources/public/include/user.js:255:27
+#: resources/public/include/user.js
 msgid "If you think this was an error, please contact us using one of the links in the info tab."
 msgstr ""
 
-#: resources/public/include/user.js:256:27
+#: resources/public/include/user.js
 msgid "Ban reason:"
 msgstr ""
 
-#: resources/public/include/user.js:260:28
-#: resources/public/admin/admin.js:203:16
+#: resources/public/include/user.js
+#: resources/public/admin/admin.js
 msgid "Banned"
 msgstr ""
 
-#: resources/public/include/user.js:330:23
+#: resources/public/include/user.js
 msgid "Staff have required you to change your username, this usually means your name breaks one of our rules."
 msgstr ""
 
-#: resources/public/include/user.js:331:23
+#: resources/public/include/user.js
 msgid "If you disagree, please contact us on Discord (link in the info panel)."
 msgstr ""
 
-#: resources/public/include/user.js:332:27
+#: resources/public/include/user.js
 msgid "New Username:"
 msgstr ""
 
-#: resources/public/include/user.js:345:89
+#: resources/public/include/user.js
 msgid "Not now"
 msgstr ""
 
-#: resources/public/include/user.js:346:86
+#: resources/public/include/user.js
 msgid "Change"
 msgstr ""
 
-#: resources/public/include/user.js:350:50
-#: resources/public/admin/admin.js:201:16
+#: resources/public/include/user.js
+#: resources/public/admin/admin.js
 msgid "Rename Requested"
 msgstr ""
 
-#: resources/public/admin/admin.js:101:38
+#: resources/public/admin/admin.js
 msgid "Something went wrong! Perhaps insufficient permissions?"
 msgstr ""
 
-#: resources/public/admin/admin.js:106:45
+#: resources/public/admin/admin.js
 msgid "Shadowban user"
 msgstr ""
 
-#: resources/public/admin/admin.js:106:67
+#: resources/public/admin/admin.js
 msgid "Shadowbanned user"
 msgstr ""
 
-#: resources/public/admin/admin.js:109:45
+#: resources/public/admin/admin.js
 msgid "Permaban user"
 msgstr ""
 
-#: resources/public/admin/admin.js:109:66
+#: resources/public/admin/admin.js
 msgid "Permabanned user"
 msgstr ""
 
-#: resources/public/admin/admin.js:112:45
+#: resources/public/admin/admin.js
 msgid "Ban user"
 msgstr ""
 
-#: resources/public/admin/admin.js:112:61
+#: resources/public/admin/admin.js
 msgid "Banned user"
 msgstr ""
 
-#: resources/public/admin/admin.js:126:36
+#: resources/public/admin/admin.js
 msgid "Unbanned user ${username}"
 msgstr ""
 
 #. Context: ban type
-#: resources/public/admin/admin.js:179:27
+#: resources/public/admin/admin.js
 msgid "shadow"
 msgstr ""
 
-#: resources/public/admin/admin.js:180:29
-#: resources/public/admin/admin.js:183:29
+#: resources/public/admin/admin.js
+#: resources/public/admin/admin.js
 msgid "never"
 msgstr ""
 
-#: resources/public/admin/admin.js:182:27
+#: resources/public/admin/admin.js
 msgid "permanent"
 msgstr ""
 
-#: resources/public/admin/admin.js:187:51
+#: resources/public/admin/admin.js
 msgid "Yes (permanent)"
 msgstr ""
 
-#: resources/public/admin/admin.js:194:16
-#: resources/public/admin/admin.js:454:21
+#: resources/public/admin/admin.js
+#: resources/public/admin/admin.js
 msgid "Logins"
 msgstr ""
 
-#: resources/public/admin/admin.js:200:16
+#: resources/public/admin/admin.js
 msgid "All Time Pixels"
 msgstr ""
 
-#: resources/public/admin/admin.js:202:16
+#: resources/public/admin/admin.js
 msgid "Discord Name"
 msgstr ""
 
-#: resources/public/admin/admin.js:204:16
+#: resources/public/admin/admin.js
 msgid "Chatbanned"
 msgstr ""
 
-#: resources/public/admin/admin.js:207:27
+#: resources/public/admin/admin.js
 msgid "Ban Reason"
 msgstr ""
 
-#: resources/public/admin/admin.js:208:27
+#: resources/public/admin/admin.js
 msgid "Ban Expiracy"
 msgstr ""
 
-#: resources/public/admin/admin.js:211:27
+#: resources/public/admin/admin.js
 msgid "Chatban Reason"
 msgstr ""
 
-#: resources/public/admin/admin.js:211:102
+#: resources/public/admin/admin.js
 msgid "(canvas ban)"
 msgstr ""
 
-#: resources/public/admin/admin.js:213:97
+#: resources/public/admin/admin.js
 msgid "when canvas ban ends"
 msgstr ""
 
-#: resources/public/admin/admin.js:214:29
+#: resources/public/admin/admin.js
 msgid "Chatban Expires"
 msgstr ""
 
 #. Admin check. Example: type = 'username', arg = 'pxlsuser94'
-#: resources/public/admin/admin.js:316:36
+#: resources/public/admin/admin.js
 msgid "${type} ${arg} not found."
 msgstr ""
 
-#: resources/public/admin/admin.js:322:50
+#: resources/public/admin/admin.js
 msgid "Unban Reason:"
 msgstr ""
 
-#: resources/public/admin/admin.js:327:25
+#: resources/public/admin/admin.js
 msgid "Unbanning ${username}"
 msgstr ""
 
-#: resources/public/admin/admin.js:449:20
+#: resources/public/admin/admin.js
 msgid "profile"
 msgstr ""
 
-#: resources/public/admin/admin.js:473:21
+#: resources/public/admin/admin.js
 msgid "User Agent"
 msgstr ""
 
-#: resources/public/admin/admin.js:478:21
+#: resources/public/admin/admin.js
 msgid "Send Alert"
 msgstr ""
 
-#: resources/public/admin/admin.js:483:21
+#: resources/public/admin/admin.js
 msgid "Mod Actions"
 msgstr ""

--- a/po/Localization_fr.po
+++ b/po/Localization_fr.po
@@ -1,2245 +1,2176 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Pxls\n"
-"POT-Creation-Date: 2021-11-23T21:32:45.968Z\n"
+"POT-Creation-Date: 2021-12-03T07:36:36.932Z\n"
 "Language: \n"
 "Content-Type: text/plain; charset=UTF-8\n"
 
 #. Site description
-#: resources/public/pebble_templates/index.html:8:42
+#: resources/public/pebble_templates/index.html
 msgid "Place pixels with people to create art"
 msgstr "Place des pixels avec d'autres pour créer des œuvres d'art"
 
-#: resources/public/pebble_templates/index.html:56:27
+#: resources/public/pebble_templates/index.html
 msgid "Lost connection to server, reconnecting..."
 msgstr "Connexion au serveur perdue, reconnexion en cours..."
 
-#: resources/public/pebble_templates/index.html:71:76
+#: resources/public/pebble_templates/index.html
 msgid "Loading Heatmap (press <kbd>H</kbd> to cancel)"
 msgstr "Chargement de la carte d'activité (appuie sur <kbd>H</kbd> pour annuler)"
 
-#: resources/public/pebble_templates/index.html:72:78
+#: resources/public/pebble_templates/index.html
 msgid "Loading Virginmap (press <kbd>X</kbd> to cancel)"
 msgstr "Chargement de la virginmap (appuie sur <kbd>X</kbd> pour annuler)"
 
-#: resources/public/pebble_templates/index.html:80:67
+#: resources/public/pebble_templates/index.html
 msgid "Logout"
 msgstr "Déconnexion"
 
 #. Canvas pixel count
-#: resources/public/pebble_templates/index.html:86:38
+#: resources/public/pebble_templates/index.html
 msgid "Canvas:"
 msgstr "Canvas :"
 
 #. Canvas pixel count
 #. All time pixel count
-#: resources/public/pebble_templates/index.html:86:118
-#: resources/public/pebble_templates/index.html:88:120
-#: resources/public/pebble_templates/index.html:100:51
-#: resources/public/pebble_templates/index.html:126:123
+#: resources/public/pebble_templates/index.html
 msgid "N/A"
 msgstr "N/A"
 
 #. All time pixel count
-#: resources/public/pebble_templates/index.html:88:38
+#: resources/public/pebble_templates/index.html
 msgid "All Time:"
 msgstr "Total :"
 
-#: resources/public/pebble_templates/index.html:93:48
+#: resources/public/pebble_templates/index.html
 msgid "Loading online user count&hellip;"
 msgstr "Chargement du nombre d'utilisateurs en ligne&hellip;"
 
-#: resources/public/pebble_templates/index.html:101:30
-#: resources/public/include/lookup.js:276:21
-#: resources/public/admin/admin.js:199:16
+#: resources/public/pebble_templates/index.html
+#: resources/public/include/lookup.js resources/public/admin/admin.js
 msgid "Pixels"
 msgstr "Pixels"
 
-#: resources/public/pebble_templates/index.html:112:54
+#: resources/public/pebble_templates/index.html
 msgid "Undo"
 msgstr "Annuler"
 
-#: resources/public/pebble_templates/index.html:114:20
+#: resources/public/pebble_templates/index.html
 msgid "You are not signed in.&nbsp;<a href=\"#\">Sign in with...</a>"
 msgstr "Tu n'es pas connecté.&nbsp;<a href=\"#\">Se connecter avec...</a>"
 
-#: resources/public/pebble_templates/index.html:124:28
+#: resources/public/pebble_templates/index.html
 msgid "Loading..."
 msgstr "Chargement..."
 
-#: resources/public/pebble_templates/index.html:132:14
-#: resources/public/pebble_templates/index.html:142:67
+#: resources/public/pebble_templates/index.html
 msgid "Sign up"
 msgstr "S'inscrire"
 
-#: resources/public/pebble_templates/index.html:133:14
+#: resources/public/pebble_templates/index.html
 msgid "Pick a username"
 msgstr "Choisis ton pseudo"
 
-#: resources/public/pebble_templates/index.html:136:43
+#: resources/public/pebble_templates/index.html
 msgid "Username:"
 msgstr "Pseudo :"
 
-#: resources/public/pebble_templates/index.html:154:65
-#: resources/public/pebble_templates/profile.html:56:96
+#: resources/public/pebble_templates/index.html
+#: resources/public/pebble_templates/profile.html
 msgid "Info"
 msgstr "Info"
 
-#: resources/public/pebble_templates/index.html:168:66
-#: resources/public/pebble_templates/index.html:206:66
-#: resources/public/pebble_templates/index.html:761:66
-#: resources/public/pebble_templates/index.html:774:66
+#: resources/public/pebble_templates/index.html
 msgid "Close Panel"
 msgstr "Fermer le panneau"
 
-#: resources/public/pebble_templates/index.html:170:61
+#: resources/public/pebble_templates/index.html
 msgid "Chat"
 msgstr "Chat"
 
-#: resources/public/pebble_templates/index.html:172:45
+#: resources/public/pebble_templates/index.html
 msgid "Pings"
 msgstr "Mentions"
 
-#: resources/public/pebble_templates/index.html:173:45
-#: resources/public/pebble_templates/index.html:209:58
+#: resources/public/pebble_templates/index.html
 msgid "Settings"
 msgstr "Paramètres"
 
-#: resources/public/pebble_templates/index.html:186:30
+#: resources/public/pebble_templates/index.html
 msgid "Jump To Bottom"
 msgstr "Sauter à la fin"
 
 #. Open emoji picker
-#: resources/public/pebble_templates/index.html:194:49
+#: resources/public/pebble_templates/index.html
 msgid "Emoji"
 msgstr "Emoji"
 
-#: resources/public/pebble_templates/index.html:214:73
+#: resources/public/pebble_templates/index.html
 msgid "Search"
 msgstr "Recherche"
 
-#: resources/public/pebble_templates/index.html:215:56
+#: resources/public/pebble_templates/index.html
 msgid "keybinds;keys;keyboard;hotkeys"
 msgstr "touches;contrôles;clavier;raccourcis clavier"
 
-#: resources/public/pebble_templates/index.html:217:24
+#: resources/public/pebble_templates/index.html
 msgid "Keybinds"
 msgstr "Contrôles"
 
-#: resources/public/pebble_templates/index.html:220:44
+#: resources/public/pebble_templates/index.html
 msgid "general"
 msgstr "général"
 
 #. General settings
-#: resources/public/pebble_templates/index.html:222:28
-#: resources/public/pebble_templates/index.html:664:28
+#: resources/public/pebble_templates/index.html
 msgid "General"
 msgstr "Général"
 
-#: resources/public/pebble_templates/index.html:223:42
+#: resources/public/pebble_templates/index.html
 msgid "move;moving;panning;drag"
 msgstr "bouger;déplacement"
 
-#: resources/public/pebble_templates/index.html:223:102
+#: resources/public/pebble_templates/index.html
 msgid "Mouse/arrows/wasd to pan"
 msgstr "Souris/flèches/wasd pour déplacer le canvas"
 
-#: resources/public/pebble_templates/index.html:224:42
+#: resources/public/pebble_templates/index.html
 msgid "mousewheel;zooming"
 msgstr "roulette;molette;zoom"
 
-#: resources/public/pebble_templates/index.html:224:96
+#: resources/public/pebble_templates/index.html
 msgid "Scroll/pinch to zoom"
 msgstr "Scroll/pincer pour zoomer"
 
-#: resources/public/pebble_templates/index.html:225:42
+#: resources/public/pebble_templates/index.html
 msgid "scroll;zooming"
 msgstr "scroll;zoom"
 
-#: resources/public/pebble_templates/index.html:225:92
+#: resources/public/pebble_templates/index.html
 msgid "<kbd>+</kbd>/<kbd>-</kbd> or <kbd>Q</kbd>/<kbd>E</kbd> to zoom"
 msgstr "<kbd>+</kbd>/<kbd>-</kbd> ou <kbd>Q</kbd>/<kbd>E</kbd> pour zoomer"
 
-#: resources/public/pebble_templates/index.html:226:42
+#: resources/public/pebble_templates/index.html
 msgid "lookups"
 msgstr "inspections"
 
-#: resources/public/pebble_templates/index.html:226:85
+#: resources/public/pebble_templates/index.html
 msgid "<kbd>Shift</kbd> + Click/Hold touch to lookup pixel"
 msgstr "<kbd>Shift</kbd> + Click/Garder appuyé pour inspecter un pixel"
 
-#: resources/public/pebble_templates/index.html:227:42
-#: resources/public/pebble_templates/index.html:489:44
+#: resources/public/pebble_templates/index.html
 msgid "overlays;alignment;grid hidden;grid shown;hide grid;show grid"
 msgstr "calques;alignement;grille cachée;grille;cacher la grille;afficher la grille"
 
-#: resources/public/pebble_templates/index.html:227:139
+#: resources/public/pebble_templates/index.html
 msgid "<kbd>G</kbd> to toggle grid"
 msgstr "<kbd>G</kbd> pour activer/désactiver la grille"
 
-#: resources/public/pebble_templates/index.html:228:42
+#: resources/public/pebble_templates/index.html
 msgid "close;information shown;information hidden;info shown;info hidden;hide information;show information"
 msgstr "fermer;information;information cachée;info;info cachée;ouvrir l'information;cacher l'information;afficher l'information"
 
-#: resources/public/pebble_templates/index.html:228:177
+#: resources/public/pebble_templates/index.html
 msgid "<kbd>I</kbd> to open info"
 msgstr "<kbd>I</kbd> pour ouvrir l'info"
 
-#: resources/public/pebble_templates/index.html:229:42
+#: resources/public/pebble_templates/index.html
 msgid "close;settings hidden;settings shown;hide settings;show settings"
 msgstr "fermer;paramètres cachés;cacher les paramètres;ouvrir les paramètres;afficher les paramètres"
 
-#: resources/public/pebble_templates/index.html:229:142
+#: resources/public/pebble_templates/index.html
 msgid "<kbd>T</kbd> to open settings"
 msgstr "<kbd>T</kbd> pour ouvrir les paramètres"
 
-#: resources/public/pebble_templates/index.html:230:42
+#: resources/public/pebble_templates/index.html
 msgid "close;chat hidden;chat shown;hide chat;show chat"
 msgstr "fermer;chat caché;chat ouvert;cacher le chat;ouvrir le chat;afficher le chat"
 
-#: resources/public/pebble_templates/index.html:230:126
+#: resources/public/pebble_templates/index.html
 msgid "<kbd>B</kbd> to open chat"
 msgstr "<kbd>B</kbd> pour ouvrir le chat"
 
-#: resources/public/pebble_templates/index.html:231:42
+#: resources/public/pebble_templates/index.html
 msgid "canvas locked;move;moving;zoom;zooming"
 msgstr "canvas verrouillé;bouger;zoom"
 
-#: resources/public/pebble_templates/index.html:231:116
+#: resources/public/pebble_templates/index.html
 msgid "<kbd>L</kbd> to toggle locking panning of the canvas"
 msgstr "<kbd>L</kbd> pour verrouiller/déverrouiller le déplacement sur le canvas"
 
-#: resources/public/pebble_templates/index.html:232:42
+#: resources/public/pebble_templates/index.html
 msgid "take screenshot;image;download;picture;canvas"
 msgstr "capture d'écran;image;télécharger;canvas"
 
-#: resources/public/pebble_templates/index.html:232:123
+#: resources/public/pebble_templates/index.html
 msgid "<kbd>P</kbd> to take a snapshot"
 msgstr "<kbd>P</kbd> pour télécharger une image du canvas"
 
-#: resources/public/pebble_templates/index.html:233:42
-#: resources/public/pebble_templates/index.html:443:44
+#: resources/public/pebble_templates/index.html
 msgid "overlays;user activity;pixels placed pixels;heatmap hidden;heatmap shown;hide heatmap;show heatmap"
 msgstr "calques;activité;pixels placés;heatmap;carte d'activité;afficher carte d'activité;cacher carte d'activité"
 
-#: resources/public/pebble_templates/index.html:233:176
+#: resources/public/pebble_templates/index.html
 msgid "<kbd>H</kbd> to toggle heatmap"
 msgstr "<kbd>H</kbd> pour activer/désactiver la carte d'activité"
 
-#: resources/public/pebble_templates/index.html:234:42
-#: resources/public/pebble_templates/index.html:463:44
+#: resources/public/pebble_templates/index.html
 msgid "overlays;user activity;pixels unplaced pixels;virginmap hidden;virginmap shown;hide virginmap;show virginmap"
 msgstr "calques;activité;pixels non touchés;virginmap;afficher virginmap;cacher virginmap"
 
-#: resources/public/pebble_templates/index.html:234:186
+#: resources/public/pebble_templates/index.html
 msgid "<kbd>X</kbd> to toggle virginmap"
 msgstr "<kbd>X</kbd> pour activer/désactiver la virginmap"
 
-#: resources/public/pebble_templates/index.html:235:42
+#: resources/public/pebble_templates/index.html
 msgid "overlays;user activity;pixels placed pixels;wipe;clean;"
 msgstr "calques;activité;pixels placés;réinitialiser;effacer"
 
-#: resources/public/pebble_templates/index.html:235:133
+#: resources/public/pebble_templates/index.html
 msgid "<kbd>O</kbd> to clear heatmap"
 msgstr "<kbd>O</kbd> pour réinitialiser la carte d'activité"
 
-#: resources/public/pebble_templates/index.html:236:42
+#: resources/public/pebble_templates/index.html
 msgid "overlays;user activity;pixels unplaced pixels;wipe;clean;"
 msgstr "calques;activité;pixels placés;réinitialiser;effacer"
 
-#: resources/public/pebble_templates/index.html:236:135
+#: resources/public/pebble_templates/index.html
 msgid "<kbd>U</kbd> to clear virginmap"
 msgstr "<kbd>U</kbd> pour réinitialiser la virginmap"
 
-#: resources/public/pebble_templates/index.html:237:42
+#: resources/public/pebble_templates/index.html
 msgid "next color;previous color"
 msgstr "couleur précédente;couleur suivante"
 
-#: resources/public/pebble_templates/index.html:237:103
+#: resources/public/pebble_templates/index.html
 msgid "<kbd>J</kbd>/<kbd>K</kbd> to cycle through palette colors"
 msgstr "<kbd>J</kbd>/<kbd>K</kbd> pour défiler parmi les couleurs de la palette"
 
-#: resources/public/pebble_templates/index.html:238:42
+#: resources/public/pebble_templates/index.html
 msgid "current coordinates;coords"
 msgstr "coordonnées"
 
-#: resources/public/pebble_templates/index.html:238:104
+#: resources/public/pebble_templates/index.html
 msgid "<kbd>C</kbd> to copy link of moused-over coordinates"
 msgstr "<kbd>C</kbd> pour copier le lien des coordonnées survolées par le curseur"
 
-#: resources/public/pebble_templates/index.html:239:42
+#: resources/public/pebble_templates/index.html
 msgid "cancel selection"
 msgstr "annuler la sélection"
 
-#: resources/public/pebble_templates/index.html:239:94
+#: resources/public/pebble_templates/index.html
 msgid "<kbd>ESC</kbd> to deselect current pixel"
 msgstr "<kbd>ESC</kbd> pour déselectionner le pixel actif"
 
-#: resources/public/pebble_templates/index.html:240:42
+#: resources/public/pebble_templates/index.html
 msgid "recenter;jump;center on template;guides;focus"
 msgstr "recentrer;centrer sur le modèle;guide;focus"
 
-#: resources/public/pebble_templates/index.html:240:123
+#: resources/public/pebble_templates/index.html
 msgid "<kbd>R</kbd> to center the board on the current template"
 msgstr "<kbd>R</kbd> pour centrer l'écran sur le modèle actif"
 
-#: resources/public/pebble_templates/index.html:243:44
+#: resources/public/pebble_templates/index.html
 msgid "templates;guides"
 msgstr "modèle;templates;guide"
 
-#: resources/public/pebble_templates/index.html:244:28
-#: resources/public/pebble_templates/index.html:579:24
+#: resources/public/pebble_templates/index.html
 msgid "Template"
 msgstr "Modèle"
 
-#: resources/public/pebble_templates/index.html:245:42
-#: resources/public/pebble_templates/index.html:246:42
+#: resources/public/pebble_templates/index.html
 msgid "transparency"
 msgstr "Transparence"
 
-#: resources/public/pebble_templates/index.html:245:90
+#: resources/public/pebble_templates/index.html
 msgid "<kbd>Page Up</kbd> to increase opacity"
 msgstr "<kbd>Page Up</kbd> pour augmenter l'opacité"
 
-#: resources/public/pebble_templates/index.html:246:90
+#: resources/public/pebble_templates/index.html
 msgid "<kbd>Page Down</kbd> to decrease opacity"
 msgstr "<kbd>Page Down</kbd> pour diminuer l'opacité"
 
-#: resources/public/pebble_templates/index.html:247:42
+#: resources/public/pebble_templates/index.html
 msgid "hidden;shown;hide;show"
 msgstr "caché;affiché;cacher;afficher"
 
-#: resources/public/pebble_templates/index.html:247:100
+#: resources/public/pebble_templates/index.html
 msgid "<kbd>V</kbd> to toggle visibility"
 msgstr "<kbd>V</kbd> pour activer/désactiver la visibilité d'un modèle"
 
-#: resources/public/pebble_templates/index.html:252:24
+#: resources/public/pebble_templates/index.html
 msgid "Note: These values are based on QWERTY keyboards. For other layouts, use the keys corresponding to the same position on a QWERTY keyboard."
 msgstr "Note : Ces touches sont basées sur les claviers QWERTY. Pour d'autres claviers, utilise les touches correspondantes aux positions sur un clavier QWERTY."
 
-#: resources/public/pebble_templates/index.html:256:36
+#: resources/public/pebble_templates/index.html
 msgid "ui;interface"
 msgstr "interface utilisateur;interface"
 
-#: resources/public/pebble_templates/index.html:258:24
+#: resources/public/pebble_templates/index.html
 msgid "UI Settings"
 msgstr "Paramètres de l'interface utilisateur"
 
-#: resources/public/pebble_templates/index.html:262:44
+#: resources/public/pebble_templates/index.html
 msgid "themes;look;stylesheets;visuals"
 msgstr "thèmes;look;graphiques;visuels"
 
-#: resources/public/pebble_templates/index.html:264:57
+#: resources/public/pebble_templates/index.html
 msgid "Theme:"
 msgstr "Thème :"
 
-#: resources/public/pebble_templates/index.html:266:64
+#: resources/public/pebble_templates/index.html
 msgid "Default"
 msgstr "Par défaut"
 
-#: resources/public/pebble_templates/index.html:270:44
+#: resources/public/pebble_templates/index.html
 msgid "hide reticule;hide reticle;reticule shown reticle shown;reticule hidden;reticle hidden"
 msgstr "cacher réticule;réticule visible;afficher réticule;cacher réticule"
 
-#: resources/public/pebble_templates/index.html:273:57
+#: resources/public/pebble_templates/index.html
 msgid "Show reticule"
 msgstr "Afficher le réticule"
 
-#: resources/public/pebble_templates/index.html:276:44
+#: resources/public/pebble_templates/index.html
 msgid "hide cursor;cursor shown;cursor hidden"
 msgstr "cacher curseur;curseur affiché;curseur caché"
 
-#: resources/public/pebble_templates/index.html:279:57
+#: resources/public/pebble_templates/index.html
 msgid "Show cursor"
 msgstr "Afficher le curseur"
 
-#: resources/public/pebble_templates/index.html:282:44
+#: resources/public/pebble_templates/index.html
 msgid "darkness filter"
 msgstr "filtre"
 
-#: resources/public/pebble_templates/index.html:285:57
+#: resources/public/pebble_templates/index.html
 msgid "Enable color brightness"
 msgstr "Activer le paramètre de luminosité des couleurs"
 
-#: resources/public/pebble_templates/index.html:288:76
+#: resources/public/pebble_templates/index.html
 msgid "Warning: Known to cause fuzziness in Chrome on some Mac/Linux installs"
 msgstr "Attention: peut causer des problèmes de netteté dans Chrome sur certaines versions de Mac/Linux"
 
-#: resources/public/pebble_templates/index.html:291:57
+#: resources/public/pebble_templates/index.html
 msgid "Color brightness:"
 msgstr "Luminosité des couleurs :"
 
-#: resources/public/pebble_templates/index.html:295:44
+#: resources/public/pebble_templates/index.html
 msgid "keep current selected;keep curent color;place"
 msgstr "garder la couleur sélectionnée;placer"
 
-#: resources/public/pebble_templates/index.html:298:57
+#: resources/public/pebble_templates/index.html
 msgid "Deselect color after placing"
 msgstr "Déselectionner la couleur après l'avoir placée"
 
-#: resources/public/pebble_templates/index.html:301:44
+#: resources/public/pebble_templates/index.html
 msgid "mousewheel;palette scrolling"
 msgstr "molette de souris;roulette de souris;scroller dans la palette"
 
-#: resources/public/pebble_templates/index.html:304:57
+#: resources/public/pebble_templates/index.html
 msgid "Enable scrolling on the palette to switch colors"
 msgstr "Changer de couleur en scrollant dans la palette"
 
-#: resources/public/pebble_templates/index.html:306:68
+#: resources/public/pebble_templates/index.html
 msgid "reverse scrolling;mousewheel;palette scrolling;enable scrolling on the palette to switch colors"
 msgstr "inverser le scrolling;molette de souris;roulette de souris"
 
-#: resources/public/pebble_templates/index.html:309:61
+#: resources/public/pebble_templates/index.html
 msgid "Invert scroll direction"
 msgstr "Inverser la direction de scrolling"
 
-#: resources/public/pebble_templates/index.html:313:44
+#: resources/public/pebble_templates/index.html
 msgid "indexed colors;palette indicies"
 msgstr "index des couleurs;indices des couleurs;numéros des couleurs"
 
-#: resources/public/pebble_templates/index.html:316:57
+#: resources/public/pebble_templates/index.html
 msgid "Add numbers to palette entries"
 msgstr "Ajouter des numéros aux couleurs de la palette"
 
-#: resources/public/pebble_templates/index.html:319:44
+#: resources/public/pebble_templates/index.html
 msgid "scrollbar;palette scrolling"
 msgstr "barre de défilement;scrolling"
 
-#: resources/public/pebble_templates/index.html:322:57
+#: resources/public/pebble_templates/index.html
 msgid "Enable thin scrollbar"
 msgstr "Activer la bare de défilement fine"
 
-#: resources/public/pebble_templates/index.html:325:44
+#: resources/public/pebble_templates/index.html
 msgid "scrollbar;palette scrolling;palette stack"
 msgstr "barre de défilement;palette"
 
-#: resources/public/pebble_templates/index.html:328:57
+#: resources/public/pebble_templates/index.html
 msgid "Enable palette stacking"
 msgstr "Empiler la palette"
 
-#: resources/public/pebble_templates/index.html:331:44
+#: resources/public/pebble_templates/index.html
 msgid "floating bubble location"
 msgstr "emplacement de la bulle flottante"
 
-#: resources/public/pebble_templates/index.html:333:57
+#: resources/public/pebble_templates/index.html
 msgid "Bubble position:"
 msgstr "Emplacement de la bulle d'information :"
 
-#: resources/public/pebble_templates/index.html:335:61
+#: resources/public/pebble_templates/index.html
 msgid "Top left"
 msgstr "Coin supérieur gauche"
 
-#: resources/public/pebble_templates/index.html:336:62
+#: resources/public/pebble_templates/index.html
 msgid "Top right"
 msgstr "Coin supérieur droit"
 
-#: resources/public/pebble_templates/index.html:337:73
+#: resources/public/pebble_templates/index.html
 msgid "Bottom left"
 msgstr "Coin inférieur gauche"
 
-#: resources/public/pebble_templates/index.html:338:65
+#: resources/public/pebble_templates/index.html
 msgid "Bottom right"
 msgstr "Coin inférieur droit"
 
-#: resources/public/pebble_templates/index.html:342:44
+#: resources/public/pebble_templates/index.html
 msgid "broken;offset workaround"
 msgstr "bug;décalage"
 
-#: resources/public/pebble_templates/index.html:345:57
+#: resources/public/pebble_templates/index.html
 msgid "Attempt to fix canvas displacement bug in Chrome 78+"
 msgstr "Essayer de régler le problème de décalage du canvas sous Chrome 78+"
 
-#: resources/public/pebble_templates/index.html:351:36
+#: resources/public/pebble_templates/index.html
 msgid "chat;message;ping sound"
 msgstr "chat;message;bruit de mention;bruit de notification"
 
-#: resources/public/pebble_templates/index.html:353:24
+#: resources/public/pebble_templates/index.html
 msgid "Chat Settings"
 msgstr "Paramètres du chat"
 
-#: resources/public/pebble_templates/index.html:356:44
+#: resources/public/pebble_templates/index.html
 msgid "username;color;colour"
 msgstr "pseudo;couleur"
 
-#: resources/public/pebble_templates/index.html:359:57
+#: resources/public/pebble_templates/index.html
 msgid "Username Color:"
 msgstr "Couleur du nom d'utilisateur :"
 
-#: resources/public/pebble_templates/index.html:365:44
+#: resources/public/pebble_templates/index.html
 msgid "chat message;chat ui"
 msgstr "message du chat;visuel du chat"
 
-#: resources/public/pebble_templates/index.html:366:28
+#: resources/public/pebble_templates/index.html
 msgid "Interface"
 msgstr "Interface"
 
-#: resources/public/pebble_templates/index.html:367:44
+#: resources/public/pebble_templates/index.html
 msgid "chat size;chat font"
 msgstr "taille du chat;police du chat"
 
-#: resources/public/pebble_templates/index.html:369:57
+#: resources/public/pebble_templates/index.html
 msgid "Font Size:"
 msgstr "Taille de caractère :"
 
-#: resources/public/pebble_templates/index.html:373:44
+#: resources/public/pebble_templates/index.html
 msgid "time;timestamps"
 msgstr "temps;date;horodatage"
 
-#: resources/public/pebble_templates/index.html:376:57
+#: resources/public/pebble_templates/index.html
 msgid "24 Hour Timestamps"
 msgstr "Format de l'horodatage par 24h"
 
-#: resources/public/pebble_templates/index.html:379:44
+#: resources/public/pebble_templates/index.html
 msgid "badges;pixel count;pixels placed"
 msgstr "badges;nombres de pixels;pixels placés"
 
-#: resources/public/pebble_templates/index.html:382:57
+#: resources/public/pebble_templates/index.html
 msgid "Show pixel-placed badges"
 msgstr "Afficher les badges de nombre de pixels"
 
-#: resources/public/pebble_templates/index.html:385:44
+#: resources/public/pebble_templates/index.html
 msgid "badges;factions"
 msgstr "badges;factions"
 
-#: resources/public/pebble_templates/index.html:388:57
+#: resources/public/pebble_templates/index.html
 msgid "Show faction tags"
 msgstr "Afficher les insignes de factions"
 
-#: resources/public/pebble_templates/index.html:391:44
+#: resources/public/pebble_templates/index.html
 msgid "template urls;template links;template name"
 msgstr "urls de modèles;liens de modèles;nom de modèle"
 
-#: resources/public/pebble_templates/index.html:394:57
+#: resources/public/pebble_templates/index.html
 msgid "Replace template titles with URLs in chat where applicable"
 msgstr "Remplacer les noms de modèles par des URLs dans le chat quand c'est possible"
 
-#: resources/public/pebble_templates/index.html:397:44
+#: resources/public/pebble_templates/index.html
 msgid "chat orientation;chat position"
 msgstr "orientation du chat;position du chat"
 
-#: resources/public/pebble_templates/index.html:400:57
+#: resources/public/pebble_templates/index.html
 msgid "Enable horizontal chat"
 msgstr "Activer le chat horizontal"
 
-#: resources/public/pebble_templates/index.html:403:44
+#: resources/public/pebble_templates/index.html
 msgid "banner;animation"
 msgstr "bannière;bandeau;animation"
 
-#: resources/public/pebble_templates/index.html:406:57
+#: resources/public/pebble_templates/index.html
 msgid "Enable the rotating banner under chat"
 msgstr "Animer le bandeau sous le chat"
 
-#: resources/public/pebble_templates/index.html:409:44
+#: resources/public/pebble_templates/index.html
 msgid "max;messages;truncate"
 msgstr "max;messages;tronquer;troncature"
 
-#: resources/public/pebble_templates/index.html:411:57
+#: resources/public/pebble_templates/index.html
 msgid "Maximum amount of chat messages:"
 msgstr "Maximum de messages visibles dans le chat"
 
-#: resources/public/pebble_templates/index.html:415:44
+#: resources/public/pebble_templates/index.html
 msgid "link;url;behaviour"
 msgstr "lien;url"
 
-#: resources/public/pebble_templates/index.html:417:57
+#: resources/public/pebble_templates/index.html
 msgid "Default internal link action click:"
 msgstr "Action par défaut au clic sur un lien interne :"
 
-#: resources/public/pebble_templates/index.html:422:44
+#: resources/public/pebble_templates/index.html
 msgid "ignored;ignores;unignore;blocked;blocking;unblock"
 msgstr "ignorés;ignorer;bloqué;bloquer"
 
-#: resources/public/pebble_templates/index.html:423:28
+#: resources/public/pebble_templates/index.html
 msgid "Ignores"
 msgstr "Ignorés"
 
-#: resources/public/pebble_templates/index.html:424:44
+#: resources/public/pebble_templates/index.html
 msgid "unignore;unblock"
 msgstr "désignorer;ne plus ignorer"
 
-#: resources/public/pebble_templates/index.html:429:85
+#: resources/public/pebble_templates/index.html
 msgid "Unignore"
 msgstr "Ne plus ignorer"
 
-#: resources/public/pebble_templates/index.html:436:36
+#: resources/public/pebble_templates/index.html
 msgid "overlays;virginmap;heatmap;grid"
 msgstr "calques;virginmap;heatmap;carte d'activité;grille"
 
-#: resources/public/pebble_templates/index.html:438:24
+#: resources/public/pebble_templates/index.html
 msgid "Overlay Settings"
 msgstr "Paramètres des calques"
 
-#: resources/public/pebble_templates/index.html:441:44
+#: resources/public/pebble_templates/index.html
 msgid "heatmap;heatmap opacity;clear heatmap"
 msgstr "heatmap;carte d'activité"
 
-#: resources/public/pebble_templates/index.html:442:28
+#: resources/public/pebble_templates/index.html
 msgid "Heatmap"
 msgstr "Carte d'activité"
 
-#: resources/public/pebble_templates/index.html:446:57
+#: resources/public/pebble_templates/index.html
 msgid "Turn on heatmap"
 msgstr "Afficher la carte d'activité"
 
-#: resources/public/pebble_templates/index.html:448:70
+#: resources/public/pebble_templates/index.html
 msgid "(toggle with <kbd>H</kbd>)"
 msgstr "(activer/désactiver avec <kbd>H</kbd>)"
 
-#: resources/public/pebble_templates/index.html:450:44
+#: resources/public/pebble_templates/index.html
 msgid "overlays;activity;pixels placed pixels;wipe;clean"
 msgstr "calques;activité;pixels placés;réinitialiser"
 
-#: resources/public/pebble_templates/index.html:451:71
+#: resources/public/pebble_templates/index.html
 msgid "Clear heatmap"
 msgstr "Réinitialiser la carte d'activité"
 
-#: resources/public/pebble_templates/index.html:452:51
+#: resources/public/pebble_templates/index.html
 msgid "(hotkey: <kbd>O</kbd>)"
 msgstr "(raccourci : <kbd>O</kbd>)"
 
-#: resources/public/pebble_templates/index.html:454:44
+#: resources/public/pebble_templates/index.html
 msgid "overlays;user activity;pixels placed pixels;transparency"
 msgstr "calques;activité utilisateur;pixels placés;transparence"
 
-#: resources/public/pebble_templates/index.html:456:57
+#: resources/public/pebble_templates/index.html
 msgid "Heatmap background opacity:"
 msgstr "Opacité du fond de la carte d'activité :"
 
-#: resources/public/pebble_templates/index.html:461:44
+#: resources/public/pebble_templates/index.html
 msgid "virginmap;virginmap opacity;clear virginmap"
 msgstr "virginmap;opacité;réinitialiser"
 
-#: resources/public/pebble_templates/index.html:462:28
+#: resources/public/pebble_templates/index.html
 msgid "Virginmap"
 msgstr "Virginmap"
 
-#: resources/public/pebble_templates/index.html:466:57
+#: resources/public/pebble_templates/index.html
 msgid "Turn on virginmap"
 msgstr "Afficher la virginmap"
 
-#: resources/public/pebble_templates/index.html:468:72
+#: resources/public/pebble_templates/index.html
 msgid "(toggle with <kbd>X</kbd>)"
 msgstr "(activer/désactiver avec <kbd>X</kbd>)"
 
-#: resources/public/pebble_templates/index.html:470:44
+#: resources/public/pebble_templates/index.html
 msgid "overlays;user activity;pixels unplaced pixels;transparency"
 msgstr "calques;activité utilisateur;pixels non placés;transparence"
 
-#: resources/public/pebble_templates/index.html:472:57
+#: resources/public/pebble_templates/index.html
 msgid "Virginmap background opacity:"
 msgstr "Opacité du fond de la virginmap :"
 
-#: resources/public/pebble_templates/index.html:476:44
+#: resources/public/pebble_templates/index.html
 msgid "overlays;activity;pixels unplaced pixels;wipe;clean"
 msgstr "calques;activité;pixels non placés;réinitialiser"
 
-#: resources/public/pebble_templates/index.html:477:71
+#: resources/public/pebble_templates/index.html
 msgid "Clear virginmap"
 msgstr "Réinitialiser la virginmap"
 
-#: resources/public/pebble_templates/index.html:478:51
+#: resources/public/pebble_templates/index.html
 msgid "(hotkey: <kbd>U</kbd>)"
 msgstr "(raccourci : <kbd>U</kbd>)"
 
-#: resources/public/pebble_templates/index.html:483:57
+#: resources/public/pebble_templates/index.html
 msgid "Layer template underneath heatmap"
 msgstr "Faire passer le modèle sous la carte d'activité"
 
-#: resources/public/pebble_templates/index.html:487:44
+#: resources/public/pebble_templates/index.html
 msgid "grid;toggle grid"
 msgstr "grille"
 
-#: resources/public/pebble_templates/index.html:488:28
+#: resources/public/pebble_templates/index.html
 msgid "Grid"
 msgstr "Grille"
 
-#: resources/public/pebble_templates/index.html:492:57
+#: resources/public/pebble_templates/index.html
 msgid "Turn on grid"
 msgstr "Activer la grille"
 
-#: resources/public/pebble_templates/index.html:494:67
+#: resources/public/pebble_templates/index.html
 msgid "(toggle with <kbd>G</kbd>)"
 msgstr "(activer/désactiver avec <kbd>G</kbd>)"
 
-#: resources/public/pebble_templates/index.html:499:36
+#: resources/public/pebble_templates/index.html
 msgid "controls;zooming;panning;movement"
 msgstr "contrôles;zoom;mouvement:déplacement"
 
-#: resources/public/pebble_templates/index.html:501:24
+#: resources/public/pebble_templates/index.html
 msgid "Control Settings"
 msgstr "Paramètres des Contrôles"
 
-#: resources/public/pebble_templates/index.html:504:44
+#: resources/public/pebble_templates/index.html
 msgid "zooming;scrolling;scale;scaling"
 msgstr "zoom;scrolling;taille;échelle"
 
-#: resources/public/pebble_templates/index.html:505:28
+#: resources/public/pebble_templates/index.html
 msgid "Zooming"
 msgstr "Zoomer"
 
-#: resources/public/pebble_templates/index.html:506:44
+#: resources/public/pebble_templates/index.html
 msgid "scrolling sensitivity;zooming sensitivity;mousewheel sensitivity"
 msgstr "sensibilité du zoom;zoom;molette de souris;roulette de souris"
 
-#: resources/public/pebble_templates/index.html:508:57
+#: resources/public/pebble_templates/index.html
 msgid "Zoom sensitivity:"
 msgstr "Sensibilité du zoom :"
 
-#: resources/public/pebble_templates/index.html:512:44
+#: resources/public/pebble_templates/index.html
 msgid "zooming limit;scrolling limit;mousewheel;zooming minimum;zooming maximum"
 msgstr "limites du zoom;limites du scroll;roulette de souris;molette de souris;minimum du zoom;maximum du zoom"
 
-#: resources/public/pebble_templates/index.html:514:57
+#: resources/public/pebble_templates/index.html
 msgid "Minimum scale:"
 msgstr "Échelle minimale :"
 
-#: resources/public/pebble_templates/index.html:518:57
+#: resources/public/pebble_templates/index.html
 msgid "Maximum scale:"
 msgstr "Échelle maximale :"
 
-#: resources/public/pebble_templates/index.html:522:44
+#: resources/public/pebble_templates/index.html
 msgid "rounding;zooming;scrolling;mousewheel;integer;decimal"
 msgstr "arrondissement;zoom;scrolling;roulette de souris;molette de souris;nombre entier"
 
-#: resources/public/pebble_templates/index.html:525:57
+#: resources/public/pebble_templates/index.html
 msgid "Round zoom values to nearest whole number"
 msgstr "Arrondir les valeurs de zoom à l'entier le plus proche"
 
-#: resources/public/pebble_templates/index.html:529:44
+#: resources/public/pebble_templates/index.html
 msgid "controls;miscellaneous"
 msgstr "contrôles;divers"
 
-#: resources/public/pebble_templates/index.html:534:57
+#: resources/public/pebble_templates/index.html
 msgid "Lock the canvas (disallow canvas drag/zoom with mouse/fingers)"
 msgstr "Verrouiller le canvas (empêcher le mouvement/zoom avec la souris ou les doigts)"
 
-#: resources/public/pebble_templates/index.html:537:44
+#: resources/public/pebble_templates/index.html
 msgid "MMB picker;mouse picker;selection;palette picker"
 msgstr "sélectionner une couleur;échantillonner une couleur"
 
-#: resources/public/pebble_templates/index.html:540:57
+#: resources/public/pebble_templates/index.html
 msgid "Enable middle mouse button selecting color from board"
 msgstr "Activer l'échantillonnage de couleur sur le canvas avec le clic du milieu"
 
-#: resources/public/pebble_templates/index.html:543:44
+#: resources/public/pebble_templates/index.html
 msgid "right click action"
 msgstr "raccourci clic droit"
 
-#: resources/public/pebble_templates/index.html:545:57
+#: resources/public/pebble_templates/index.html
 msgid "Right-click action:"
 msgstr "Action du clic droit :"
 
-#: resources/public/pebble_templates/index.html:547:60
+#: resources/public/pebble_templates/index.html
 msgid "Nothing"
 msgstr "Rien"
 
-#: resources/public/pebble_templates/index.html:548:58
+#: resources/public/pebble_templates/index.html
 msgid "Clear color"
 msgstr "Retirer la couleur"
 
-#: resources/public/pebble_templates/index.html:549:57
+#: resources/public/pebble_templates/index.html
 msgid "Copy color"
 msgstr "Copier la couleur"
 
-#: resources/public/pebble_templates/index.html:550:59
+#: resources/public/pebble_templates/index.html
 msgid "Lookup"
 msgstr "inspection du pixel"
 
-#: resources/public/pebble_templates/index.html:551:64
+#: resources/public/pebble_templates/index.html
 msgid "Clear color + Lookup"
 msgstr "Retirer la couleur + inspection du pixel"
 
-#: resources/public/pebble_templates/index.html:558:36
+#: resources/public/pebble_templates/index.html
 msgid "snapshots;screenshot;download;picture;canvas"
 msgstr "captures;capture d'écran;télécharger;image;canvas"
 
-#: resources/public/pebble_templates/index.html:560:24
+#: resources/public/pebble_templates/index.html
 msgid "Snapshot Settings"
 msgstr "Paramètres de capture"
 
-#: resources/public/pebble_templates/index.html:563:44
+#: resources/public/pebble_templates/index.html
 msgid "screenshot;snapshot;download;board;canvas"
 msgstr "captures;capture d'écran;télécharger;canvas"
 
-#: resources/public/pebble_templates/index.html:564:44
+#: resources/public/pebble_templates/index.html
 msgid "take screenshot;image;download format;picture;canvas;board"
 msgstr "prendre une capture;image;télécharger;format;image;canvas"
 
-#: resources/public/pebble_templates/index.html:566:57
+#: resources/public/pebble_templates/index.html
 msgid "Snapshot image format:"
 msgstr "Format de la capture du canvas :"
 
-#: resources/public/pebble_templates/index.html:568:71
+#: resources/public/pebble_templates/index.html
 msgid "PNG"
 msgstr "PNG"
 
-#: resources/public/pebble_templates/index.html:569:63
+#: resources/public/pebble_templates/index.html
 msgid "JPEG"
 msgstr "JPEG"
 
-#: resources/public/pebble_templates/index.html:570:63
+#: resources/public/pebble_templates/index.html
 msgid "WEBP (Chrome only)"
 msgstr "WEBP (seulement pour Chrome)"
 
-#: resources/public/pebble_templates/index.html:577:36
+#: resources/public/pebble_templates/index.html
 msgid "templates;overlays;guides"
 msgstr "modèles;calques;guides"
 
-#: resources/public/pebble_templates/index.html:582:44
+#: resources/public/pebble_templates/index.html
 msgid "templates;overlays;image;pixel art"
 msgstr "modèles;calques;image;pixel art;pixelart"
 
-#: resources/public/pebble_templates/index.html:583:44
+#: resources/public/pebble_templates/index.html
 msgid "template enabled;template disabled;show template;hide template;template shown;template hidden"
 msgstr "modèle activé;modèle désactivé;afficher modèle;cacher modèle"
 
-#: resources/public/pebble_templates/index.html:586:57
+#: resources/public/pebble_templates/index.html
 msgid "Use template"
 msgstr "Afficher le modèle"
 
-#: resources/public/pebble_templates/index.html:589:27
+#: resources/public/pebble_templates/index.html
 msgid "Hold down <kbd>Ctrl</kbd> (or <kbd>Option</kbd> on mac) to drag the template around"
 msgstr "Garder <kbd>Ctrl</kbd> appuyé (ou <kbd>Option</kbd> sur mac) avec le clic pour déplacer le modèle sur le canvas"
 
-#: resources/public/pebble_templates/index.html:590:44
+#: resources/public/pebble_templates/index.html
 msgid "template title;template name;tab name;tab title;title="
 msgstr "titre du modèle;nom du modèle;nom de l'onglet;titre de l'onglet;title="
 
-#: resources/public/pebble_templates/index.html:592:57
+#: resources/public/pebble_templates/index.html
 msgid "Title:"
 msgstr "Titre :"
 
-#: resources/public/pebble_templates/index.html:596:44
+#: resources/public/pebble_templates/index.html
 msgid "template location source;template source URL;template URL;template="
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:598:57
+#: resources/public/pebble_templates/index.html
 msgid "URL:"
 msgstr "URL :"
 
-#: resources/public/pebble_templates/index.html:603:44
+#: resources/public/pebble_templates/index.html
 msgid "template position;template x;template y;template location; template vertical; template horizontal;ox=;oy="
 msgstr "position du modèle;coordonnées du modèle;ox=;oy="
 
-#: resources/public/pebble_templates/index.html:605:57
+#: resources/public/pebble_templates/index.html
 msgid "Horizontal position:"
 msgstr "Position horizontale :"
 
-#: resources/public/pebble_templates/index.html:609:57
+#: resources/public/pebble_templates/index.html
 msgid "Vertical position:"
 msgstr "Position verticale :"
 
-#: resources/public/pebble_templates/index.html:613:44
+#: resources/public/pebble_templates/index.html
 msgid "template width;tw="
 msgstr "largeur du modèle;tw="
 
-#: resources/public/pebble_templates/index.html:615:57
+#: resources/public/pebble_templates/index.html
 msgid "Width:"
 msgstr "Largeur :"
 
-#: resources/public/pebble_templates/index.html:618:82
-#: resources/public/pebble_templates/index.html:688:79
+#: resources/public/pebble_templates/index.html
 msgid "Reset"
 msgstr "Réinitialiser"
 
-#: resources/public/pebble_templates/index.html:620:44
+#: resources/public/pebble_templates/index.html
 msgid "template style;custom template"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:622:57
+#: resources/public/pebble_templates/index.html
 msgid "Style:"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:624:53
+#: resources/public/pebble_templates/index.html
 msgid "Use Source Style"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:625:239
+#: resources/public/pebble_templates/index.html
 msgid "Dotted (Small, 1:2)"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:626:271
+#: resources/public/pebble_templates/index.html
 msgid "Dotted (Big, 2:2)"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:627:1803
+#: resources/public/pebble_templates/index.html
 msgid "Numbers"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:628:85
+#: resources/public/pebble_templates/index.html
 msgid "Custom…"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:632:44
+#: resources/public/pebble_templates/index.html
 msgid "template style source;template style URL;custom style URL;custom template"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:634:57
+#: resources/public/pebble_templates/index.html
 msgid "Custom style URL:"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:639:44
+#: resources/public/pebble_templates/index.html
 msgid "template conversion;template palette conversion;convert to palette"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:641:57
+#: resources/public/pebble_templates/index.html
 msgid "Color Conversion Mode:"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:643:64
+#: resources/public/pebble_templates/index.html
 msgid "Unconverted"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:644:66
+#: resources/public/pebble_templates/index.html
 msgid "Nearest Custom"
 msgstr ""
 
-#: resources/public/pebble_templates/index.html:648:44
+#: resources/public/pebble_templates/index.html
 msgid "template transparency;template opacity;oo="
 msgstr "transparence du modèle;opacité du modèle;oo="
 
-#: resources/public/pebble_templates/index.html:650:57
+#: resources/public/pebble_templates/index.html
 msgid "Opacity:"
 msgstr "Opacité :"
 
-#: resources/public/pebble_templates/index.html:658:36
+#: resources/public/pebble_templates/index.html
 msgid "sound;notification;alert;notify;ping"
 msgstr "son;notification;alerte;ping"
 
-#: resources/public/pebble_templates/index.html:660:24
+#: resources/public/pebble_templates/index.html
 msgid "Sound and Notification Settings"
 msgstr "Paramètres des Notifications/Sons"
 
-#: resources/public/pebble_templates/index.html:665:44
+#: resources/public/pebble_templates/index.html
 msgid "audio;mute;noise;volume"
 msgstr "audio;rendre muet;son;volume"
 
-#: resources/public/pebble_templates/index.html:668:57
+#: resources/public/pebble_templates/index.html
 msgid "Enable sound"
 msgstr "Activer le son"
 
-#: resources/public/pebble_templates/index.html:671:44
+#: resources/public/pebble_templates/index.html
 msgid "notifs;notify;pixel notification"
 msgstr "notifications;notifs;notification de pixel"
 
-#: resources/public/pebble_templates/index.html:674:57
+#: resources/public/pebble_templates/index.html
 msgid "Enable pixel available notification"
 msgstr "Activer la notification quand un pixel est prêt à être placé"
 
-#: resources/public/pebble_templates/index.html:678:44
+#: resources/public/pebble_templates/index.html
 msgid "notification;pixel ready;alert"
 msgstr "notification;pixel prêt;alerte"
 
-#: resources/public/pebble_templates/index.html:679:28
+#: resources/public/pebble_templates/index.html
 msgid "Pixel Ready Notification"
 msgstr "Notification quand un pixel est prêt"
 
-#: resources/public/pebble_templates/index.html:680:44
+#: resources/public/pebble_templates/index.html
 msgid "alert source;notify url;notify source;notification url;notification source"
 msgstr "source du son;source de la notification;url de la notification;son"
 
-#: resources/public/pebble_templates/index.html:682:57
+#: resources/public/pebble_templates/index.html
 msgid "Alert URL:"
 msgstr "URL du son d'alerte :"
 
-#: resources/public/pebble_templates/index.html:686:85
+#: resources/public/pebble_templates/index.html
 msgid "Update"
 msgstr "Mettre à jour"
 
-#: resources/public/pebble_templates/index.html:687:83
+#: resources/public/pebble_templates/index.html
 msgid "Test"
 msgstr "Tester"
 
-#: resources/public/pebble_templates/index.html:691:44
+#: resources/public/pebble_templates/index.html
 msgid "sound level;audio level;mute audio;mute sound"
 msgstr "niveau sonore;volume sonore;rendre muet"
 
-#: resources/public/pebble_templates/index.html:693:57
+#: resources/public/pebble_templates/index.html
 msgid "Volume:"
 msgstr "Volume :"
 
-#: resources/public/pebble_templates/index.html:698:44
+#: resources/public/pebble_templates/index.html
 msgid "alert forewarning;alert delay; notification delay; notification forewarning"
 msgstr "délai;délai de notification;délai d'alerte"
 
-#: resources/public/pebble_templates/index.html:700:57
+#: resources/public/pebble_templates/index.html
 msgid "Delay (seconds):"
 msgstr "Délai (secondes) :"
 
-#: resources/public/pebble_templates/index.html:705:44
+#: resources/public/pebble_templates/index.html
 msgid "chat mentions;chat pings;chat sound"
 msgstr "mentions de chat;notifications de chat;ping"
 
-#: resources/public/pebble_templates/index.html:706:28
+#: resources/public/pebble_templates/index.html
 msgid "Chat Pings"
 msgstr "Mentions de chat"
 
-#: resources/public/pebble_templates/index.html:710:57
+#: resources/public/pebble_templates/index.html
 msgid "Enable pings"
 msgstr "Autoriser les mentions de chat"
 
-#: resources/public/pebble_templates/index.html:713:44
+#: resources/public/pebble_templates/index.html
 msgid "mention sound"
 msgstr "son de mention;ping"
 
-#: resources/public/pebble_templates/index.html:715:57
+#: resources/public/pebble_templates/index.html
 msgid "Play sound on ping:"
 msgstr "Émettre un son quand on est mentionné :"
 
-#: resources/public/pebble_templates/index.html:717:56
-#: resources/public/include/chat.js:1937:100
+#: resources/public/pebble_templates/index.html
+#: resources/public/include/chat.js
 msgid "Off"
 msgstr "Jamais"
 
-#: resources/public/pebble_templates/index.html:718:61
+#: resources/public/pebble_templates/index.html
 msgid "Only when necessary"
 msgstr "Seulement quand nécessaire"
 
-#: resources/public/pebble_templates/index.html:719:59
+#: resources/public/pebble_templates/index.html
 msgid "Always"
 msgstr "Toujours"
 
-#: resources/public/pebble_templates/index.html:723:44
+#: resources/public/pebble_templates/index.html
 msgid "mention sound volume"
 msgstr "volume;son;mention"
 
-#: resources/public/pebble_templates/index.html:725:57
+#: resources/public/pebble_templates/index.html
 msgid "Ping sound volume:"
 msgstr "Volume du son de mention :"
 
-#: resources/public/pebble_templates/index.html:733:36
+#: resources/public/pebble_templates/index.html
 msgid "personal account"
 msgstr "compte personnel"
 
-#: resources/public/pebble_templates/index.html:735:24
+#: resources/public/pebble_templates/index.html
 msgid "Account Settings"
 msgstr "Paramètres du Compte"
 
-#: resources/public/pebble_templates/index.html:741:57
+#: resources/public/pebble_templates/index.html
 msgid "Public Discord name:"
 msgstr "Nom Public Discord :"
 
-#: resources/public/pebble_templates/index.html:745:83
-#: resources/public/include/chat.js:1939:92
-#: resources/public/include/chat.js:2003:92
+#: resources/public/pebble_templates/index.html
+#: resources/public/include/chat.js
 msgid "Set"
 msgstr "Définir"
 
-#: resources/public/pebble_templates/index.html:746:86
+#: resources/public/pebble_templates/index.html
 msgid "Remove"
 msgstr "Retirer"
 
 #. FAQ panel
-#: resources/public/pebble_templates/index.html:759:65
+#: resources/public/pebble_templates/index.html
 msgid "Help"
 msgstr "Aide"
 
-#: resources/public/pebble_templates/index.html:772:54
+#: resources/public/pebble_templates/index.html
 msgid "Notifications"
 msgstr "Notifications"
 
-#: resources/public/pebble_templates/faq.html:3:16
+#: resources/public/pebble_templates/faq.html
 msgid "FAQ"
 msgstr "FAQ"
 
-#: resources/public/pebble_templates/faq.html:7:20
+#: resources/public/pebble_templates/faq.html
 msgid "Why is the cooldown as long as it is?"
 msgstr "Pourquoi est-ce que le temps à attendre entre chaque pixel est aussi long ?"
 
-#: resources/public/pebble_templates/faq.html:8:20
+#: resources/public/pebble_templates/faq.html
 msgid "The time it takes to get a pixel is dynamic, and changes based on how many people are online. The cooldown time is longer when more users are online."
 msgstr "Le temps que ça prend pour charger un pixel change en fonction du nombre de personnes en ligne. Ce temps sera plus long si plus de monde est en ligne."
 
-#: resources/public/pebble_templates/faq.html:9:20
+#: resources/public/pebble_templates/faq.html
 msgid "Why does it say 0/6 pixels?"
 msgstr "Pourquoi est-ce que ça dit que j'ai 0/6 pixels ?"
 
-#: resources/public/pebble_templates/faq.html:10:20
+#: resources/public/pebble_templates/faq.html
 msgid "This means that you are waiting for your next pixel. When you place a pixel, there is a cooldown for when you can place the next one. Over time, you can gain up to 6 \"stacked\" pixels to place at once."
 msgstr "Ça veut dire que tu es en train d'attendre que ton prochain pixel soit prêt. Quand tu places un pixel, il y a un certain temps avant que tu puisses en placer un autre. Après un certain temps, tu peux obtenir jusqu'à 6 pixels \"stackés\""
 
-#: resources/public/pebble_templates/faq.html:11:20
+#: resources/public/pebble_templates/faq.html
 msgid "Why does it take so long to \"stack\" pixels?"
 msgstr "Pourquoi est-ce que ça prend autant de temps pour \"stacker\" des pixels ?"
 
-#: resources/public/pebble_templates/faq.html:12:20
+#: resources/public/pebble_templates/faq.html
 msgid "This is by design. It is better to place a pixel as soon as you get one. Pixel \"stacking\" is meant to give you a bump if you go AFK for a bit. It takes around 40 minutes to get a full 6/6 pixels, but it only takes around 3 minutes to place 6 pixels if you place them as soon as possible."
 msgstr "Simple design. C'est mieux de placer un pixel dès que tu en as l'opportunité. Le \"stacking\"est fait pour te donner un coup de pouce pour les moments où tu est AFK. Ça peut prendre jusqu'à 40 minutes pour obtenir 6/6 pixels, mais ça prend jusqu'à 3 minutes d'en placer 6 si tu les places dès que possible."
 
-#: resources/public/pebble_templates/faq.html:13:20
+#: resources/public/pebble_templates/faq.html
 msgid "How do I appeal a ban?"
 msgstr "Comment puis-je faire appel à un bannissement ?"
 
-#: resources/public/pebble_templates/faq.html:14:20
+#: resources/public/pebble_templates/faq.html
 msgid "Contact us on <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord</a> or send an appeal to our <a href=\"https://pxls.space/appeal\" target=\"_blank\">Google form</a> after reading the rules in the site's info panel."
 msgstr "Contacte-nous à <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord</a> ou envoie un appel à notre <a href=\"https://pxls.space/appeal\" target=\"_blank\">Google form</a> après avoir lu les règles dans le panel des infos du site."
 
-#: resources/public/pebble_templates/faq.html:15:20
+#: resources/public/pebble_templates/faq.html
 msgid "How do I make a template?"
 msgstr "Comment créer un modèle ?"
 
-#: resources/public/pebble_templates/faq.html:16:20
+#: resources/public/pebble_templates/faq.html
 msgid "A template is an image link that is posted in the template textbox in the settings panel so you can place over it on the canvas. You may use a regular image link to your pixel art, but many people use the 3rd party tool <a href=\"https://pxlsfiddle.com\" target=\"_blank\">PxlsFiddle</a> to turn pixel art into a fancier link. If you need to make pixel art yourself, you can use <a href=\"https://www.piskelapp.com/p/create\" target=\"_blank\">Piskel</a> to create art to put into PxlsFiddle."
 msgstr "Un modèle est un lien d'image qui est posté dans la boîte de texte des modèles dans les paramètres afin de pouvoir le placer sur le canvas. Tu peux utiliser un lien d'image normal pour ton pixel art, mais beaucoup de gens utilisent l'outil <a href=\"https://pxlsfiddle.com\" target=\"_blank\">PxlsFiddle</a> pour transformer ton pixel art en un lien plus simple. Si tu as besoin de faire un pixel art toi même, tu peux utliser <a href=\"https://www.piskelapp.com/p/create\" target=\"_blank\">Piskel</a> pour créer un modèle et le mettre ensuite dans PxlsFiddle."
 
-#: resources/public/pebble_templates/faq.html:17:20
+#: resources/public/pebble_templates/faq.html
 msgid "How do I move a template?"
 msgstr "Comment est-ce que je déplace mon modèle ?"
 
-#: resources/public/pebble_templates/faq.html:18:20
+#: resources/public/pebble_templates/faq.html
 msgid "Hold <kbd>CTRL</kbd> (or <kbd>OPTION</kbd> on macOS) and click and drag to move it around. On mobile, you can tap and hold where you want to move the template and click \"Move Template Here\" in the pop-up."
 msgstr "Maintiens <kbd>CTRL</kbd> (ou <kbd>OPTION</kbd> sur macOS) et déplace le en laissant appuyer le clique gauche. Sur téléphone, tu peux taper et laisser appuyer ou tu veux déplacer ton modèle et cliquer \"Déplacer le modèle ici\" dans le pop-up"
 
-#: resources/public/pebble_templates/faq.html:19:20
+#: resources/public/pebble_templates/faq.html
 msgid "Does the canvas reset? When?"
 msgstr "Est-ce que le canvas se réinitialise ? Quand ?"
 
-#: resources/public/pebble_templates/faq.html:20:20
+#: resources/public/pebble_templates/faq.html
 msgid "Yes. The canvas resets when it is completely full. A reset date is not usually decided until the canvas is full, but the average canvas life-span is around 1 month. Updates are posted in our <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a> when a reset date is set."
 msgstr "Oui. Le canvas se réinitialise quand il est complètement rempli. Une date exacte est choisie seulement quand le canvas est plein, mais la durée de vie moyenne est de 1 mois. Les annonces sont publiées dans notre <a href=\"https://pxls.space/discord\" target=\"_blank\">serveur Discord</a> lorsqu'une date est choisie."
 
-#: resources/public/pebble_templates/faq.html:21:20
+#: resources/public/pebble_templates/faq.html
 msgid "Where can I see the past canvases?"
 msgstr "Où puis-je voir les anciens canvas ?"
 
-#: resources/public/pebble_templates/faq.html:22:20
+#: resources/public/pebble_templates/faq.html
 msgid "The past canvases are featured on our <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a>, or the 3rd party website <a href=\"https://pxlsfiddle.com\" target=\"_blank\">PxlsFiddle</a>, which records timelapses and a lot of useful information on each canvas."
 msgstr "Les anciens canvas sont situés dans notre <a href=\"https://pxls.space/discord\" target=\"_blank\">serveur Discord</a>, ou sur le site web third-party <a href=\"https://pxlsfiddle.com\" target=\"_blank\">PxlsFiddle</a>, qui enregistre des timelapses et plein d'autres informations utiles pour chaque canvas."
 
-#: resources/public/pebble_templates/faq.html:23:20
+#: resources/public/pebble_templates/faq.html
 msgid "How do I see who placed a pixel?"
 msgstr "Comment puis-je voir qui a placé un pixel ?"
 
-#: resources/public/pebble_templates/faq.html:24:20
+#: resources/public/pebble_templates/faq.html
 msgid "By shift-clicking (or tap and hold on mobile) a pixel, you can see who placed a pixel, how many pixels they have placed, and when they placed it."
 msgstr "En shift-cliquant (ou en maintenant son doigt sur mobile) sur un pixel, vous pouvez voir qui l'a placé, le nombre de pixels que l'individu a placé, et le moment ou ce pixel a été placé."
 
-#: resources/public/pebble_templates/faq.html:25:20
+#: resources/public/pebble_templates/faq.html
 msgid "How do I report someone?"
 msgstr "Comment est-ce que je signale quelqu'un ?"
 
-#: resources/public/pebble_templates/faq.html:26:20
+#: resources/public/pebble_templates/faq.html
 msgid "Shift-click (or tap and hold on mobile) on a pixel, and click the Report button."
 msgstr "Shift-click (ou en maintenant son doigt sur mobile) sur un pixel, et appuyez sur le bouton Signaler."
 
-#: resources/public/pebble_templates/faq.html:27:20
+#: resources/public/pebble_templates/faq.html
 msgid "How do I change the color of my name in the chat?"
 msgstr "Comment est-ce que je change la couleur de mon nom dans le chat ?"
 
-#: resources/public/pebble_templates/faq.html:28:20
+#: resources/public/pebble_templates/faq.html
 msgid "There is a \"Username Color\" option near the bottom of the settings panel."
 msgstr "Il y a une option \"Couleur du nom d'utilisateur\" près du bas des options."
 
-#: resources/public/pebble_templates/faq.html:29:20
+#: resources/public/pebble_templates/faq.html
 msgid "What is a \"virginmap\"?"
 msgstr "Qu'est-ce que la \"virginmap\" ?"
 
-#: resources/public/pebble_templates/faq.html:30:20
+#: resources/public/pebble_templates/faq.html
 msgid "The virginmap shows which pixels have not yet been placed on (or “virgin” pixels)."
 msgstr "La virginmap montre quels pixels n'ont pas encore été touchés (les pixels “vierges”)."
 
-#: resources/public/pebble_templates/faq.html:31:20
+#: resources/public/pebble_templates/faq.html
 msgid "How do I report bugs?"
 msgstr "Comment puis-je signaler un bug ?"
 
-#: resources/public/pebble_templates/faq.html:32:20
+#: resources/public/pebble_templates/faq.html
 msgid "Submit bugs to the #dev-and-bugs channel in the <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a>. If you have found an exploit, please message one of the staff members privately (through DMs)."
 msgstr "Publie ton problème dans le salon #devs-and-bugs dans notre <a href=\"https://pxls.space/discord\" target=\"_blank\">serveur Discord</a>. Si tu as trouvé une méthode pour exploiter le site, merci de contacter un membre du staff (en message privé)."
 
-#: resources/public/pebble_templates/faq.html:33:20
+#: resources/public/pebble_templates/faq.html
 msgid "How do I get more info or contact staff?"
 msgstr "Comment puis-je avoir plus d'informations ou contacter le staff ?"
 
-#: resources/public/pebble_templates/faq.html:34:20
+#: resources/public/pebble_templates/faq.html
 msgid "Check the info panel (the icon on the top left) for more details and links, or join our <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a>, where a staff member will gladly respond."
 msgstr "Regarde l'onglet d'information (l'icône dans le coin en haut à gauche) pour plus de détails et des liens, ou rejoignez notre <a href=\"https://pxls.space/discord\" target=\"_blank\">Discord server</a>, où un membre du staff te répondra avec plaisir."
 
-#: resources/public/pebble_templates/info.html:3:10
+#: resources/public/pebble_templates/info.html
 msgid "Welcome!"
 msgstr "Bienvenue !"
 
-#: resources/public/pebble_templates/info.html:6:9
+#: resources/public/pebble_templates/info.html
 msgid "Welcome to pxls.space! Pxls is a multiplayer online collaborative canvas that allows you to create anything you can imagine, one pixel at a time. Join hundreds of other players in the Pxls community and create amazing works of art together as a team, or solo."
 msgstr "Bienvenue sur pxls.space ! Pxls est un canvas collaboratif en ligne qui te permet de créer tout ce que tu peux imaginer, pixel après pixel. Rejoins des centaines de joueurs dans la communauté de Pxls et crée des œuvres d'art en équipe ou en solo."
 
-#: resources/public/pebble_templates/info.html:7:9
+#: resources/public/pebble_templates/info.html
 msgid "The best place to reach staff and fellow community is in the discord!"
 msgstr "Le meilleur endroit pour contacter le staff ou d'autres membres de la communauté est le serveur Discord !"
 
-#: resources/public/pebble_templates/info.html:8:9
+#: resources/public/pebble_templates/info.html
 msgid "Check out our social media pages, and please take the time to read the rules below. Have fun creating (or changing) art!"
 msgstr "Jette un œil à nos réseaux sociaux, et n'oublie pas de lire les règles ci-dessous. Profite bien du site, et amuse-toi bien à créer (ou modifier) de l'art !"
 
-#: resources/public/pebble_templates/info.html:13:27
+#: resources/public/pebble_templates/info.html
 msgid "Canvas Rules"
 msgstr "Règles du canvas"
 
-#: resources/public/pebble_templates/info.html:16:9
+#: resources/public/pebble_templates/info.html
 msgid "We pride ourselves on trying to keep an open canvas for all free from outside interference on our end, and especially censorship. However, for the good of the community and on accounts of our own beliefs, please acknowledge and obey the following guidelines:"
 msgstr "Nous mettons un point d'honneur à garder un canvas ouvert à tous sans interférences de notre part, et surtout sans censure. Toutefois, pour le bien de la communauté, nous te remercions de lire et obéir les quelques consignes suivantes :"
 
-#: resources/public/pebble_templates/info.html:18:11
+#: resources/public/pebble_templates/info.html
 msgid "No hateful imagery or derogatory speech. This includes but is not limited to words such as <i>faggot</i>, <i>nigger</i>, etc; as well as the Swastika, Hammer and Sickle, and any symbols of terrorism."
 msgstr "Pas d'imagerie haineuse ou propos dérogatoires. Ceci inclut (liste non exhaustive) des mots tels que <i>faggot</i>, <i>pédé</i>, <i>nigger</i>, etc, quelle que soit la langue utilisée ; ainsi que la croix gammée et tout symbole de terrorisme."
 
-#: resources/public/pebble_templates/info.html:19:11
+#: resources/public/pebble_templates/info.html
 msgid "No NSFW or NSFL content."
 msgstr "Pas de contenu NSFW ou NSFL (Not Safe For Work ou Not Safe For Life, autrement dit, indécent)"
 
-#: resources/public/pebble_templates/info.html:21:13
+#: resources/public/pebble_templates/info.html
 msgid "No nudity or otherwise sexually explicit content"
 msgstr "Pas de nudité ou autre contenu sexuellement explicite"
 
-#: resources/public/pebble_templates/info.html:23:15
+#: resources/public/pebble_templates/info.html
 msgid "No female-presenting nipples/bare breasts, genitalia, sexual fluids"
 msgstr "Pas de tétons féminins/seins nus, organes génitaux, fluides sexuels"
 
-#: resources/public/pebble_templates/info.html:26:13
+#: resources/public/pebble_templates/info.html
 msgid "No sexual imagery/erotica"
 msgstr "Pas d'imagerie pornographique/érotique"
 
-#: resources/public/pebble_templates/info.html:27:13
+#: resources/public/pebble_templates/info.html
 msgid "No excessive blood or otherwise obscene/shocking content"
 msgstr "Pas de sang excessif ou autre contenu obscène/choquant"
 
-#: resources/public/pebble_templates/info.html:30:11
+#: resources/public/pebble_templates/info.html
 msgid "No more than <b>one</b> account per user, no exceptions. Multiple account users will be banned from creating art on the canvas."
 msgstr "Pas plus d'<b>un</b> compte par personne, pas d'exceptions. Les utilisateurs utilisant plus d'un compte seront bannis définitivement du canvas sur tous leurs comptes."
 
-#: resources/public/pebble_templates/info.html:31:11
+#: resources/public/pebble_templates/info.html
 msgid "No auto-placement tools of any kind, you must place the pixels manually."
 msgstr "Pas d'outil d'autoplacement d'aucune sorte, les pixels doivent être placés manuellement."
 
-#: resources/public/pebble_templates/info.html:32:11
+#: resources/public/pebble_templates/info.html
 msgid "Do not abuse site functionality, such as reports or lookups. (e.g. automated reporting/lookups, etc.)"
 msgstr "Pas d'utilisation abusive de fonctionnalités du site, telles que les signalements ou les inspections. (Par exemple signalements/inspections automatisées, etc.)"
 
-#: resources/public/pebble_templates/info.html:33:11
+#: resources/public/pebble_templates/info.html
 msgid "Any automated aggregation of data from user lookups is not allowed, and will result in a ban."
 msgstr "Toute accumulation automatisée d'information utilisateur par inspections est interdite, et résultera en un bannissement."
 
-#: resources/public/pebble_templates/info.html:34:11
-#: resources/public/pebble_templates/info.html:62:11
+#: resources/public/pebble_templates/info.html
 msgid "Staff have final say in any rule disputes"
 msgstr "Le staff a le dernier mot dans tout débat concernant les règles"
 
-#: resources/public/pebble_templates/info.html:35:12
-#: resources/public/pebble_templates/info.html:64:13
+#: resources/public/pebble_templates/info.html
 msgid "If you feel a moderator has acted inappropriately, please report it to an administrator."
 msgstr "Si tu penses qu'un modérateur a agi de façon inappropriée, merci de le signaler à un administrateur."
 
-#: resources/public/pebble_templates/info.html:38:9
+#: resources/public/pebble_templates/info.html
 msgid "If you believe you have been falsely banned you may contact a moderator or administrator."
 msgstr "Si tu penses avoir été banni à tort, tu peux contacter un modérateur ou un administrateur."
 
-#: resources/public/pebble_templates/info.html:43:27
+#: resources/public/pebble_templates/info.html
 msgid "Chat Rules"
 msgstr "Règles du chat"
 
-#: resources/public/pebble_templates/info.html:47:11
+#: resources/public/pebble_templates/info.html
 msgid "Keep chat civil. No harassment or homophobic/transphobic/disablist language."
 msgstr "Garde le chat civil. Pas de harcèlement ou de propos homophobes/transphobes/dénigrant envers les personnes handicapées."
 
-#: resources/public/pebble_templates/info.html:48:11
+#: resources/public/pebble_templates/info.html
 msgid "No hate speech. This includes emoji/symbols/ASCII art."
 msgstr "Pas de langage haineux, y compris dans les émojis/symboles/l'art ASCII."
 
-#: resources/public/pebble_templates/info.html:50:13
+#: resources/public/pebble_templates/info.html
 msgid "Normal swearing/etc is allowed"
 msgstr "Les jurons normaux sont autorisés"
 
-#: resources/public/pebble_templates/info.html:53:11
+#: resources/public/pebble_templates/info.html
 msgid "No spamming"
 msgstr "Pas de spam"
 
-#: resources/public/pebble_templates/info.html:55:13
+#: resources/public/pebble_templates/info.html
 msgid "This includes excessive ASCII art/emojis/symbols/whitespace"
 msgstr "Cela inclut l'usage excessif d'art ASCII/émojis/symboles/blancs"
 
-#: resources/public/pebble_templates/info.html:58:11
+#: resources/public/pebble_templates/info.html
 msgid "No \"copy pasta\"s"
 msgstr "Pas de \"copy pasta\"s"
 
-#: resources/public/pebble_templates/info.html:59:11
+#: resources/public/pebble_templates/info.html
 msgid "No links to sites that actively break the canvas or chat rules (e.g. porn sites)"
 msgstr "Pas de liens vers des sites qui enfreignent aux règles du canvas ou du chat (par exemple des sites pornographiques)"
 
-#: resources/public/pebble_templates/info.html:60:11
+#: resources/public/pebble_templates/info.html
 msgid "No symbology which break the canvas or chat rules (e.g. NSFW ASCII art)"
 msgstr "Pas de symboles qui enfreignent les règles du canvas ou du chat (par exemple de l'art ASCII NSFW)"
 
-#: resources/public/pebble_templates/info.html:61:16
+#: resources/public/pebble_templates/info.html
 msgid "No personal information"
 msgstr "Pas d'information personnelle"
 
-#: resources/public/pebble_templates/info.html:72:10
+#: resources/public/pebble_templates/info.html
 msgid "Links"
 msgstr "Liens"
 
-#: resources/public/pebble_templates/info.html:76:64
+#: resources/public/pebble_templates/info.html
 msgid "Discord (main hub)"
 msgstr "Discord (hub principal)"
 
-#: resources/public/pebble_templates/info.html:77:68
+#: resources/public/pebble_templates/info.html
 msgid "Subreddit"
 msgstr "Subreddit"
 
-#: resources/public/pebble_templates/info.html:78:68
+#: resources/public/pebble_templates/info.html
 msgid "Twitter"
 msgstr "Twitter"
 
-#: resources/public/pebble_templates/info.html:79:66
+#: resources/public/pebble_templates/info.html
 msgid "GitHub"
 msgstr "GitHub"
 
 #. link to piskelapp.com
-#: resources/public/pebble_templates/info.html:81:71
+#: resources/public/pebble_templates/info.html
 msgid "Single-player mode"
 msgstr "Mode solo"
 
-#: resources/public/pebble_templates/info.html:84:62
+#: resources/public/pebble_templates/info.html
 msgid "Statistics"
 msgstr "Statistiques"
 
-#: resources/public/pebble_templates/info.html:85:64
+#: resources/public/pebble_templates/info.html
 msgid "Profile (user info, factions, etc.)"
 msgstr "Profil (informations sur les utilisateurs, factions, etc.)"
 
 #. link to pxlsfiddle.com
-#: resources/public/pebble_templates/info.html:87:68
+#: resources/public/pebble_templates/info.html
 msgid "Template generator, archives, timelapses, and other utilities"
 msgstr "Générateur de modèles, archives, timelapses et autres outils"
 
 #. link to pxlsfiddle.com
-#: resources/public/pebble_templates/info.html:87:165
+#: resources/public/pebble_templates/info.html
 msgid "PxlsFiddle (templates, archives, etc.)"
 msgstr "PxlsFiddle (modèles, archives, etc.)"
 
-#: resources/public/pebble_templates/info.html:93:10
+#: resources/public/pebble_templates/info.html
 msgid "Donate"
 msgstr "Don"
 
-#: resources/public/pebble_templates/info.html:96:9
+#: resources/public/pebble_templates/info.html
 msgid "Donations are not accepted at this time, but this panel will be updated when they're open again!"
 msgstr "Les dons ne sont pas acceptés en ce moment, mais cet onglet sera mis à jour quand ils seront de retour!"
 
 #. eg "Alice's profile". Double singlequote is a java thing - needed if a replacement (such as this) contains a singlequote.
-#: resources/public/pebble_templates/profile.html:31:66
-#: resources/public/pebble_templates/profile.html:50:131
+#: resources/public/pebble_templates/profile.html
 msgid "{0}''s Profile"
 msgstr "Profil de {0}"
 
-#: resources/public/pebble_templates/profile.html:41:84
-#: resources/public/pebble_templates/40x.html:28:84
-#: resources/public/pebble_templates/40x.html:45:100
-#: resources/public/pebble_templates/40x.html:62:100
+#: resources/public/pebble_templates/profile.html
+#: resources/public/pebble_templates/40x.html
 msgid "My Profile"
 msgstr "Mon Profil"
 
-#: resources/public/pebble_templates/profile.html:42:85
-#: resources/public/pebble_templates/40x.html:29:85
+#: resources/public/pebble_templates/profile.html
+#: resources/public/pebble_templates/40x.html
 msgid "My Factions"
 msgstr "Mes Factions"
 
-#: resources/public/pebble_templates/profile.html:60:93
-#: resources/public/pebble_templates/profile.html:126:56
+#: resources/public/pebble_templates/profile.html
 msgid "Reports"
 msgstr "Signalements"
 
-#: resources/public/pebble_templates/profile.html:63:94
+#: resources/public/pebble_templates/profile.html
 msgid "Factions"
 msgstr "Factions"
 
-#: resources/public/pebble_templates/profile.html:71:68
+#: resources/public/pebble_templates/profile.html
 msgid "You must be logged in to view your profile."
 msgstr "Tu dois être connecté pour consulter ton profil."
 
-#: resources/public/pebble_templates/profile.html:77:72
+#: resources/public/pebble_templates/profile.html
 msgid "Registration Date"
 msgstr "Date d'inscription"
 
-#: resources/public/pebble_templates/profile.html:82:72
-#: resources/public/include/lookup.js:280:21
+#: resources/public/pebble_templates/profile.html
+#: resources/public/include/lookup.js
 msgid "Alltime Pixels"
 msgstr "Pixels totaux"
 
-#: resources/public/pebble_templates/profile.html:86:72
+#: resources/public/pebble_templates/profile.html
 msgid "Current Canvas Pixels"
 msgstr "Pixels placés ce canvas"
 
-#: resources/public/pebble_templates/profile.html:91:72
+#: resources/public/pebble_templates/profile.html
 msgid "Discord Tag"
 msgstr "Tag Discord"
 
-#: resources/public/pebble_templates/profile.html:95:72
-#: resources/public/include/lookup.js:235:21
+#: resources/public/pebble_templates/profile.html
+#: resources/public/include/lookup.js
 msgid "Faction"
 msgstr "Faction"
 
-#: resources/public/pebble_templates/profile.html:96:259
+#: resources/public/pebble_templates/profile.html
 msgid "None"
 msgstr "Aucune"
 
-#: resources/public/pebble_templates/profile.html:99:72
-#: resources/public/admin/admin.js:198:16
+#: resources/public/pebble_templates/profile.html
+#: resources/public/admin/admin.js
 msgid "Roles"
 msgstr "Rôles"
 
-#: resources/public/pebble_templates/profile.html:104:72
+#: resources/public/pebble_templates/profile.html
 msgid "Canvas Ban Expiry"
 msgstr "Expiration du bannissement de canvas"
 
-#: resources/public/pebble_templates/profile.html:105:101
-#: resources/public/pebble_templates/profile.html:111:105
+#: resources/public/pebble_templates/profile.html
 msgid "Never"
 msgstr "Jamais"
 
-#: resources/public/pebble_templates/profile.html:110:72
+#: resources/public/pebble_templates/profile.html
 msgid "Chat Ban Expiry"
 msgstr "Expiration du bannissement de chat"
 
-#: resources/public/pebble_templates/profile.html:117:36
+#: resources/public/pebble_templates/profile.html
 msgid "View rankings and other stats <a href=\"/stats\">here</a>."
 msgstr "Consulter les classements et d'autres statistiques <a href=\"/stats\">ici</a>."
 
-#: resources/public/pebble_templates/profile.html:124:68
+#: resources/public/pebble_templates/profile.html
 msgid "You must be logged in to view your reports."
 msgstr "Tu dois être connecté pour consulter tes signalements."
 
-#: resources/public/pebble_templates/profile.html:130:64
+#: resources/public/pebble_templates/profile.html
 msgid "Canvas Reports ({0}/{1} open)"
 msgstr "Signalements du canvas ({0}/{1} ouvert(s))"
 
 #. eg "Report on Bob (closed)
-#: resources/public/pebble_templates/profile.html:142:56
-#: resources/public/pebble_templates/profile.html:177:56
+#: resources/public/pebble_templates/profile.html
 msgid "Report on {0} (closed)"
 msgstr "Signalement sur {0} (fermé)"
 
 #. eg "Report on Bob (open)
-#: resources/public/pebble_templates/profile.html:145:56
-#: resources/public/pebble_templates/profile.html:179:56
+#: resources/public/pebble_templates/profile.html
 msgid "Report on {0} (open)"
 msgstr "Signalement sur {0} (ouvert)"
 
 #. eg "Reported Bob on Jan 1, 1970, 00:00:00 AM (UTC)
-#: resources/public/pebble_templates/profile.html:152:60
-#: resources/public/pebble_templates/profile.html:185:60
+#: resources/public/pebble_templates/profile.html
 msgid "Reported {0} on {1}"
 msgstr "Signalé {0} à la date du {1}"
 
-#: resources/public/pebble_templates/profile.html:158:47
+#: resources/public/pebble_templates/profile.html
 msgid "There are no canvas reports to show."
 msgstr "Il n'y a aucun signalement du canvas à montrer."
 
-#: resources/public/pebble_templates/profile.html:166:64
+#: resources/public/pebble_templates/profile.html
 msgid "Chat Reports ({0}/{1} open)"
 msgstr "Signalement du Chat ({0}/{1} ouvert)"
 
-#: resources/public/pebble_templates/profile.html:191:47
+#: resources/public/pebble_templates/profile.html
 msgid "There are no chat reports to show."
 msgstr "Il n'y a aucun signalement du chat à montrer."
 
-#: resources/public/pebble_templates/profile.html:200:68
+#: resources/public/pebble_templates/profile.html
 msgid "You must be logged in to manage your factions."
 msgstr "Tu dois être connecté pour modifier tes factions."
 
-#: resources/public/pebble_templates/profile.html:205:36
+#: resources/public/pebble_templates/profile.html
 msgid "You are faction restricted and cannot create new factions. If you believe this is an error, please contact a moderator."
 msgstr "Tu es banni de la création des factions et ne peux pas en créer des nouvelles. Si tu penses que ceci est une erreur, merci de contacter un modérateur."
 
-#: resources/public/pebble_templates/profile.html:207:36
+#: resources/public/pebble_templates/profile.html
 msgid "You are canvas banned and cannot create new factions. If you believe this is an error, please contact a moderator."
 msgstr "Tu es banni du canvas et ne peux pas créer de nouvelles factions. Si tu penses que ceci est une erreur, merci de contacter un modérateur."
 
-#: resources/public/pebble_templates/profile.html:212:76
+#: resources/public/pebble_templates/profile.html
 msgid "You must have at least {0} all-time pixels to create a faction."
 msgstr "Tu dois avoir au moins {0} pixels totaux pour créer une faction."
 
-#: resources/public/pebble_templates/profile.html:215:300
+#: resources/public/pebble_templates/profile.html
 msgid "Create"
 msgstr "Créer"
 
-#: resources/public/pebble_templates/profile.html:216:191
+#: resources/public/pebble_templates/profile.html
 msgid "Join"
 msgstr "Rejoindre"
 
-#: resources/public/pebble_templates/profile.html:225:118
+#: resources/public/pebble_templates/profile.html
 msgid "This is your currently displayed faction."
 msgstr "Ceci est ta faction affichée actuelle."
 
 #. eg "Pixelers (members: 100, ID: 1)"
-#: resources/public/pebble_templates/profile.html:228:44
+#: resources/public/pebble_templates/profile.html
 msgid "{0} (members: {1}, ID: {2}"
 msgstr "{0} (membres: {1}, ID: {2}"
 
-#: resources/public/pebble_templates/profile.html:231:69
+#: resources/public/pebble_templates/profile.html
 msgid "Owner: {0}"
 msgstr "Propriétaire: {0}"
 
 #. makes the faction no longer the one displayed for the current user
-#: resources/public/pebble_templates/profile.html:236:175
+#: resources/public/pebble_templates/profile.html
 msgid "Remove Displayed"
 msgstr "Enlever la faction affichée"
 
 #. makes the faction the one displayed for the current user
-#: resources/public/pebble_templates/profile.html:239:172
+#: resources/public/pebble_templates/profile.html
 msgid "Set Displayed"
 msgstr "Choisir comme faction affichée"
 
-#: resources/public/pebble_templates/profile.html:242:235
+#: resources/public/pebble_templates/profile.html
 msgid "Members"
 msgstr "Membres"
 
-#: resources/public/pebble_templates/profile.html:243:169
+#: resources/public/pebble_templates/profile.html
 msgid "Edit"
 msgstr "Modifier"
 
-#: resources/public/pebble_templates/profile.html:244:168
-#: resources/public/include/chat.js:1462:24
+#: resources/public/pebble_templates/profile.html
+#: resources/public/include/chat.js
 msgid "Delete"
 msgstr "Supprimer"
 
-#: resources/public/pebble_templates/profile.html:246:174
+#: resources/public/pebble_templates/profile.html
 msgid "Leave"
 msgstr "Quitter"
 
-#: resources/public/pebble_templates/profile.html:253:68
+#: resources/public/pebble_templates/profile.html
 msgid "You are not in any factions yet!"
 msgstr "Tu n'es pas encore dans une faction !"
 
-#: resources/public/pebble_templates/profile.html:269:52
+#: resources/public/pebble_templates/profile.html
 msgid "Members of {0} ([{1}])"
 msgstr "Membres de {0} ([{1}])"
 
-#: resources/public/pebble_templates/profile.html:270:97
-#: resources/public/pebble_templates/profile.html:329:97
-#: resources/public/pebble_templates/profile.html:342:97
-#: resources/public/pebble_templates/profile.html:366:97
+#: resources/public/pebble_templates/profile.html
 msgid "Close"
 msgstr "Fermer"
 
-#: resources/public/pebble_templates/profile.html:278:60
+#: resources/public/pebble_templates/profile.html
 msgid "Faction Members"
 msgstr "Membres de la Faction"
 
-#: resources/public/pebble_templates/profile.html:292:128
+#: resources/public/pebble_templates/profile.html
 msgid "Transfer Ownership"
 msgstr "Transférer la possession"
 
 #. bans a user from the faction
-#: resources/public/pebble_templates/profile.html:294:122
-#: resources/public/include/chat.js:1733:60
+#: resources/public/pebble_templates/profile.html
+#: resources/public/include/chat.js
 msgid "Ban"
 msgstr "Exclure"
 
-#: resources/public/pebble_templates/profile.html:300:79
-#: resources/public/pebble_templates/profile.html:322:79
+#: resources/public/pebble_templates/profile.html
 msgid "Nothing to see here!"
 msgstr "Rien à voir ici !"
 
-#: resources/public/pebble_templates/profile.html:308:60
+#: resources/public/pebble_templates/profile.html
 msgid "Faction Bans"
 msgstr "Bannissements de la Faction"
 
-#: resources/public/pebble_templates/profile.html:318:125
-#: resources/public/include/chat.js:1629:36
-#: resources/public/include/chat.js:1733:46
-#: resources/public/admin/admin.js:320:88
-#: resources/public/admin/admin.js:347:52
+#: resources/public/pebble_templates/profile.html
+#: resources/public/include/chat.js resources/public/admin/admin.js
 msgid "Unban"
 msgstr "Révoquer le bannissement"
 
-#: resources/public/pebble_templates/profile.html:341:52
+#: resources/public/pebble_templates/profile.html
 msgid "Find A Faction"
 msgstr "Trouver une Faction"
 
-#: resources/public/pebble_templates/profile.html:351:99
+#: resources/public/pebble_templates/profile.html
 msgid "Search:"
 msgstr "Rechercher :"
 
-#: resources/public/pebble_templates/profile.html:361:66
+#: resources/public/pebble_templates/profile.html
 msgid "Enter a search term to get started."
 msgstr "Entre un terme de recherche ici pour débuter."
 
-#: resources/public/pebble_templates/profile.html:363:116
+#: resources/public/pebble_templates/profile.html
 msgid "Load More"
 msgstr "Charger plus"
 
 #. HTTP status code name
-#: resources/public/pebble_templates/40x.html:39:24
+#: resources/public/pebble_templates/40x.html
 msgid "Not Found"
 msgstr "Pas trouvé"
 
-#: resources/public/pebble_templates/40x.html:41:23
+#: resources/public/pebble_templates/40x.html
 msgid "The content you requested could not be found at this URL. If you believe this is an error, please contact a developer."
 msgstr "Le contenu que tu as demandé n'a pas pu être trouvé sur ce lien. Si tu penses que c'est un erreur, merci de contacter un développeur."
 
 #. links to the homepage (the app itself)
-#: resources/public/pebble_templates/40x.html:44:99
-#: resources/public/pebble_templates/40x.html:53:99
-#: resources/public/pebble_templates/40x.html:61:99
+#: resources/public/pebble_templates/40x.html
 msgid "Back to Pxls"
 msgstr "Retourner sur Pxls"
 
 #. HTTP status code name
-#: resources/public/pebble_templates/40x.html:49:24
+#: resources/public/pebble_templates/40x.html
 msgid "Not Authenticated"
 msgstr "Non Authentifié"
 
-#: resources/public/pebble_templates/40x.html:51:23
+#: resources/public/pebble_templates/40x.html
 msgid "You must be logged in to access this data. Please go back to pxls and go through the authentication process."
 msgstr "Tu dois être connecté pour accéder cette information. Merci de retourner sur Pxls et de poursuivre le processus d'authentification. "
 
 #. HTTP status code name
-#: resources/public/pebble_templates/40x.html:57:24
+#: resources/public/pebble_templates/40x.html
 msgid "Not Allowed"
 msgstr "Non Autorisé"
 
-#: resources/public/pebble_templates/40x.html:59:23
+#: resources/public/pebble_templates/40x.html
 msgid "The action you attempted to perform is not allowed or resulted in an error. Please ensure you have access to the endpoint and try again later."
 msgstr "L'action que tu essayes d'effectuer n'est pas permise ou une erreur est survenue. Merci de t'assurer que tu as l'accès nécessaire et de réessayer plus tard."
 
-#: resources/public/pxls.js:134:38
+#: resources/public/pxls.js
 msgid "Alert"
 msgstr "Alerte"
 
 #. Snapshot save name
-#: resources/public/include/board.js:806:100
+#: resources/public/include/board.js
 msgid "pxls canvas"
 msgstr "canvas de pxls"
 
 #. template link action
-#: resources/public/include/chat.js:80:21
+#: resources/public/include/chat.js
 msgid "Ask"
 msgstr "Demander"
 
-#: resources/public/include/chat.js:84:21
+#: resources/public/include/chat.js
 msgid "Open in a new tab"
 msgstr "Ouvrir dans un nouvel onglet"
 
-#: resources/public/include/chat.js:88:21
+#: resources/public/include/chat.js
 msgid "Open in current tab (replacing template)"
 msgstr "Ouvrir dans cet onglet (en remplaçant le modèle)"
 
-#: resources/public/include/chat.js:92:21
+#: resources/public/include/chat.js
 msgid "Jump to coordinates without replacing template"
 msgstr "Aller aux coordonnées sans remplacer le modèle"
 
-#: resources/public/include/chat.js:437:55
-#: resources/public/include/chat.js:956:53
+#: resources/public/include/chat.js
 msgid "You must be logged in to chat."
 msgstr ""
 
-#: resources/public/include/chat.js:1260:42
-#: resources/public/include/chat.js:1753:27
+#: resources/public/include/chat.js
 msgid "none provided"
 msgstr "aucune donnée"
 
-#: resources/public/include/chat.js:1261:38
+#: resources/public/include/chat.js
 msgid "Purged by ${purge.initiator} with reason: ${reason}"
 msgstr "Purgé par ${purge.initiator} pour la raison: ${reason}"
 
-#: resources/public/include/chat.js:1279:26
+#: resources/public/include/chat.js
 msgid "template:"
 msgstr "modèle :"
 
-#: resources/public/include/chat.js:1331:56
-#: resources/public/include/chat.js:2057:56
+#: resources/public/include/chat.js
 msgid "Open Failed"
 msgstr "Échec de l'ouverture"
 
-#: resources/public/include/chat.js:1333:32
-#: resources/public/include/chat.js:2059:32
+#: resources/public/include/chat.js
 msgid "Failed to automatically open in a new tab"
 msgstr "Échec de l'ouverture automatique dans un nouvel onglet"
 
-#: resources/public/include/chat.js:1337:24
-#: resources/public/include/chat.js:2063:24
+#: resources/public/include/chat.js
 msgid "Click here to open in a new tab instead"
 msgstr "Clique ici pour ouvrir dans un nouveau onglet à la place"
 
-#: resources/public/include/chat.js:1351:52
+#: resources/public/include/chat.js
 msgid "Open Template"
 msgstr "Ouvrir le Modèle"
 
-#: resources/public/include/chat.js:1353:54
+#: resources/public/include/chat.js
 msgid "This link will overwrite your current template. What would you like to do?"
 msgstr "Ce lien va écraser ton modèle actuel. Que voudrais-tu faire ?"
 
-#: resources/public/include/chat.js:1364:55
+#: resources/public/include/chat.js
 msgid "Note: You can set a default action in the settings menu which bypasses this popup completely."
 msgstr "Note : Tu peux définir une action par défaut dans les paramètres qui passera ce pop-up."
 
-#: resources/public/include/chat.js:1455:24
-#: resources/public/include/chat.js:1534:18
-#: resources/public/include/lookup.js:18:90
+#: resources/public/include/chat.js resources/public/include/lookup.js
 msgid "Report"
 msgstr "Signaler"
 
-#: resources/public/include/chat.js:1456:24
+#: resources/public/include/chat.js
 msgid "Mention"
 msgstr "Mentionner"
 
-#: resources/public/include/chat.js:1457:24
+#: resources/public/include/chat.js
 msgid "Ignore"
 msgstr "Ignorer"
 
-#: resources/public/include/chat.js:1458:102
-#: resources/public/admin/admin.js:193:16
+#: resources/public/include/chat.js resources/public/admin/admin.js
 msgid "Profile"
 msgstr "Profil"
 
-#: resources/public/include/chat.js:1459:24
+#: resources/public/include/chat.js
 msgid "Chat (un)ban"
 msgstr "Bannir/Révoquer le bannissement du chat"
 
-#: resources/public/include/chat.js:1461:43
-#: resources/public/include/chat.js:1911:54
+#: resources/public/include/chat.js
 msgid "Purge User"
 msgstr "Purger l'utilisateur"
 
-#: resources/public/include/chat.js:1463:24
+#: resources/public/include/chat.js
 msgid "Mod Lookup"
 msgstr "Inspection modérateur"
 
-#: resources/public/include/chat.js:1464:24
+#: resources/public/include/chat.js
 msgid "Chat Lookup"
 msgstr "Inspection du chat"
 
-#: resources/public/include/chat.js:1536:30
+#: resources/public/include/chat.js
 msgid "Enter a reason for your report"
 msgstr "Entre une raison pour ton signalement"
 
-#: resources/public/include/chat.js:1565:26
-#: resources/public/include/chat.js:1686:18
-#: resources/public/include/chat.js:1845:22
-#: resources/public/include/chat.js:1893:22
-#: resources/public/include/chat.js:1961:22
-#: resources/public/include/chat.js:2021:22
-#: resources/public/include/lookup.js:64:91
-#: resources/public/include/user.js:73:87
-#: resources/public/admin/admin.js:334:20
+#: resources/public/include/chat.js resources/public/include/lookup.js
+#: resources/public/include/user.js resources/public/admin/admin.js
 msgid "Cancel"
 msgstr "Annuler"
 
-#: resources/public/include/chat.js:1580:34
-#: resources/public/include/lookup.js:45:30
+#: resources/public/include/chat.js resources/public/include/lookup.js
 msgid "Error sending report."
 msgstr "Erreur lors de l'envoi du signalement."
 
-#: resources/public/include/chat.js:1585:54
+#: resources/public/include/chat.js
 msgid "Report User"
 msgstr "Signaler l'utilisateur"
 
-#: resources/public/include/chat.js:1599:34
+#: resources/public/include/chat.js
 msgid "User ignored. You can unignore from chat settings."
 msgstr "Utilisateur ignoré. Tu peux le désignorer dans les paramètres du chat."
 
-#: resources/public/include/chat.js:1601:34
+#: resources/public/include/chat.js
 msgid "Failed to ignore user. Either they\\'re already ignored, or an error occurred. If the problem persists, contact a developer."
 msgstr "Échec à ignorer l'utilisateur. Il/elle est déjà ignoré(e), ou une erreur s'est produite. Si le problème persiste, merci de contacter un développeur."
 
-#: resources/public/include/chat.js:1629:55
+#: resources/public/include/chat.js
 msgid "Permanent"
 msgstr "Permanent"
 
-#: resources/public/include/chat.js:1629:78
+#: resources/public/include/chat.js
 msgid "Temporary"
 msgstr "Temporaire"
 
-#: resources/public/include/chat.js:1656:32
+#: resources/public/include/chat.js
 msgid "Rule 3: Spam"
 msgstr "Règle 3 : Spam"
 
-#: resources/public/include/chat.js:1657:32
+#: resources/public/include/chat.js
 msgid "Rule 1: Chat civility"
 msgstr "Règle 1 : Civilité du chat"
 
-#: resources/public/include/chat.js:1658:32
+#: resources/public/include/chat.js
 msgid "Rule 2: Hate Speech"
 msgstr "Règle 2 : Propos haineux"
 
-#: resources/public/include/chat.js:1659:32
+#: resources/public/include/chat.js
 msgid "Rule 5: NSFW"
 msgstr "Règle 5 : NSFW"
 
-#: resources/public/include/chat.js:1660:32
-#: resources/public/include/chat.js:1738:58
-#: resources/public/include/chat.js:1759:45
+#: resources/public/include/chat.js
 msgid "Custom"
 msgstr "Personalisée"
 
-#: resources/public/include/chat.js:1693:33
+#: resources/public/include/chat.js
 msgid "Banning:"
 msgstr "Bannir :"
 
-#: resources/public/include/chat.js:1693:50
+#: resources/public/include/chat.js
 msgid "Message:"
 msgstr "Message :"
 
-#: resources/public/include/chat.js:1695:26
+#: resources/public/include/chat.js
 msgid "Ban Length"
 msgstr "Durée du bannissement"
 
-#: resources/public/include/chat.js:1702:28
+#: resources/public/include/chat.js
 msgid "Reason"
 msgstr "Raison"
 
-#: resources/public/include/chat.js:1707:28
+#: resources/public/include/chat.js
 msgid "Purge Messages"
 msgstr "Purger les messages"
 
-#: resources/public/include/chat.js:1711:27
+#: resources/public/include/chat.js
 msgid "Purging all messages is disabled during snip mode"
 msgstr "La purge de tous les messages est désactivée en mode snip"
 
-#: resources/public/include/chat.js:1714:79
-#: resources/public/include/user.js:174:22
-#: resources/public/admin/admin.js:185:41
-#: resources/public/admin/admin.js:187:94
+#: resources/public/include/chat.js resources/public/include/user.js
+#: resources/public/admin/admin.js
 msgid "Yes"
 msgstr "Oui"
 
-#: resources/public/include/chat.js:1715:78
-#: resources/public/include/user.js:178:22
-#: resources/public/admin/admin.js:185:53
-#: resources/public/admin/admin.js:187:106
+#: resources/public/include/chat.js resources/public/include/user.js
+#: resources/public/admin/admin.js
 msgid "No"
 msgstr "Non"
 
-#: resources/public/include/chat.js:1739:63
+#: resources/public/include/chat.js
 msgid "Custom reason"
 msgstr "Raison personalisée"
 
-#: resources/public/include/chat.js:1739:85
-#: resources/public/include/lookup.js:59:30
+#: resources/public/include/chat.js resources/public/include/lookup.js
 msgid "Additional information (if applicable)"
 msgstr "Information supplémentaire (si applicable)"
 
-#: resources/public/include/chat.js:1764:45
+#: resources/public/include/chat.js
 msgid "Additional information:"
 msgstr "Information supplémentaire :"
 
-#: resources/public/include/chat.js:1786:34
+#: resources/public/include/chat.js
 msgid "Error occurred while chatbanning"
 msgstr "Une erreur s'est produite lors du bannissement de chat"
 
-#: resources/public/include/chat.js:1790:54
+#: resources/public/include/chat.js
 msgid "Chatban"
 msgstr "Bannissement du chat"
 
-#: resources/public/include/chat.js:1810:32
+#: resources/public/include/chat.js
 msgid "Failed to delete"
 msgstr "Échec de la suppression"
 
-#: resources/public/include/chat.js:1821:32
-#: resources/public/include/chat.js:1863:32
+#: resources/public/include/chat.js
 msgid "ID: "
 msgstr "ID :"
 
-#: resources/public/include/chat.js:1825:32
-#: resources/public/include/chat.js:1873:32
+#: resources/public/include/chat.js
 msgid "User: "
 msgstr "Utilisateur :"
 
-#: resources/public/include/chat.js:1829:32
-#: resources/public/include/chat.js:1867:32
+#: resources/public/include/chat.js
 msgid "Message: "
 msgstr "Message :"
 
-#: resources/public/include/chat.js:1833:32
+#: resources/public/include/chat.js
 msgid "Reason: "
 msgstr "Raison :"
 
-#: resources/public/include/chat.js:1850:54
+#: resources/public/include/chat.js
 msgid "Delete Message"
 msgstr "Supprimer le message :"
 
-#: resources/public/include/chat.js:1858:106
+#: resources/public/include/chat.js
 msgid "Purge"
 msgstr "Purger"
 
-#: resources/public/include/chat.js:1879:28
+#: resources/public/include/chat.js
 msgid "Selected Message"
 msgstr "Message sélectionné"
 
-#: resources/public/include/chat.js:1882:30
+#: resources/public/include/chat.js
 msgid "Purge Reason"
 msgstr "Raison de la purge"
 
-#: resources/public/include/chat.js:1907:34
+#: resources/public/include/chat.js
 msgid "Error sending purge."
 msgstr "Erreur lors de l'envoi de la purge"
 
-#: resources/public/include/chat.js:1936:98
+#: resources/public/include/chat.js
 msgid "On"
 msgstr "Activé"
 
-#: resources/public/include/chat.js:1949:28
+#: resources/public/include/chat.js
 msgid "Toggle Rename Request"
 msgstr "Activer/Désactiver la demande de renommage"
 
-#: resources/public/include/chat.js:1950:27
+#: resources/public/include/chat.js
 msgid "Select one of the options below to set the current rename request state."
 msgstr "Sélectionner une des options ci-dessous pour définir le statut actuel de la demande de renommage"
 
-#: resources/public/include/chat.js:1975:30
-#: resources/public/include/chat.js:2034:30
+#: resources/public/include/chat.js
 msgid "An unknown error occurred. Please contact a developer"
 msgstr "Une erreur inconnue s'est produite. Merci de contacter un développeur."
 
-#: resources/public/include/chat.js:2001:52
+#: resources/public/include/chat.js
 msgid "New Name: "
 msgstr "Nouveau Nom :"
 
-#: resources/public/include/chat.js:2011:27
+#: resources/public/include/chat.js
 msgid "Enter the new name for the user below. Please note that if you\\'re trying to change the caps, you\\'ll have to rename to something else first."
 msgstr "Entre un nouveau nom pour l'utilisateur ci-dessous. Merci de prendre en compte que si tu essaies de changer la capitalization, il te faudra d'abord renommer en quelque chose d'autre."
 
-#: resources/public/include/chat.js:2049:54
+#: resources/public/include/chat.js
 msgid "Force Rename"
 msgstr "Forcer le renommage"
 
-#: resources/public/include/chat.js:2088:118
+#: resources/public/include/chat.js
 msgid "You cannot use chat while canvas banned."
 msgstr "Tu ne peux pas utiliser le chat si tu es banni sur le canvas."
 
-#: resources/public/include/lookup.js:21:32
+#: resources/public/include/lookup.js
 msgid "Sending..."
 msgstr "Envoi..."
 
-#: resources/public/include/lookup.js:28:32
+#: resources/public/include/lookup.js
 msgid "You must specify the details."
 msgstr "Tu dois spécifier les détails."
 
-#: resources/public/include/lookup.js:33:27
+#: resources/public/include/lookup.js
 msgid "additional information:"
 msgstr "information supplémentaire :"
 
-#: resources/public/include/lookup.js:49:50
+#: resources/public/include/lookup.js
 msgid "Report Pixel"
 msgstr "Signaler un pixel"
 
-#: resources/public/include/lookup.js:52:32
+#: resources/public/include/lookup.js
 msgid "Rule #1: Hateful/derogatory speech or symbols"
 msgstr "Règle #1 : Propos ou symboles haineux/dérogatoires"
 
-#: resources/public/include/lookup.js:53:32
+#: resources/public/include/lookup.js
 msgid "Rule #2: Nudity, genitalia, or non-PG-13 content"
 msgstr "Règle #2 : Nudité, organes génitaux ou contenu non adapté aux mineurs"
 
-#: resources/public/include/lookup.js:54:32
+#: resources/public/include/lookup.js
 msgid "Rule #3: Multi-account"
 msgstr "Règle #3 : Multi-compte"
 
-#: resources/public/include/lookup.js:55:32
+#: resources/public/include/lookup.js
 msgid "Rule #4: Botting"
 msgstr "Règle #4 : Usage de bot"
 
-#: resources/public/include/lookup.js:56:52
+#: resources/public/include/lookup.js
 msgid "Other (specify below)"
 msgstr "Autre (préciser ci-dessous)"
 
-#: resources/public/include/lookup.js:168:62
+#: resources/public/include/lookup.js
 msgid "Hide sensitive information"
 msgstr "Cacher les informations sensibles"
 
-#: resources/public/include/lookup.js:207:120
+#: resources/public/include/lookup.js
 msgid "An error occurred, either you aren't logged in or you may be attempting to look up users too fast. Please try again in 60 seconds"
 msgstr "Une erreur s'est produite, tu n'es pas connecté ou tu essaies d'inspecter des pixels trop rapidement. Merci de réessayer dans 60 secondes"
 
-#: resources/public/include/lookup.js:218:21
+#: resources/public/include/lookup.js
 msgid "Coords"
 msgstr "Coordonnées"
 
-#: resources/public/include/lookup.js:223:21
-#: resources/public/admin/admin.js:189:16
+#: resources/public/include/lookup.js resources/public/admin/admin.js
 msgid "Username"
 msgstr "Nom d'utilisateur"
 
-#: resources/public/include/lookup.js:229:28
+#: resources/public/include/lookup.js
 msgid "View Profile"
 msgstr "Voir le profil"
 
-#: resources/public/include/lookup.js:239:21
+#: resources/public/include/lookup.js
 msgid "Origin"
 msgstr "Origine"
 
-#: resources/public/include/lookup.js:243:28
+#: resources/public/include/lookup.js
 msgid "Part of a nuke"
 msgstr "Fait partie d'un nuke"
 
-#: resources/public/include/lookup.js:245:28
+#: resources/public/include/lookup.js
 msgid "Placed by a staff member using placement overrides"
 msgstr "Placé par un membre de l'équipe avec les outils du staff"
 
-#: resources/public/include/lookup.js:252:21
+#: resources/public/include/lookup.js
 msgid "Time"
 msgstr "Horaire"
 
-#: resources/public/include/lookup.js:263:36
+#: resources/public/include/lookup.js
 msgid "just now"
 msgstr "à l'instant"
 
-#: resources/public/include/lookup.js:271:36
+#: resources/public/include/lookup.js
 msgid "${hoursStr}:${minuteStr}:${secsStr} ago"
 msgstr "il y a ${hoursStr}:${minuteStr}:${secsStr}"
 
-#: resources/public/include/lookup.js:284:21
+#: resources/public/include/lookup.js
 msgid "Discord"
 msgstr "Discord"
 
-#: resources/public/include/notifications.js:60:58
+#: resources/public/include/notifications.js
 msgid "Posted by ${notification.who}"
 msgstr "Posté par ${notification.who}"
 
-#: resources/public/include/notifications.js:63:111
+#: resources/public/include/notifications.js
 msgid "Expires ${expiry}"
 msgstr "Expire à"
 
-#: resources/public/include/template.js:440:50
+#: resources/public/include/template.js
 msgid "There was an error getting the image"
 msgstr "Erreur à l'obtention de l'image"
 
-#: resources/public/include/timer.js:42:53
+#: resources/public/include/timer.js
 msgid "Your next pixel will be available in ${delay} seconds!"
 msgstr "Ton prochain pixel sera disponible dans ${delay} secondes !"
 
-#: resources/public/include/timer.js:87:61
+#: resources/public/include/timer.js
 msgid "Your next pixel has been available for ${alertDelay} seconds!"
 msgstr "Ton nouveau pixel est disponible depuis ${alertDelay} secondes !"
 
-#: resources/public/include/timer.js:101:59
+#: resources/public/include/timer.js
 msgid "Your next pixel is available!"
 msgstr "Ton prochain pixel est disponible !"
 
 #. theme name
-#: resources/public/include/uiHelper.js:48:19
+#: resources/public/include/uiHelper.js
 msgid "Dark"
 msgstr "Sombre"
 
 #. theme name
-#: resources/public/include/uiHelper.js:54:19
+#: resources/public/include/uiHelper.js
 msgid "Darker"
 msgstr "Plus sombre"
 
 #. theme name
-#: resources/public/include/uiHelper.js:60:19
+#: resources/public/include/uiHelper.js
 msgid "Blue"
 msgstr "Bleu"
 
 #. theme name
-#: resources/public/include/uiHelper.js:66:19
+#: resources/public/include/uiHelper.js
 msgid "Purple"
 msgstr "Violet"
 
 #. theme name
-#: resources/public/include/uiHelper.js:72:19
+#: resources/public/include/uiHelper.js
 msgid "Green"
 msgstr "Vert"
 
 #. theme name
-#: resources/public/include/uiHelper.js:78:19
+#: resources/public/include/uiHelper.js
 msgid "Matte"
 msgstr "Mat"
 
 #. theme name
-#: resources/public/include/uiHelper.js:84:19
+#: resources/public/include/uiHelper.js
 msgid "Terminal"
 msgstr "Terminal"
 
 #. theme name
-#: resources/public/include/uiHelper.js:90:19
+#: resources/public/include/uiHelper.js
 msgid "Red"
 msgstr "Rouge"
 
-#: resources/public/include/uiHelper.js:467:30
+#: resources/public/include/uiHelper.js
 msgid "Discord name updated successfully"
 msgstr "Le nom Discord a bien été mis à jour"
 
-#: resources/public/include/uiHelper.js:474:32
+#: resources/public/include/uiHelper.js
 msgid "Couldn\\'t change discord name: "
 msgstr "Échec du changement du nom Discord"
 
-#: resources/public/include/user.js:81:28
+#: resources/public/include/user.js
 msgid "Sign in with..."
 msgstr "Se connecter avec..."
 
-#: resources/public/include/user.js:94:149
+#: resources/public/include/user.js
 msgid "New Accounts Disabled"
 msgstr "Nouveaux comptes désactivés"
 
-#: resources/public/include/user.js:167:52
+#: resources/public/include/user.js
 msgid "Sign Out"
 msgstr "Se déconnecter"
 
-#: resources/public/include/user.js:169:27
+#: resources/public/include/user.js
 msgid "Are you sure you want to sign out?"
 msgstr "Es-tu sûr(e) de vouloir te déconnecter ?"
 
-#: resources/public/include/user.js:223:39
+#: resources/public/include/user.js
 msgid "You are permanently banned."
 msgstr "Tu es banni définitivement."
 
-#: resources/public/include/user.js:227:39
+#: resources/public/include/user.js
 msgid "You are temporarily banned and will not be allowed to place until ${timestamp}"
 msgstr "Tu es banni temporairement et ne pourra pas placer de pixel jusqu'à ${timestamp}"
 
-#: resources/public/include/user.js:255:27
+#: resources/public/include/user.js
 msgid "If you think this was an error, please contact us using one of the links in the info tab."
 msgstr "Si tu penses que ceci est une erreur, merci de nous contacter en utilisant un des liens dans la barre d'informations."
 
-#: resources/public/include/user.js:256:27
+#: resources/public/include/user.js
 msgid "Ban reason:"
 msgstr "Raison du bannissement :"
 
-#: resources/public/include/user.js:260:28
-#: resources/public/admin/admin.js:203:16
+#: resources/public/include/user.js resources/public/admin/admin.js
 msgid "Banned"
 msgstr "Banni"
 
-#: resources/public/include/user.js:330:23
+#: resources/public/include/user.js
 msgid "Staff have required you to change your username, this usually means your name breaks one of our rules."
 msgstr "Le staff te demande de changer de nom d'utilisateur, ceci signifie généralement que ton nom enfreint une de nos règles."
 
-#: resources/public/include/user.js:331:23
+#: resources/public/include/user.js
 msgid "If you disagree, please contact us on Discord (link in the info panel)."
 msgstr "Si tu n'es pas d'accord, merci de nous contacter sur Discord (lien dans la barre d'informations)."
 
-#: resources/public/include/user.js:332:27
+#: resources/public/include/user.js
 msgid "New Username:"
 msgstr "Nouveau nom d'utilisateur :"
 
-#: resources/public/include/user.js:345:89
+#: resources/public/include/user.js
 msgid "Not now"
 msgstr "Pas maintenant"
 
-#: resources/public/include/user.js:346:86
+#: resources/public/include/user.js
 msgid "Change"
 msgstr "Changer"
 
-#: resources/public/include/user.js:350:50
-#: resources/public/admin/admin.js:201:16
+#: resources/public/include/user.js resources/public/admin/admin.js
 msgid "Rename Requested"
 msgstr "Renommage demandé"
 
-#: resources/public/admin/admin.js:101:38
+#: resources/public/admin/admin.js
 msgid "Something went wrong! Perhaps insufficient permissions?"
 msgstr "Il y a eu un problème ! Peut-être un manque de permissions ?"
 
-#: resources/public/admin/admin.js:106:45
+#: resources/public/admin/admin.js
 msgid "Shadowban user"
 msgstr "Shadowban l'utilisateur"
 
-#: resources/public/admin/admin.js:106:67
+#: resources/public/admin/admin.js
 msgid "Shadowbanned user"
 msgstr "L'utilisateur a été shadowban"
 
-#: resources/public/admin/admin.js:109:45
+#: resources/public/admin/admin.js
 msgid "Permaban user"
 msgstr "Bannir l'utilisateur définitivement"
 
-#: resources/public/admin/admin.js:109:66
+#: resources/public/admin/admin.js
 msgid "Permabanned user"
 msgstr "L'utilisateur a été banni définitivement"
 
-#: resources/public/admin/admin.js:112:45
+#: resources/public/admin/admin.js
 msgid "Ban user"
 msgstr "Bannir l'utilisateur"
 
-#: resources/public/admin/admin.js:112:61
+#: resources/public/admin/admin.js
 msgid "Banned user"
 msgstr "L'utilisateur a été banni"
 
-#: resources/public/admin/admin.js:126:36
+#: resources/public/admin/admin.js
 msgid "Unbanned user ${username}"
 msgstr "L'utilisateur ${username} n'est plus banni"
 
 #. Context: ban type
-#: resources/public/admin/admin.js:179:27
+#: resources/public/admin/admin.js
 msgid "shadow"
 msgstr "shadow"
 
-#: resources/public/admin/admin.js:180:29
-#: resources/public/admin/admin.js:183:29
+#: resources/public/admin/admin.js
 msgid "never"
 msgstr "jamais"
 
-#: resources/public/admin/admin.js:182:27
+#: resources/public/admin/admin.js
 msgid "permanent"
 msgstr "définitif"
 
-#: resources/public/admin/admin.js:187:51
+#: resources/public/admin/admin.js
 msgid "Yes (permanent)"
 msgstr "Oui (définitif)"
 
-#: resources/public/admin/admin.js:194:16
-#: resources/public/admin/admin.js:454:21
+#: resources/public/admin/admin.js
 msgid "Logins"
 msgstr "Logins"
 
-#: resources/public/admin/admin.js:200:16
+#: resources/public/admin/admin.js
 msgid "All Time Pixels"
 msgstr "Pixels totaux"
 
-#: resources/public/admin/admin.js:202:16
+#: resources/public/admin/admin.js
 msgid "Discord Name"
 msgstr "Nom Discord"
 
-#: resources/public/admin/admin.js:204:16
+#: resources/public/admin/admin.js
 msgid "Chatbanned"
 msgstr "Banni du chat"
 
-#: resources/public/admin/admin.js:207:27
+#: resources/public/admin/admin.js
 msgid "Ban Reason"
 msgstr "Raison du bannissement"
 
-#: resources/public/admin/admin.js:208:27
+#: resources/public/admin/admin.js
 msgid "Ban Expiracy"
 msgstr "Expiration du bannissement"
 
-#: resources/public/admin/admin.js:211:27
+#: resources/public/admin/admin.js
 msgid "Chatban Reason"
 msgstr "Raison du bannissement du chat"
 
-#: resources/public/admin/admin.js:211:102
+#: resources/public/admin/admin.js
 msgid "(canvas ban)"
 msgstr "(bannissement de canvas)"
 
-#: resources/public/admin/admin.js:213:97
+#: resources/public/admin/admin.js
 msgid "when canvas ban ends"
 msgstr "quand le bannissement de canvas prend fin"
 
-#: resources/public/admin/admin.js:214:29
+#: resources/public/admin/admin.js
 msgid "Chatban Expires"
 msgstr "Expiration du bannissement de chat"
 
 #. Admin check. Example: type = 'username', arg = 'pxlsuser94'
-#: resources/public/admin/admin.js:316:36
+#: resources/public/admin/admin.js
 msgid "${type} ${arg} not found."
 msgstr "${type} ${arg} non trouvé"
 
-#: resources/public/admin/admin.js:322:50
+#: resources/public/admin/admin.js
 msgid "Unban Reason:"
 msgstr "Raison de la révocation du bannissement"
 
-#: resources/public/admin/admin.js:327:25
+#: resources/public/admin/admin.js
 msgid "Unbanning ${username}"
 msgstr "Révocation du bannissement de ${username}"
 
-#: resources/public/admin/admin.js:449:20
+#: resources/public/admin/admin.js
 msgid "profile"
 msgstr "profil"
 
-#: resources/public/admin/admin.js:473:21
+#: resources/public/admin/admin.js
 msgid "User Agent"
 msgstr "Agent Utilisateur"
 
-#: resources/public/admin/admin.js:478:21
+#: resources/public/admin/admin.js
 msgid "Send Alert"
 msgstr "Envoyer une alerte"
 
-#: resources/public/admin/admin.js:483:21
+#: resources/public/admin/admin.js
 msgid "Mod Actions"
 msgstr "Actions modérateur"

--- a/resources/Localization.properties
+++ b/resources/Localization.properties
@@ -1,1710 +1,1641 @@
-!=Project-Id-Version\: Pxls\nPOT-Creation-Date\: 2021-11-23T21\:32\:45.968Z\nLanguage\: en\nContent-Type\: text/plain; charset\=UTF-8\n
+!=Project-Id-Version\: Pxls\nPOT-Creation-Date\: 2021-12-03T07\:36\:36.932Z\nLanguage\: en\nContent-Type\: text/plain; charset\=UTF-8\n
 
 #. Site description
-#: resources/public/pebble_templates/index.html:8:42
+#: resources/public/pebble_templates/index.html
 Place\ pixels\ with\ people\ to\ create\ art=Place pixels with people to create art
 
-#: resources/public/pebble_templates/index.html:56:27
+#: resources/public/pebble_templates/index.html
 Lost\ connection\ to\ server,\ reconnecting...=Lost connection to server, reconnecting...
 
-#: resources/public/pebble_templates/index.html:71:76
+#: resources/public/pebble_templates/index.html
 Loading\ Heatmap\ (press\ <kbd>H</kbd>\ to\ cancel)=Loading Heatmap (press <kbd>H</kbd> to cancel)
 
-#: resources/public/pebble_templates/index.html:72:78
+#: resources/public/pebble_templates/index.html
 Loading\ Virginmap\ (press\ <kbd>X</kbd>\ to\ cancel)=Loading Virginmap (press <kbd>X</kbd> to cancel)
 
-#: resources/public/pebble_templates/index.html:80:67
+#: resources/public/pebble_templates/index.html
 Logout=Logout
 
 #. Canvas pixel count
-#: resources/public/pebble_templates/index.html:86:38
+#: resources/public/pebble_templates/index.html
 Canvas\:=Canvas\:
 
 #. Canvas pixel count
 #. All time pixel count
-#: resources/public/pebble_templates/index.html:86:118
-#: resources/public/pebble_templates/index.html:88:120
-#: resources/public/pebble_templates/index.html:100:51
-#: resources/public/pebble_templates/index.html:126:123
+#: resources/public/pebble_templates/index.html
 N/A=N/A
 
 #. All time pixel count
-#: resources/public/pebble_templates/index.html:88:38
+#: resources/public/pebble_templates/index.html
 All\ Time\:=All Time\:
 
-#: resources/public/pebble_templates/index.html:93:48
+#: resources/public/pebble_templates/index.html
 Loading\ online\ user\ count&hellip;=Loading online user count&hellip;
 
-#: resources/public/pebble_templates/index.html:101:30
-#: resources/public/include/lookup.js:276:21
-#: resources/public/admin/admin.js:199:16
+#: resources/public/pebble_templates/index.html
+#: resources/public/include/lookup.js resources/public/admin/admin.js
 Pixels=Pixels
 
-#: resources/public/pebble_templates/index.html:112:54
+#: resources/public/pebble_templates/index.html
 Undo=Undo
 
-#: resources/public/pebble_templates/index.html:114:20
+#: resources/public/pebble_templates/index.html
 You\ are\ not\ signed\ in.&nbsp;<a\ href\="\#">Sign\ in\ with...</a>=You are not signed in.&nbsp;<a href\="\#">Sign in with...</a>
 
-#: resources/public/pebble_templates/index.html:124:28
+#: resources/public/pebble_templates/index.html
 Loading...=Loading...
 
-#: resources/public/pebble_templates/index.html:132:14
-#: resources/public/pebble_templates/index.html:142:67
+#: resources/public/pebble_templates/index.html
 Sign\ up=Sign up
 
-#: resources/public/pebble_templates/index.html:133:14
+#: resources/public/pebble_templates/index.html
 Pick\ a\ username=Pick a username
 
-#: resources/public/pebble_templates/index.html:136:43
+#: resources/public/pebble_templates/index.html
 Username\:=Username\:
 
-#: resources/public/pebble_templates/index.html:154:65
-#: resources/public/pebble_templates/profile.html:56:96
+#: resources/public/pebble_templates/index.html
+#: resources/public/pebble_templates/profile.html
 Info=Info
 
-#: resources/public/pebble_templates/index.html:168:66
-#: resources/public/pebble_templates/index.html:206:66
-#: resources/public/pebble_templates/index.html:761:66
-#: resources/public/pebble_templates/index.html:774:66
+#: resources/public/pebble_templates/index.html
 Close\ Panel=Close Panel
 
-#: resources/public/pebble_templates/index.html:170:61
+#: resources/public/pebble_templates/index.html
 Chat=Chat
 
-#: resources/public/pebble_templates/index.html:172:45
+#: resources/public/pebble_templates/index.html
 Pings=Pings
 
-#: resources/public/pebble_templates/index.html:173:45
-#: resources/public/pebble_templates/index.html:209:58
+#: resources/public/pebble_templates/index.html
 Settings=Settings
 
-#: resources/public/pebble_templates/index.html:186:30
+#: resources/public/pebble_templates/index.html
 Jump\ To\ Bottom=Jump To Bottom
 
 #. Open emoji picker
-#: resources/public/pebble_templates/index.html:194:49
+#: resources/public/pebble_templates/index.html
 Emoji=Emoji
 
-#: resources/public/pebble_templates/index.html:214:73
+#: resources/public/pebble_templates/index.html
 Search=Search
 
-#: resources/public/pebble_templates/index.html:215:56
+#: resources/public/pebble_templates/index.html
 keybinds;keys;keyboard;hotkeys=keybinds;keys;keyboard;hotkeys
 
-#: resources/public/pebble_templates/index.html:217:24
+#: resources/public/pebble_templates/index.html
 Keybinds=Keybinds
 
-#: resources/public/pebble_templates/index.html:220:44
+#: resources/public/pebble_templates/index.html
 general=general
 
 #. General settings
-#: resources/public/pebble_templates/index.html:222:28
-#: resources/public/pebble_templates/index.html:664:28
+#: resources/public/pebble_templates/index.html
 General=General
 
-#: resources/public/pebble_templates/index.html:223:42
+#: resources/public/pebble_templates/index.html
 move;moving;panning;drag=move;moving;panning;drag
 
-#: resources/public/pebble_templates/index.html:223:102
+#: resources/public/pebble_templates/index.html
 Mouse/arrows/wasd\ to\ pan=Mouse/arrows/wasd to pan
 
-#: resources/public/pebble_templates/index.html:224:42
+#: resources/public/pebble_templates/index.html
 mousewheel;zooming=mousewheel;zooming
 
-#: resources/public/pebble_templates/index.html:224:96
+#: resources/public/pebble_templates/index.html
 Scroll/pinch\ to\ zoom=Scroll/pinch to zoom
 
-#: resources/public/pebble_templates/index.html:225:42
+#: resources/public/pebble_templates/index.html
 scroll;zooming=scroll;zooming
 
-#: resources/public/pebble_templates/index.html:225:92
+#: resources/public/pebble_templates/index.html
 <kbd>+</kbd>/<kbd>-</kbd>\ or\ <kbd>Q</kbd>/<kbd>E</kbd>\ to\ zoom=<kbd>+</kbd>/<kbd>-</kbd> or <kbd>Q</kbd>/<kbd>E</kbd> to zoom
 
-#: resources/public/pebble_templates/index.html:226:42
+#: resources/public/pebble_templates/index.html
 lookups=lookups
 
-#: resources/public/pebble_templates/index.html:226:85
+#: resources/public/pebble_templates/index.html
 <kbd>Shift</kbd>\ +\ Click/Hold\ touch\ to\ lookup\ pixel=<kbd>Shift</kbd> + Click/Hold touch to lookup pixel
 
-#: resources/public/pebble_templates/index.html:227:42
-#: resources/public/pebble_templates/index.html:489:44
+#: resources/public/pebble_templates/index.html
 overlays;alignment;grid\ hidden;grid\ shown;hide\ grid;show\ grid=overlays;alignment;grid hidden;grid shown;hide grid;show grid
 
-#: resources/public/pebble_templates/index.html:227:139
+#: resources/public/pebble_templates/index.html
 <kbd>G</kbd>\ to\ toggle\ grid=<kbd>G</kbd> to toggle grid
 
-#: resources/public/pebble_templates/index.html:228:42
+#: resources/public/pebble_templates/index.html
 close;information\ shown;information\ hidden;info\ shown;info\ hidden;hide\ information;show\ information=close;information shown;information hidden;info shown;info hidden;hide information;show information
 
-#: resources/public/pebble_templates/index.html:228:177
+#: resources/public/pebble_templates/index.html
 <kbd>I</kbd>\ to\ open\ info=<kbd>I</kbd> to open info
 
-#: resources/public/pebble_templates/index.html:229:42
+#: resources/public/pebble_templates/index.html
 close;settings\ hidden;settings\ shown;hide\ settings;show\ settings=close;settings hidden;settings shown;hide settings;show settings
 
-#: resources/public/pebble_templates/index.html:229:142
+#: resources/public/pebble_templates/index.html
 <kbd>T</kbd>\ to\ open\ settings=<kbd>T</kbd> to open settings
 
-#: resources/public/pebble_templates/index.html:230:42
+#: resources/public/pebble_templates/index.html
 close;chat\ hidden;chat\ shown;hide\ chat;show\ chat=close;chat hidden;chat shown;hide chat;show chat
 
-#: resources/public/pebble_templates/index.html:230:126
+#: resources/public/pebble_templates/index.html
 <kbd>B</kbd>\ to\ open\ chat=<kbd>B</kbd> to open chat
 
-#: resources/public/pebble_templates/index.html:231:42
+#: resources/public/pebble_templates/index.html
 canvas\ locked;move;moving;zoom;zooming=canvas locked;move;moving;zoom;zooming
 
-#: resources/public/pebble_templates/index.html:231:116
+#: resources/public/pebble_templates/index.html
 <kbd>L</kbd>\ to\ toggle\ locking\ panning\ of\ the\ canvas=<kbd>L</kbd> to toggle locking panning of the canvas
 
-#: resources/public/pebble_templates/index.html:232:42
+#: resources/public/pebble_templates/index.html
 take\ screenshot;image;download;picture;canvas=take screenshot;image;download;picture;canvas
 
-#: resources/public/pebble_templates/index.html:232:123
+#: resources/public/pebble_templates/index.html
 <kbd>P</kbd>\ to\ take\ a\ snapshot=<kbd>P</kbd> to take a snapshot
 
-#: resources/public/pebble_templates/index.html:233:42
-#: resources/public/pebble_templates/index.html:443:44
+#: resources/public/pebble_templates/index.html
 overlays;user\ activity;pixels\ placed\ pixels;heatmap\ hidden;heatmap\ shown;hide\ heatmap;show\ heatmap=overlays;user activity;pixels placed pixels;heatmap hidden;heatmap shown;hide heatmap;show heatmap
 
-#: resources/public/pebble_templates/index.html:233:176
+#: resources/public/pebble_templates/index.html
 <kbd>H</kbd>\ to\ toggle\ heatmap=<kbd>H</kbd> to toggle heatmap
 
-#: resources/public/pebble_templates/index.html:234:42
-#: resources/public/pebble_templates/index.html:463:44
+#: resources/public/pebble_templates/index.html
 overlays;user\ activity;pixels\ unplaced\ pixels;virginmap\ hidden;virginmap\ shown;hide\ virginmap;show\ virginmap=overlays;user activity;pixels unplaced pixels;virginmap hidden;virginmap shown;hide virginmap;show virginmap
 
-#: resources/public/pebble_templates/index.html:234:186
+#: resources/public/pebble_templates/index.html
 <kbd>X</kbd>\ to\ toggle\ virginmap=<kbd>X</kbd> to toggle virginmap
 
-#: resources/public/pebble_templates/index.html:235:42
+#: resources/public/pebble_templates/index.html
 overlays;user\ activity;pixels\ placed\ pixels;wipe;clean;=overlays;user activity;pixels placed pixels;wipe;clean;
 
-#: resources/public/pebble_templates/index.html:235:133
+#: resources/public/pebble_templates/index.html
 <kbd>O</kbd>\ to\ clear\ heatmap=<kbd>O</kbd> to clear heatmap
 
-#: resources/public/pebble_templates/index.html:236:42
+#: resources/public/pebble_templates/index.html
 overlays;user\ activity;pixels\ unplaced\ pixels;wipe;clean;=overlays;user activity;pixels unplaced pixels;wipe;clean;
 
-#: resources/public/pebble_templates/index.html:236:135
+#: resources/public/pebble_templates/index.html
 <kbd>U</kbd>\ to\ clear\ virginmap=<kbd>U</kbd> to clear virginmap
 
-#: resources/public/pebble_templates/index.html:237:42
+#: resources/public/pebble_templates/index.html
 next\ color;previous\ color=next color;previous color
 
-#: resources/public/pebble_templates/index.html:237:103
+#: resources/public/pebble_templates/index.html
 <kbd>J</kbd>/<kbd>K</kbd>\ to\ cycle\ through\ palette\ colors=<kbd>J</kbd>/<kbd>K</kbd> to cycle through palette colors
 
-#: resources/public/pebble_templates/index.html:238:42
+#: resources/public/pebble_templates/index.html
 current\ coordinates;coords=current coordinates;coords
 
-#: resources/public/pebble_templates/index.html:238:104
+#: resources/public/pebble_templates/index.html
 <kbd>C</kbd>\ to\ copy\ link\ of\ moused-over\ coordinates=<kbd>C</kbd> to copy link of moused-over coordinates
 
-#: resources/public/pebble_templates/index.html:239:42
+#: resources/public/pebble_templates/index.html
 cancel\ selection=cancel selection
 
-#: resources/public/pebble_templates/index.html:239:94
+#: resources/public/pebble_templates/index.html
 <kbd>ESC</kbd>\ to\ deselect\ current\ pixel=<kbd>ESC</kbd> to deselect current pixel
 
-#: resources/public/pebble_templates/index.html:240:42
+#: resources/public/pebble_templates/index.html
 recenter;jump;center\ on\ template;guides;focus=recenter;jump;center on template;guides;focus
 
-#: resources/public/pebble_templates/index.html:240:123
+#: resources/public/pebble_templates/index.html
 <kbd>R</kbd>\ to\ center\ the\ board\ on\ the\ current\ template=<kbd>R</kbd> to center the board on the current template
 
-#: resources/public/pebble_templates/index.html:243:44
+#: resources/public/pebble_templates/index.html
 templates;guides=templates;guides
 
-#: resources/public/pebble_templates/index.html:244:28
-#: resources/public/pebble_templates/index.html:579:24
+#: resources/public/pebble_templates/index.html
 Template=Template
 
-#: resources/public/pebble_templates/index.html:245:42
-#: resources/public/pebble_templates/index.html:246:42
+#: resources/public/pebble_templates/index.html
 transparency=transparency
 
-#: resources/public/pebble_templates/index.html:245:90
+#: resources/public/pebble_templates/index.html
 <kbd>Page\ Up</kbd>\ to\ increase\ opacity=<kbd>Page Up</kbd> to increase opacity
 
-#: resources/public/pebble_templates/index.html:246:90
+#: resources/public/pebble_templates/index.html
 <kbd>Page\ Down</kbd>\ to\ decrease\ opacity=<kbd>Page Down</kbd> to decrease opacity
 
-#: resources/public/pebble_templates/index.html:247:42
+#: resources/public/pebble_templates/index.html
 hidden;shown;hide;show=hidden;shown;hide;show
 
-#: resources/public/pebble_templates/index.html:247:100
+#: resources/public/pebble_templates/index.html
 <kbd>V</kbd>\ to\ toggle\ visibility=<kbd>V</kbd> to toggle visibility
 
-#: resources/public/pebble_templates/index.html:252:24
+#: resources/public/pebble_templates/index.html
 Note\:\ These\ values\ are\ based\ on\ QWERTY\ keyboards.\ For\ other\ layouts,\ use\ the\ keys\ corresponding\ to\ the\ same\ position\ on\ a\ QWERTY\ keyboard.=Note\: These values are based on QWERTY keyboards. For other layouts, use the keys corresponding to the same position on a QWERTY keyboard.
 
-#: resources/public/pebble_templates/index.html:256:36
+#: resources/public/pebble_templates/index.html
 ui;interface=ui;interface
 
-#: resources/public/pebble_templates/index.html:258:24
+#: resources/public/pebble_templates/index.html
 UI\ Settings=UI Settings
 
-#: resources/public/pebble_templates/index.html:262:44
+#: resources/public/pebble_templates/index.html
 themes;look;stylesheets;visuals=themes;look;stylesheets;visuals
 
-#: resources/public/pebble_templates/index.html:264:57
+#: resources/public/pebble_templates/index.html
 Theme\:=Theme\:
 
-#: resources/public/pebble_templates/index.html:266:64
+#: resources/public/pebble_templates/index.html
 Default=Default
 
-#: resources/public/pebble_templates/index.html:270:44
+#: resources/public/pebble_templates/index.html
 hide\ reticule;hide\ reticle;reticule\ shown\ reticle\ shown;reticule\ hidden;reticle\ hidden=hide reticule;hide reticle;reticule shown reticle shown;reticule hidden;reticle hidden
 
-#: resources/public/pebble_templates/index.html:273:57
+#: resources/public/pebble_templates/index.html
 Show\ reticule=Show reticule
 
-#: resources/public/pebble_templates/index.html:276:44
+#: resources/public/pebble_templates/index.html
 hide\ cursor;cursor\ shown;cursor\ hidden=hide cursor;cursor shown;cursor hidden
 
-#: resources/public/pebble_templates/index.html:279:57
+#: resources/public/pebble_templates/index.html
 Show\ cursor=Show cursor
 
-#: resources/public/pebble_templates/index.html:282:44
+#: resources/public/pebble_templates/index.html
 darkness\ filter=darkness filter
 
-#: resources/public/pebble_templates/index.html:285:57
+#: resources/public/pebble_templates/index.html
 Enable\ color\ brightness=Enable color brightness
 
-#: resources/public/pebble_templates/index.html:288:76
+#: resources/public/pebble_templates/index.html
 Warning\:\ Known\ to\ cause\ fuzziness\ in\ Chrome\ on\ some\ Mac/Linux\ installs=Warning\: Known to cause fuzziness in Chrome on some Mac/Linux installs
 
-#: resources/public/pebble_templates/index.html:291:57
+#: resources/public/pebble_templates/index.html
 Color\ brightness\:=Color brightness\:
 
-#: resources/public/pebble_templates/index.html:295:44
+#: resources/public/pebble_templates/index.html
 keep\ current\ selected;keep\ curent\ color;place=keep current selected;keep curent color;place
 
-#: resources/public/pebble_templates/index.html:298:57
+#: resources/public/pebble_templates/index.html
 Deselect\ color\ after\ placing=Deselect color after placing
 
-#: resources/public/pebble_templates/index.html:301:44
+#: resources/public/pebble_templates/index.html
 mousewheel;palette\ scrolling=mousewheel;palette scrolling
 
-#: resources/public/pebble_templates/index.html:304:57
+#: resources/public/pebble_templates/index.html
 Enable\ scrolling\ on\ the\ palette\ to\ switch\ colors=Enable scrolling on the palette to switch colors
 
-#: resources/public/pebble_templates/index.html:306:68
+#: resources/public/pebble_templates/index.html
 reverse\ scrolling;mousewheel;palette\ scrolling;enable\ scrolling\ on\ the\ palette\ to\ switch\ colors=reverse scrolling;mousewheel;palette scrolling;enable scrolling on the palette to switch colors
 
-#: resources/public/pebble_templates/index.html:309:61
+#: resources/public/pebble_templates/index.html
 Invert\ scroll\ direction=Invert scroll direction
 
-#: resources/public/pebble_templates/index.html:313:44
+#: resources/public/pebble_templates/index.html
 indexed\ colors;palette\ indicies=indexed colors;palette indicies
 
-#: resources/public/pebble_templates/index.html:316:57
+#: resources/public/pebble_templates/index.html
 Add\ numbers\ to\ palette\ entries=Add numbers to palette entries
 
-#: resources/public/pebble_templates/index.html:319:44
+#: resources/public/pebble_templates/index.html
 scrollbar;palette\ scrolling=scrollbar;palette scrolling
 
-#: resources/public/pebble_templates/index.html:322:57
+#: resources/public/pebble_templates/index.html
 Enable\ thin\ scrollbar=Enable thin scrollbar
 
-#: resources/public/pebble_templates/index.html:325:44
+#: resources/public/pebble_templates/index.html
 scrollbar;palette\ scrolling;palette\ stack=scrollbar;palette scrolling;palette stack
 
-#: resources/public/pebble_templates/index.html:328:57
+#: resources/public/pebble_templates/index.html
 Enable\ palette\ stacking=Enable palette stacking
 
-#: resources/public/pebble_templates/index.html:331:44
+#: resources/public/pebble_templates/index.html
 floating\ bubble\ location=floating bubble location
 
-#: resources/public/pebble_templates/index.html:333:57
+#: resources/public/pebble_templates/index.html
 Bubble\ position\:=Bubble position\:
 
-#: resources/public/pebble_templates/index.html:335:61
+#: resources/public/pebble_templates/index.html
 Top\ left=Top left
 
-#: resources/public/pebble_templates/index.html:336:62
+#: resources/public/pebble_templates/index.html
 Top\ right=Top right
 
-#: resources/public/pebble_templates/index.html:337:73
+#: resources/public/pebble_templates/index.html
 Bottom\ left=Bottom left
 
-#: resources/public/pebble_templates/index.html:338:65
+#: resources/public/pebble_templates/index.html
 Bottom\ right=Bottom right
 
-#: resources/public/pebble_templates/index.html:342:44
+#: resources/public/pebble_templates/index.html
 broken;offset\ workaround=broken;offset workaround
 
-#: resources/public/pebble_templates/index.html:345:57
+#: resources/public/pebble_templates/index.html
 Attempt\ to\ fix\ canvas\ displacement\ bug\ in\ Chrome\ 78+=Attempt to fix canvas displacement bug in Chrome 78+
 
-#: resources/public/pebble_templates/index.html:351:36
+#: resources/public/pebble_templates/index.html
 chat;message;ping\ sound=chat;message;ping sound
 
-#: resources/public/pebble_templates/index.html:353:24
+#: resources/public/pebble_templates/index.html
 Chat\ Settings=Chat Settings
 
-#: resources/public/pebble_templates/index.html:356:44
+#: resources/public/pebble_templates/index.html
 username;color;colour=username;color;colour
 
-#: resources/public/pebble_templates/index.html:359:57
+#: resources/public/pebble_templates/index.html
 Username\ Color\:=Username Color\:
 
-#: resources/public/pebble_templates/index.html:365:44
+#: resources/public/pebble_templates/index.html
 chat\ message;chat\ ui=chat message;chat ui
 
-#: resources/public/pebble_templates/index.html:366:28
+#: resources/public/pebble_templates/index.html
 Interface=Interface
 
-#: resources/public/pebble_templates/index.html:367:44
+#: resources/public/pebble_templates/index.html
 chat\ size;chat\ font=chat size;chat font
 
-#: resources/public/pebble_templates/index.html:369:57
+#: resources/public/pebble_templates/index.html
 Font\ Size\:=Font Size\:
 
-#: resources/public/pebble_templates/index.html:373:44
+#: resources/public/pebble_templates/index.html
 time;timestamps=time;timestamps
 
-#: resources/public/pebble_templates/index.html:376:57
+#: resources/public/pebble_templates/index.html
 24\ Hour\ Timestamps=24 Hour Timestamps
 
-#: resources/public/pebble_templates/index.html:379:44
+#: resources/public/pebble_templates/index.html
 badges;pixel\ count;pixels\ placed=badges;pixel count;pixels placed
 
-#: resources/public/pebble_templates/index.html:382:57
+#: resources/public/pebble_templates/index.html
 Show\ pixel-placed\ badges=Show pixel-placed badges
 
-#: resources/public/pebble_templates/index.html:385:44
+#: resources/public/pebble_templates/index.html
 badges;factions=badges;factions
 
-#: resources/public/pebble_templates/index.html:388:57
+#: resources/public/pebble_templates/index.html
 Show\ faction\ tags=Show faction tags
 
-#: resources/public/pebble_templates/index.html:391:44
+#: resources/public/pebble_templates/index.html
 template\ urls;template\ links;template\ name=template urls;template links;template name
 
-#: resources/public/pebble_templates/index.html:394:57
+#: resources/public/pebble_templates/index.html
 Replace\ template\ titles\ with\ URLs\ in\ chat\ where\ applicable=Replace template titles with URLs in chat where applicable
 
-#: resources/public/pebble_templates/index.html:397:44
+#: resources/public/pebble_templates/index.html
 chat\ orientation;chat\ position=chat orientation;chat position
 
-#: resources/public/pebble_templates/index.html:400:57
+#: resources/public/pebble_templates/index.html
 Enable\ horizontal\ chat=Enable horizontal chat
 
-#: resources/public/pebble_templates/index.html:403:44
+#: resources/public/pebble_templates/index.html
 banner;animation=banner;animation
 
-#: resources/public/pebble_templates/index.html:406:57
+#: resources/public/pebble_templates/index.html
 Enable\ the\ rotating\ banner\ under\ chat=Enable the rotating banner under chat
 
-#: resources/public/pebble_templates/index.html:409:44
+#: resources/public/pebble_templates/index.html
 max;messages;truncate=max;messages;truncate
 
-#: resources/public/pebble_templates/index.html:411:57
+#: resources/public/pebble_templates/index.html
 Maximum\ amount\ of\ chat\ messages\:=Maximum amount of chat messages\:
 
-#: resources/public/pebble_templates/index.html:415:44
+#: resources/public/pebble_templates/index.html
 link;url;behaviour=link;url;behaviour
 
-#: resources/public/pebble_templates/index.html:417:57
+#: resources/public/pebble_templates/index.html
 Default\ internal\ link\ action\ click\:=Default internal link action click\:
 
-#: resources/public/pebble_templates/index.html:422:44
+#: resources/public/pebble_templates/index.html
 ignored;ignores;unignore;blocked;blocking;unblock=ignored;ignores;unignore;blocked;blocking;unblock
 
-#: resources/public/pebble_templates/index.html:423:28
+#: resources/public/pebble_templates/index.html
 Ignores=Ignores
 
-#: resources/public/pebble_templates/index.html:424:44
+#: resources/public/pebble_templates/index.html
 unignore;unblock=unignore;unblock
 
-#: resources/public/pebble_templates/index.html:429:85
+#: resources/public/pebble_templates/index.html
 Unignore=Unignore
 
-#: resources/public/pebble_templates/index.html:436:36
+#: resources/public/pebble_templates/index.html
 overlays;virginmap;heatmap;grid=overlays;virginmap;heatmap;grid
 
-#: resources/public/pebble_templates/index.html:438:24
+#: resources/public/pebble_templates/index.html
 Overlay\ Settings=Overlay Settings
 
-#: resources/public/pebble_templates/index.html:441:44
+#: resources/public/pebble_templates/index.html
 heatmap;heatmap\ opacity;clear\ heatmap=heatmap;heatmap opacity;clear heatmap
 
-#: resources/public/pebble_templates/index.html:442:28
+#: resources/public/pebble_templates/index.html
 Heatmap=Heatmap
 
-#: resources/public/pebble_templates/index.html:446:57
+#: resources/public/pebble_templates/index.html
 Turn\ on\ heatmap=Turn on heatmap
 
-#: resources/public/pebble_templates/index.html:448:70
+#: resources/public/pebble_templates/index.html
 (toggle\ with\ <kbd>H</kbd>)=(toggle with <kbd>H</kbd>)
 
-#: resources/public/pebble_templates/index.html:450:44
+#: resources/public/pebble_templates/index.html
 overlays;activity;pixels\ placed\ pixels;wipe;clean=overlays;activity;pixels placed pixels;wipe;clean
 
-#: resources/public/pebble_templates/index.html:451:71
+#: resources/public/pebble_templates/index.html
 Clear\ heatmap=Clear heatmap
 
-#: resources/public/pebble_templates/index.html:452:51
+#: resources/public/pebble_templates/index.html
 (hotkey\:\ <kbd>O</kbd>)=(hotkey\: <kbd>O</kbd>)
 
-#: resources/public/pebble_templates/index.html:454:44
+#: resources/public/pebble_templates/index.html
 overlays;user\ activity;pixels\ placed\ pixels;transparency=overlays;user activity;pixels placed pixels;transparency
 
-#: resources/public/pebble_templates/index.html:456:57
+#: resources/public/pebble_templates/index.html
 Heatmap\ background\ opacity\:=Heatmap background opacity\:
 
-#: resources/public/pebble_templates/index.html:461:44
+#: resources/public/pebble_templates/index.html
 virginmap;virginmap\ opacity;clear\ virginmap=virginmap;virginmap opacity;clear virginmap
 
-#: resources/public/pebble_templates/index.html:462:28
+#: resources/public/pebble_templates/index.html
 Virginmap=Virginmap
 
-#: resources/public/pebble_templates/index.html:466:57
+#: resources/public/pebble_templates/index.html
 Turn\ on\ virginmap=Turn on virginmap
 
-#: resources/public/pebble_templates/index.html:468:72
+#: resources/public/pebble_templates/index.html
 (toggle\ with\ <kbd>X</kbd>)=(toggle with <kbd>X</kbd>)
 
-#: resources/public/pebble_templates/index.html:470:44
+#: resources/public/pebble_templates/index.html
 overlays;user\ activity;pixels\ unplaced\ pixels;transparency=overlays;user activity;pixels unplaced pixels;transparency
 
-#: resources/public/pebble_templates/index.html:472:57
+#: resources/public/pebble_templates/index.html
 Virginmap\ background\ opacity\:=Virginmap background opacity\:
 
-#: resources/public/pebble_templates/index.html:476:44
+#: resources/public/pebble_templates/index.html
 overlays;activity;pixels\ unplaced\ pixels;wipe;clean=overlays;activity;pixels unplaced pixels;wipe;clean
 
-#: resources/public/pebble_templates/index.html:477:71
+#: resources/public/pebble_templates/index.html
 Clear\ virginmap=Clear virginmap
 
-#: resources/public/pebble_templates/index.html:478:51
+#: resources/public/pebble_templates/index.html
 (hotkey\:\ <kbd>U</kbd>)=(hotkey\: <kbd>U</kbd>)
 
-#: resources/public/pebble_templates/index.html:483:57
+#: resources/public/pebble_templates/index.html
 Layer\ template\ underneath\ heatmap=Layer template underneath heatmap
 
-#: resources/public/pebble_templates/index.html:487:44
+#: resources/public/pebble_templates/index.html
 grid;toggle\ grid=grid;toggle grid
 
-#: resources/public/pebble_templates/index.html:488:28
+#: resources/public/pebble_templates/index.html
 Grid=Grid
 
-#: resources/public/pebble_templates/index.html:492:57
+#: resources/public/pebble_templates/index.html
 Turn\ on\ grid=Turn on grid
 
-#: resources/public/pebble_templates/index.html:494:67
+#: resources/public/pebble_templates/index.html
 (toggle\ with\ <kbd>G</kbd>)=(toggle with <kbd>G</kbd>)
 
-#: resources/public/pebble_templates/index.html:499:36
+#: resources/public/pebble_templates/index.html
 controls;zooming;panning;movement=controls;zooming;panning;movement
 
-#: resources/public/pebble_templates/index.html:501:24
+#: resources/public/pebble_templates/index.html
 Control\ Settings=Control Settings
 
-#: resources/public/pebble_templates/index.html:504:44
+#: resources/public/pebble_templates/index.html
 zooming;scrolling;scale;scaling=zooming;scrolling;scale;scaling
 
-#: resources/public/pebble_templates/index.html:505:28
+#: resources/public/pebble_templates/index.html
 Zooming=Zooming
 
-#: resources/public/pebble_templates/index.html:506:44
+#: resources/public/pebble_templates/index.html
 scrolling\ sensitivity;zooming\ sensitivity;mousewheel\ sensitivity=scrolling sensitivity;zooming sensitivity;mousewheel sensitivity
 
-#: resources/public/pebble_templates/index.html:508:57
+#: resources/public/pebble_templates/index.html
 Zoom\ sensitivity\:=Zoom sensitivity\:
 
-#: resources/public/pebble_templates/index.html:512:44
+#: resources/public/pebble_templates/index.html
 zooming\ limit;scrolling\ limit;mousewheel;zooming\ minimum;zooming\ maximum=zooming limit;scrolling limit;mousewheel;zooming minimum;zooming maximum
 
-#: resources/public/pebble_templates/index.html:514:57
+#: resources/public/pebble_templates/index.html
 Minimum\ scale\:=Minimum scale\:
 
-#: resources/public/pebble_templates/index.html:518:57
+#: resources/public/pebble_templates/index.html
 Maximum\ scale\:=Maximum scale\:
 
-#: resources/public/pebble_templates/index.html:522:44
+#: resources/public/pebble_templates/index.html
 rounding;zooming;scrolling;mousewheel;integer;decimal=rounding;zooming;scrolling;mousewheel;integer;decimal
 
-#: resources/public/pebble_templates/index.html:525:57
+#: resources/public/pebble_templates/index.html
 Round\ zoom\ values\ to\ nearest\ whole\ number=Round zoom values to nearest whole number
 
-#: resources/public/pebble_templates/index.html:529:44
+#: resources/public/pebble_templates/index.html
 controls;miscellaneous=controls;miscellaneous
 
-#: resources/public/pebble_templates/index.html:534:57
+#: resources/public/pebble_templates/index.html
 Lock\ the\ canvas\ (disallow\ canvas\ drag/zoom\ with\ mouse/fingers)=Lock the canvas (disallow canvas drag/zoom with mouse/fingers)
 
-#: resources/public/pebble_templates/index.html:537:44
+#: resources/public/pebble_templates/index.html
 MMB\ picker;mouse\ picker;selection;palette\ picker=MMB picker;mouse picker;selection;palette picker
 
-#: resources/public/pebble_templates/index.html:540:57
+#: resources/public/pebble_templates/index.html
 Enable\ middle\ mouse\ button\ selecting\ color\ from\ board=Enable middle mouse button selecting color from board
 
-#: resources/public/pebble_templates/index.html:543:44
+#: resources/public/pebble_templates/index.html
 right\ click\ action=right click action
 
-#: resources/public/pebble_templates/index.html:545:57
+#: resources/public/pebble_templates/index.html
 Right-click\ action\:=Right-click action\:
 
-#: resources/public/pebble_templates/index.html:547:60
+#: resources/public/pebble_templates/index.html
 Nothing=Nothing
 
-#: resources/public/pebble_templates/index.html:548:58
+#: resources/public/pebble_templates/index.html
 Clear\ color=Clear color
 
-#: resources/public/pebble_templates/index.html:549:57
+#: resources/public/pebble_templates/index.html
 Copy\ color=Copy color
 
-#: resources/public/pebble_templates/index.html:550:59
+#: resources/public/pebble_templates/index.html
 Lookup=Lookup
 
-#: resources/public/pebble_templates/index.html:551:64
+#: resources/public/pebble_templates/index.html
 Clear\ color\ +\ Lookup=Clear color + Lookup
 
-#: resources/public/pebble_templates/index.html:558:36
+#: resources/public/pebble_templates/index.html
 snapshots;screenshot;download;picture;canvas=snapshots;screenshot;download;picture;canvas
 
-#: resources/public/pebble_templates/index.html:560:24
+#: resources/public/pebble_templates/index.html
 Snapshot\ Settings=Snapshot Settings
 
-#: resources/public/pebble_templates/index.html:563:44
+#: resources/public/pebble_templates/index.html
 screenshot;snapshot;download;board;canvas=screenshot;snapshot;download;board;canvas
 
-#: resources/public/pebble_templates/index.html:564:44
+#: resources/public/pebble_templates/index.html
 take\ screenshot;image;download\ format;picture;canvas;board=take screenshot;image;download format;picture;canvas;board
 
-#: resources/public/pebble_templates/index.html:566:57
+#: resources/public/pebble_templates/index.html
 Snapshot\ image\ format\:=Snapshot image format\:
 
-#: resources/public/pebble_templates/index.html:568:71
+#: resources/public/pebble_templates/index.html
 PNG=PNG
 
-#: resources/public/pebble_templates/index.html:569:63
+#: resources/public/pebble_templates/index.html
 JPEG=JPEG
 
-#: resources/public/pebble_templates/index.html:570:63
+#: resources/public/pebble_templates/index.html
 WEBP\ (Chrome\ only)=WEBP (Chrome only)
 
-#: resources/public/pebble_templates/index.html:577:36
+#: resources/public/pebble_templates/index.html
 templates;overlays;guides=templates;overlays;guides
 
-#: resources/public/pebble_templates/index.html:582:44
+#: resources/public/pebble_templates/index.html
 templates;overlays;image;pixel\ art=templates;overlays;image;pixel art
 
-#: resources/public/pebble_templates/index.html:583:44
+#: resources/public/pebble_templates/index.html
 template\ enabled;template\ disabled;show\ template;hide\ template;template\ shown;template\ hidden=template enabled;template disabled;show template;hide template;template shown;template hidden
 
-#: resources/public/pebble_templates/index.html:586:57
+#: resources/public/pebble_templates/index.html
 Use\ template=Use template
 
-#: resources/public/pebble_templates/index.html:589:27
+#: resources/public/pebble_templates/index.html
 Hold\ down\ <kbd>Ctrl</kbd>\ (or\ <kbd>Option</kbd>\ on\ mac)\ to\ drag\ the\ template\ around=Hold down <kbd>Ctrl</kbd> (or <kbd>Option</kbd> on mac) to drag the template around
 
-#: resources/public/pebble_templates/index.html:590:44
+#: resources/public/pebble_templates/index.html
 template\ title;template\ name;tab\ name;tab\ title;title\==template title;template name;tab name;tab title;title\=
 
-#: resources/public/pebble_templates/index.html:592:57
+#: resources/public/pebble_templates/index.html
 Title\:=Title\:
 
-#: resources/public/pebble_templates/index.html:596:44
+#: resources/public/pebble_templates/index.html
 template\ location\ source;template\ source\ URL;template\ URL;template\==template location source;template source URL;template URL;template\=
 
-#: resources/public/pebble_templates/index.html:598:57
+#: resources/public/pebble_templates/index.html
 URL\:=URL\:
 
-#: resources/public/pebble_templates/index.html:603:44
+#: resources/public/pebble_templates/index.html
 template\ position;template\ x;template\ y;template\ location;\ template\ vertical;\ template\ horizontal;ox\=;oy\==template position;template x;template y;template location; template vertical; template horizontal;ox\=;oy\=
 
-#: resources/public/pebble_templates/index.html:605:57
+#: resources/public/pebble_templates/index.html
 Horizontal\ position\:=Horizontal position\:
 
-#: resources/public/pebble_templates/index.html:609:57
+#: resources/public/pebble_templates/index.html
 Vertical\ position\:=Vertical position\:
 
-#: resources/public/pebble_templates/index.html:613:44
+#: resources/public/pebble_templates/index.html
 template\ width;tw\==template width;tw\=
 
-#: resources/public/pebble_templates/index.html:615:57
+#: resources/public/pebble_templates/index.html
 Width\:=Width\:
 
-#: resources/public/pebble_templates/index.html:618:82
-#: resources/public/pebble_templates/index.html:688:79
+#: resources/public/pebble_templates/index.html
 Reset=Reset
 
-#: resources/public/pebble_templates/index.html:620:44
+#: resources/public/pebble_templates/index.html
 template\ style;custom\ template=template style;custom template
 
-#: resources/public/pebble_templates/index.html:622:57
+#: resources/public/pebble_templates/index.html
 Style\:=Style\:
 
-#: resources/public/pebble_templates/index.html:624:53
+#: resources/public/pebble_templates/index.html
 Use\ Source\ Style=Use Source Style
 
-#: resources/public/pebble_templates/index.html:625:239
+#: resources/public/pebble_templates/index.html
 Dotted\ (Small,\ 1\:2)=Dotted (Small, 1\:2)
 
-#: resources/public/pebble_templates/index.html:626:271
+#: resources/public/pebble_templates/index.html
 Dotted\ (Big,\ 2\:2)=Dotted (Big, 2\:2)
 
-#: resources/public/pebble_templates/index.html:627:1803
+#: resources/public/pebble_templates/index.html
 Numbers=Numbers
 
-#: resources/public/pebble_templates/index.html:628:85
+#: resources/public/pebble_templates/index.html
 Custom\u2026=Custom\u2026
 
-#: resources/public/pebble_templates/index.html:632:44
+#: resources/public/pebble_templates/index.html
 template\ style\ source;template\ style\ URL;custom\ style\ URL;custom\ template=template style source;template style URL;custom style URL;custom template
 
-#: resources/public/pebble_templates/index.html:634:57
+#: resources/public/pebble_templates/index.html
 Custom\ style\ URL\:=Custom style URL\:
 
-#: resources/public/pebble_templates/index.html:639:44
+#: resources/public/pebble_templates/index.html
 template\ conversion;template\ palette\ conversion;convert\ to\ palette=template conversion;template palette conversion;convert to palette
 
-#: resources/public/pebble_templates/index.html:641:57
+#: resources/public/pebble_templates/index.html
 Color\ Conversion\ Mode\:=Color Conversion Mode\:
 
-#: resources/public/pebble_templates/index.html:643:64
+#: resources/public/pebble_templates/index.html
 Unconverted=Unconverted
 
-#: resources/public/pebble_templates/index.html:644:66
+#: resources/public/pebble_templates/index.html
 Nearest\ Custom=Nearest Custom
 
-#: resources/public/pebble_templates/index.html:648:44
+#: resources/public/pebble_templates/index.html
 template\ transparency;template\ opacity;oo\==template transparency;template opacity;oo\=
 
-#: resources/public/pebble_templates/index.html:650:57
+#: resources/public/pebble_templates/index.html
 Opacity\:=Opacity\:
 
-#: resources/public/pebble_templates/index.html:658:36
+#: resources/public/pebble_templates/index.html
 sound;notification;alert;notify;ping=sound;notification;alert;notify;ping
 
-#: resources/public/pebble_templates/index.html:660:24
+#: resources/public/pebble_templates/index.html
 Sound\ and\ Notification\ Settings=Sound and Notification Settings
 
-#: resources/public/pebble_templates/index.html:665:44
+#: resources/public/pebble_templates/index.html
 audio;mute;noise;volume=audio;mute;noise;volume
 
-#: resources/public/pebble_templates/index.html:668:57
+#: resources/public/pebble_templates/index.html
 Enable\ sound=Enable sound
 
-#: resources/public/pebble_templates/index.html:671:44
+#: resources/public/pebble_templates/index.html
 notifs;notify;pixel\ notification=notifs;notify;pixel notification
 
-#: resources/public/pebble_templates/index.html:674:57
+#: resources/public/pebble_templates/index.html
 Enable\ pixel\ available\ notification=Enable pixel available notification
 
-#: resources/public/pebble_templates/index.html:678:44
+#: resources/public/pebble_templates/index.html
 notification;pixel\ ready;alert=notification;pixel ready;alert
 
-#: resources/public/pebble_templates/index.html:679:28
+#: resources/public/pebble_templates/index.html
 Pixel\ Ready\ Notification=Pixel Ready Notification
 
-#: resources/public/pebble_templates/index.html:680:44
+#: resources/public/pebble_templates/index.html
 alert\ source;notify\ url;notify\ source;notification\ url;notification\ source=alert source;notify url;notify source;notification url;notification source
 
-#: resources/public/pebble_templates/index.html:682:57
+#: resources/public/pebble_templates/index.html
 Alert\ URL\:=Alert URL\:
 
-#: resources/public/pebble_templates/index.html:686:85
+#: resources/public/pebble_templates/index.html
 Update=Update
 
-#: resources/public/pebble_templates/index.html:687:83
+#: resources/public/pebble_templates/index.html
 Test=Test
 
-#: resources/public/pebble_templates/index.html:691:44
+#: resources/public/pebble_templates/index.html
 sound\ level;audio\ level;mute\ audio;mute\ sound=sound level;audio level;mute audio;mute sound
 
-#: resources/public/pebble_templates/index.html:693:57
+#: resources/public/pebble_templates/index.html
 Volume\:=Volume\:
 
-#: resources/public/pebble_templates/index.html:698:44
+#: resources/public/pebble_templates/index.html
 alert\ forewarning;alert\ delay;\ notification\ delay;\ notification\ forewarning=alert forewarning;alert delay; notification delay; notification forewarning
 
-#: resources/public/pebble_templates/index.html:700:57
+#: resources/public/pebble_templates/index.html
 Delay\ (seconds)\:=Delay (seconds)\:
 
-#: resources/public/pebble_templates/index.html:705:44
+#: resources/public/pebble_templates/index.html
 chat\ mentions;chat\ pings;chat\ sound=chat mentions;chat pings;chat sound
 
-#: resources/public/pebble_templates/index.html:706:28
+#: resources/public/pebble_templates/index.html
 Chat\ Pings=Chat Pings
 
-#: resources/public/pebble_templates/index.html:710:57
+#: resources/public/pebble_templates/index.html
 Enable\ pings=Enable pings
 
-#: resources/public/pebble_templates/index.html:713:44
+#: resources/public/pebble_templates/index.html
 mention\ sound=mention sound
 
-#: resources/public/pebble_templates/index.html:715:57
+#: resources/public/pebble_templates/index.html
 Play\ sound\ on\ ping\:=Play sound on ping\:
 
-#: resources/public/pebble_templates/index.html:717:56
-#: resources/public/include/chat.js:1937:100
+#: resources/public/pebble_templates/index.html
+#: resources/public/include/chat.js
 Off=Off
 
-#: resources/public/pebble_templates/index.html:718:61
+#: resources/public/pebble_templates/index.html
 Only\ when\ necessary=Only when necessary
 
-#: resources/public/pebble_templates/index.html:719:59
+#: resources/public/pebble_templates/index.html
 Always=Always
 
-#: resources/public/pebble_templates/index.html:723:44
+#: resources/public/pebble_templates/index.html
 mention\ sound\ volume=mention sound volume
 
-#: resources/public/pebble_templates/index.html:725:57
+#: resources/public/pebble_templates/index.html
 Ping\ sound\ volume\:=Ping sound volume\:
 
-#: resources/public/pebble_templates/index.html:733:36
+#: resources/public/pebble_templates/index.html
 personal\ account=personal account
 
-#: resources/public/pebble_templates/index.html:735:24
+#: resources/public/pebble_templates/index.html
 Account\ Settings=Account Settings
 
-#: resources/public/pebble_templates/index.html:741:57
+#: resources/public/pebble_templates/index.html
 Public\ Discord\ name\:=Public Discord name\:
 
-#: resources/public/pebble_templates/index.html:745:83
-#: resources/public/include/chat.js:1939:92
-#: resources/public/include/chat.js:2003:92
+#: resources/public/pebble_templates/index.html
+#: resources/public/include/chat.js
 Set=Set
 
-#: resources/public/pebble_templates/index.html:746:86
+#: resources/public/pebble_templates/index.html
 Remove=Remove
 
 #. FAQ panel
-#: resources/public/pebble_templates/index.html:759:65
+#: resources/public/pebble_templates/index.html
 Help=Help
 
-#: resources/public/pebble_templates/index.html:772:54
+#: resources/public/pebble_templates/index.html
 Notifications=Notifications
 
-#: resources/public/pebble_templates/faq.html:3:16
+#: resources/public/pebble_templates/faq.html
 FAQ=FAQ
 
-#: resources/public/pebble_templates/faq.html:7:20
+#: resources/public/pebble_templates/faq.html
 Why\ is\ the\ cooldown\ as\ long\ as\ it\ is?=Why is the cooldown as long as it is?
 
-#: resources/public/pebble_templates/faq.html:8:20
+#: resources/public/pebble_templates/faq.html
 The\ time\ it\ takes\ to\ get\ a\ pixel\ is\ dynamic,\ and\ changes\ based\ on\ how\ many\ people\ are\ online.\ The\ cooldown\ time\ is\ longer\ when\ more\ users\ are\ online.=The time it takes to get a pixel is dynamic, and changes based on how many people are online. The cooldown time is longer when more users are online.
 
-#: resources/public/pebble_templates/faq.html:9:20
+#: resources/public/pebble_templates/faq.html
 Why\ does\ it\ say\ 0/6\ pixels?=Why does it say 0/6 pixels?
 
-#: resources/public/pebble_templates/faq.html:10:20
+#: resources/public/pebble_templates/faq.html
 This\ means\ that\ you\ are\ waiting\ for\ your\ next\ pixel.\ When\ you\ place\ a\ pixel,\ there\ is\ a\ cooldown\ for\ when\ you\ can\ place\ the\ next\ one.\ Over\ time,\ you\ can\ gain\ up\ to\ 6\ "stacked"\ pixels\ to\ place\ at\ once.=This means that you are waiting for your next pixel. When you place a pixel, there is a cooldown for when you can place the next one. Over time, you can gain up to 6 "stacked" pixels to place at once.
 
-#: resources/public/pebble_templates/faq.html:11:20
+#: resources/public/pebble_templates/faq.html
 Why\ does\ it\ take\ so\ long\ to\ "stack"\ pixels?=Why does it take so long to "stack" pixels?
 
-#: resources/public/pebble_templates/faq.html:12:20
+#: resources/public/pebble_templates/faq.html
 This\ is\ by\ design.\ It\ is\ better\ to\ place\ a\ pixel\ as\ soon\ as\ you\ get\ one.\ Pixel\ "stacking"\ is\ meant\ to\ give\ you\ a\ bump\ if\ you\ go\ AFK\ for\ a\ bit.\ It\ takes\ around\ 40\ minutes\ to\ get\ a\ full\ 6/6\ pixels,\ but\ it\ only\ takes\ around\ 3\ minutes\ to\ place\ 6\ pixels\ if\ you\ place\ them\ as\ soon\ as\ possible.=This is by design. It is better to place a pixel as soon as you get one. Pixel "stacking" is meant to give you a bump if you go AFK for a bit. It takes around 40 minutes to get a full 6/6 pixels, but it only takes around 3 minutes to place 6 pixels if you place them as soon as possible.
 
-#: resources/public/pebble_templates/faq.html:13:20
+#: resources/public/pebble_templates/faq.html
 How\ do\ I\ appeal\ a\ ban?=How do I appeal a ban?
 
-#: resources/public/pebble_templates/faq.html:14:20
+#: resources/public/pebble_templates/faq.html
 Contact\ us\ on\ <a\ href\="https\://pxls.space/discord"\ target\="_blank">Discord</a>\ or\ send\ an\ appeal\ to\ our\ <a\ href\="https\://pxls.space/appeal"\ target\="_blank">Google\ form</a>\ after\ reading\ the\ rules\ in\ the\ site's\ info\ panel.=Contact us on <a href\="https\://pxls.space/discord" target\="_blank">Discord</a> or send an appeal to our <a href\="https\://pxls.space/appeal" target\="_blank">Google form</a> after reading the rules in the site's info panel.
 
-#: resources/public/pebble_templates/faq.html:15:20
+#: resources/public/pebble_templates/faq.html
 How\ do\ I\ make\ a\ template?=How do I make a template?
 
-#: resources/public/pebble_templates/faq.html:16:20
+#: resources/public/pebble_templates/faq.html
 A\ template\ is\ an\ image\ link\ that\ is\ posted\ in\ the\ template\ textbox\ in\ the\ settings\ panel\ so\ you\ can\ place\ over\ it\ on\ the\ canvas.\ You\ may\ use\ a\ regular\ image\ link\ to\ your\ pixel\ art,\ but\ many\ people\ use\ the\ 3rd\ party\ tool\ <a\ href\="https\://pxlsfiddle.com"\ target\="_blank">PxlsFiddle</a>\ to\ turn\ pixel\ art\ into\ a\ fancier\ link.\ If\ you\ need\ to\ make\ pixel\ art\ yourself,\ you\ can\ use\ <a\ href\="https\://www.piskelapp.com/p/create"\ target\="_blank">Piskel</a>\ to\ create\ art\ to\ put\ into\ PxlsFiddle.=A template is an image link that is posted in the template textbox in the settings panel so you can place over it on the canvas. You may use a regular image link to your pixel art, but many people use the 3rd party tool <a href\="https\://pxlsfiddle.com" target\="_blank">PxlsFiddle</a> to turn pixel art into a fancier link. If you need to make pixel art yourself, you can use <a href\="https\://www.piskelapp.com/p/create" target\="_blank">Piskel</a> to create art to put into PxlsFiddle.
 
-#: resources/public/pebble_templates/faq.html:17:20
+#: resources/public/pebble_templates/faq.html
 How\ do\ I\ move\ a\ template?=How do I move a template?
 
-#: resources/public/pebble_templates/faq.html:18:20
+#: resources/public/pebble_templates/faq.html
 Hold\ <kbd>CTRL</kbd>\ (or\ <kbd>OPTION</kbd>\ on\ macOS)\ and\ click\ and\ drag\ to\ move\ it\ around.\ On\ mobile,\ you\ can\ tap\ and\ hold\ where\ you\ want\ to\ move\ the\ template\ and\ click\ "Move\ Template\ Here"\ in\ the\ pop-up.=Hold <kbd>CTRL</kbd> (or <kbd>OPTION</kbd> on macOS) and click and drag to move it around. On mobile, you can tap and hold where you want to move the template and click "Move Template Here" in the pop-up.
 
-#: resources/public/pebble_templates/faq.html:19:20
+#: resources/public/pebble_templates/faq.html
 Does\ the\ canvas\ reset?\ When?=Does the canvas reset? When?
 
-#: resources/public/pebble_templates/faq.html:20:20
+#: resources/public/pebble_templates/faq.html
 Yes.\ The\ canvas\ resets\ when\ it\ is\ completely\ full.\ A\ reset\ date\ is\ not\ usually\ decided\ until\ the\ canvas\ is\ full,\ but\ the\ average\ canvas\ life-span\ is\ around\ 1\ month.\ Updates\ are\ posted\ in\ our\ <a\ href\="https\://pxls.space/discord"\ target\="_blank">Discord\ server</a>\ when\ a\ reset\ date\ is\ set.=Yes. The canvas resets when it is completely full. A reset date is not usually decided until the canvas is full, but the average canvas life-span is around 1 month. Updates are posted in our <a href\="https\://pxls.space/discord" target\="_blank">Discord server</a> when a reset date is set.
 
-#: resources/public/pebble_templates/faq.html:21:20
+#: resources/public/pebble_templates/faq.html
 Where\ can\ I\ see\ the\ past\ canvases?=Where can I see the past canvases?
 
-#: resources/public/pebble_templates/faq.html:22:20
+#: resources/public/pebble_templates/faq.html
 The\ past\ canvases\ are\ featured\ on\ our\ <a\ href\="https\://pxls.space/discord"\ target\="_blank">Discord\ server</a>,\ or\ the\ 3rd\ party\ website\ <a\ href\="https\://pxlsfiddle.com"\ target\="_blank">PxlsFiddle</a>,\ which\ records\ timelapses\ and\ a\ lot\ of\ useful\ information\ on\ each\ canvas.=The past canvases are featured on our <a href\="https\://pxls.space/discord" target\="_blank">Discord server</a>, or the 3rd party website <a href\="https\://pxlsfiddle.com" target\="_blank">PxlsFiddle</a>, which records timelapses and a lot of useful information on each canvas.
 
-#: resources/public/pebble_templates/faq.html:23:20
+#: resources/public/pebble_templates/faq.html
 How\ do\ I\ see\ who\ placed\ a\ pixel?=How do I see who placed a pixel?
 
-#: resources/public/pebble_templates/faq.html:24:20
+#: resources/public/pebble_templates/faq.html
 By\ shift-clicking\ (or\ tap\ and\ hold\ on\ mobile)\ a\ pixel,\ you\ can\ see\ who\ placed\ a\ pixel,\ how\ many\ pixels\ they\ have\ placed,\ and\ when\ they\ placed\ it.=By shift-clicking (or tap and hold on mobile) a pixel, you can see who placed a pixel, how many pixels they have placed, and when they placed it.
 
-#: resources/public/pebble_templates/faq.html:25:20
+#: resources/public/pebble_templates/faq.html
 How\ do\ I\ report\ someone?=How do I report someone?
 
-#: resources/public/pebble_templates/faq.html:26:20
+#: resources/public/pebble_templates/faq.html
 Shift-click\ (or\ tap\ and\ hold\ on\ mobile)\ on\ a\ pixel,\ and\ click\ the\ Report\ button.=Shift-click (or tap and hold on mobile) on a pixel, and click the Report button.
 
-#: resources/public/pebble_templates/faq.html:27:20
+#: resources/public/pebble_templates/faq.html
 How\ do\ I\ change\ the\ color\ of\ my\ name\ in\ the\ chat?=How do I change the color of my name in the chat?
 
-#: resources/public/pebble_templates/faq.html:28:20
+#: resources/public/pebble_templates/faq.html
 There\ is\ a\ "Username\ Color"\ option\ near\ the\ bottom\ of\ the\ settings\ panel.=There is a "Username Color" option near the bottom of the settings panel.
 
-#: resources/public/pebble_templates/faq.html:29:20
+#: resources/public/pebble_templates/faq.html
 What\ is\ a\ "virginmap"?=What is a "virginmap"?
 
-#: resources/public/pebble_templates/faq.html:30:20
+#: resources/public/pebble_templates/faq.html
 The\ virginmap\ shows\ which\ pixels\ have\ not\ yet\ been\ placed\ on\ (or\ \u201cvirgin\u201d\ pixels).=The virginmap shows which pixels have not yet been placed on (or \u201cvirgin\u201d pixels).
 
-#: resources/public/pebble_templates/faq.html:31:20
+#: resources/public/pebble_templates/faq.html
 How\ do\ I\ report\ bugs?=How do I report bugs?
 
-#: resources/public/pebble_templates/faq.html:32:20
+#: resources/public/pebble_templates/faq.html
 Submit\ bugs\ to\ the\ \#dev-and-bugs\ channel\ in\ the\ <a\ href\="https\://pxls.space/discord"\ target\="_blank">Discord\ server</a>.\ If\ you\ have\ found\ an\ exploit,\ please\ message\ one\ of\ the\ staff\ members\ privately\ (through\ DMs).=Submit bugs to the \#dev-and-bugs channel in the <a href\="https\://pxls.space/discord" target\="_blank">Discord server</a>. If you have found an exploit, please message one of the staff members privately (through DMs).
 
-#: resources/public/pebble_templates/faq.html:33:20
+#: resources/public/pebble_templates/faq.html
 How\ do\ I\ get\ more\ info\ or\ contact\ staff?=How do I get more info or contact staff?
 
-#: resources/public/pebble_templates/faq.html:34:20
+#: resources/public/pebble_templates/faq.html
 Check\ the\ info\ panel\ (the\ icon\ on\ the\ top\ left)\ for\ more\ details\ and\ links,\ or\ join\ our\ <a\ href\="https\://pxls.space/discord"\ target\="_blank">Discord\ server</a>,\ where\ a\ staff\ member\ will\ gladly\ respond.=Check the info panel (the icon on the top left) for more details and links, or join our <a href\="https\://pxls.space/discord" target\="_blank">Discord server</a>, where a staff member will gladly respond.
 
-#: resources/public/pebble_templates/info.html:3:10
+#: resources/public/pebble_templates/info.html
 Welcome\!=Welcome\!
 
-#: resources/public/pebble_templates/info.html:6:9
+#: resources/public/pebble_templates/info.html
 Welcome\ to\ pxls.space\!\ Pxls\ is\ a\ multiplayer\ online\ collaborative\ canvas\ that\ allows\ you\ to\ create\ anything\ you\ can\ imagine,\ one\ pixel\ at\ a\ time.\ Join\ hundreds\ of\ other\ players\ in\ the\ Pxls\ community\ and\ create\ amazing\ works\ of\ art\ together\ as\ a\ team,\ or\ solo.=Welcome to pxls.space\! Pxls is a multiplayer online collaborative canvas that allows you to create anything you can imagine, one pixel at a time. Join hundreds of other players in the Pxls community and create amazing works of art together as a team, or solo.
 
-#: resources/public/pebble_templates/info.html:7:9
+#: resources/public/pebble_templates/info.html
 The\ best\ place\ to\ reach\ staff\ and\ fellow\ community\ is\ in\ the\ discord\!=The best place to reach staff and fellow community is in the discord\!
 
-#: resources/public/pebble_templates/info.html:8:9
+#: resources/public/pebble_templates/info.html
 Check\ out\ our\ social\ media\ pages,\ and\ please\ take\ the\ time\ to\ read\ the\ rules\ below.\ Have\ fun\ creating\ (or\ changing)\ art\!=Check out our social media pages, and please take the time to read the rules below. Have fun creating (or changing) art\!
 
-#: resources/public/pebble_templates/info.html:13:27
+#: resources/public/pebble_templates/info.html
 Canvas\ Rules=Canvas Rules
 
-#: resources/public/pebble_templates/info.html:16:9
+#: resources/public/pebble_templates/info.html
 We\ pride\ ourselves\ on\ trying\ to\ keep\ an\ open\ canvas\ for\ all\ free\ from\ outside\ interference\ on\ our\ end,\ and\ especially\ censorship.\ However,\ for\ the\ good\ of\ the\ community\ and\ on\ accounts\ of\ our\ own\ beliefs,\ please\ acknowledge\ and\ obey\ the\ following\ guidelines\:=We pride ourselves on trying to keep an open canvas for all free from outside interference on our end, and especially censorship. However, for the good of the community and on accounts of our own beliefs, please acknowledge and obey the following guidelines\:
 
-#: resources/public/pebble_templates/info.html:18:11
+#: resources/public/pebble_templates/info.html
 No\ hateful\ imagery\ or\ derogatory\ speech.\ This\ includes\ but\ is\ not\ limited\ to\ words\ such\ as\ <i>faggot</i>,\ <i>nigger</i>,\ etc;\ as\ well\ as\ the\ Swastika,\ Hammer\ and\ Sickle,\ and\ any\ symbols\ of\ terrorism.=No hateful imagery or derogatory speech. This includes but is not limited to words such as <i>faggot</i>, <i>nigger</i>, etc; as well as the Swastika, Hammer and Sickle, and any symbols of terrorism.
 
-#: resources/public/pebble_templates/info.html:19:11
+#: resources/public/pebble_templates/info.html
 No\ NSFW\ or\ NSFL\ content.=No NSFW or NSFL content.
 
-#: resources/public/pebble_templates/info.html:21:13
+#: resources/public/pebble_templates/info.html
 No\ nudity\ or\ otherwise\ sexually\ explicit\ content=No nudity or otherwise sexually explicit content
 
-#: resources/public/pebble_templates/info.html:23:15
+#: resources/public/pebble_templates/info.html
 No\ female-presenting\ nipples/bare\ breasts,\ genitalia,\ sexual\ fluids=No female-presenting nipples/bare breasts, genitalia, sexual fluids
 
-#: resources/public/pebble_templates/info.html:26:13
+#: resources/public/pebble_templates/info.html
 No\ sexual\ imagery/erotica=No sexual imagery/erotica
 
-#: resources/public/pebble_templates/info.html:27:13
+#: resources/public/pebble_templates/info.html
 No\ excessive\ blood\ or\ otherwise\ obscene/shocking\ content=No excessive blood or otherwise obscene/shocking content
 
-#: resources/public/pebble_templates/info.html:30:11
+#: resources/public/pebble_templates/info.html
 No\ more\ than\ <b>one</b>\ account\ per\ user,\ no\ exceptions.\ Multiple\ account\ users\ will\ be\ banned\ from\ creating\ art\ on\ the\ canvas.=No more than <b>one</b> account per user, no exceptions. Multiple account users will be banned from creating art on the canvas.
 
-#: resources/public/pebble_templates/info.html:31:11
+#: resources/public/pebble_templates/info.html
 No\ auto-placement\ tools\ of\ any\ kind,\ you\ must\ place\ the\ pixels\ manually.=No auto-placement tools of any kind, you must place the pixels manually.
 
-#: resources/public/pebble_templates/info.html:32:11
+#: resources/public/pebble_templates/info.html
 Do\ not\ abuse\ site\ functionality,\ such\ as\ reports\ or\ lookups.\ (e.g.\ automated\ reporting/lookups,\ etc.)=Do not abuse site functionality, such as reports or lookups. (e.g. automated reporting/lookups, etc.)
 
-#: resources/public/pebble_templates/info.html:33:11
+#: resources/public/pebble_templates/info.html
 Any\ automated\ aggregation\ of\ data\ from\ user\ lookups\ is\ not\ allowed,\ and\ will\ result\ in\ a\ ban.=Any automated aggregation of data from user lookups is not allowed, and will result in a ban.
 
-#: resources/public/pebble_templates/info.html:34:11
-#: resources/public/pebble_templates/info.html:62:11
+#: resources/public/pebble_templates/info.html
 Staff\ have\ final\ say\ in\ any\ rule\ disputes=Staff have final say in any rule disputes
 
-#: resources/public/pebble_templates/info.html:35:12
-#: resources/public/pebble_templates/info.html:64:13
+#: resources/public/pebble_templates/info.html
 If\ you\ feel\ a\ moderator\ has\ acted\ inappropriately,\ please\ report\ it\ to\ an\ administrator.=If you feel a moderator has acted inappropriately, please report it to an administrator.
 
-#: resources/public/pebble_templates/info.html:38:9
+#: resources/public/pebble_templates/info.html
 If\ you\ believe\ you\ have\ been\ falsely\ banned\ you\ may\ contact\ a\ moderator\ or\ administrator.=If you believe you have been falsely banned you may contact a moderator or administrator.
 
-#: resources/public/pebble_templates/info.html:43:27
+#: resources/public/pebble_templates/info.html
 Chat\ Rules=Chat Rules
 
-#: resources/public/pebble_templates/info.html:47:11
+#: resources/public/pebble_templates/info.html
 Keep\ chat\ civil.\ No\ harassment\ or\ homophobic/transphobic/disablist\ language.=Keep chat civil. No harassment or homophobic/transphobic/disablist language.
 
-#: resources/public/pebble_templates/info.html:48:11
+#: resources/public/pebble_templates/info.html
 No\ hate\ speech.\ This\ includes\ emoji/symbols/ASCII\ art.=No hate speech. This includes emoji/symbols/ASCII art.
 
-#: resources/public/pebble_templates/info.html:50:13
+#: resources/public/pebble_templates/info.html
 Normal\ swearing/etc\ is\ allowed=Normal swearing/etc is allowed
 
-#: resources/public/pebble_templates/info.html:53:11
+#: resources/public/pebble_templates/info.html
 No\ spamming=No spamming
 
-#: resources/public/pebble_templates/info.html:55:13
+#: resources/public/pebble_templates/info.html
 This\ includes\ excessive\ ASCII\ art/emojis/symbols/whitespace=This includes excessive ASCII art/emojis/symbols/whitespace
 
-#: resources/public/pebble_templates/info.html:58:11
+#: resources/public/pebble_templates/info.html
 No\ "copy\ pasta"s=No "copy pasta"s
 
-#: resources/public/pebble_templates/info.html:59:11
+#: resources/public/pebble_templates/info.html
 No\ links\ to\ sites\ that\ actively\ break\ the\ canvas\ or\ chat\ rules\ (e.g.\ porn\ sites)=No links to sites that actively break the canvas or chat rules (e.g. porn sites)
 
-#: resources/public/pebble_templates/info.html:60:11
+#: resources/public/pebble_templates/info.html
 No\ symbology\ which\ break\ the\ canvas\ or\ chat\ rules\ (e.g.\ NSFW\ ASCII\ art)=No symbology which break the canvas or chat rules (e.g. NSFW ASCII art)
 
-#: resources/public/pebble_templates/info.html:61:16
+#: resources/public/pebble_templates/info.html
 No\ personal\ information=No personal information
 
-#: resources/public/pebble_templates/info.html:72:10
+#: resources/public/pebble_templates/info.html
 Links=Links
 
-#: resources/public/pebble_templates/info.html:76:64
+#: resources/public/pebble_templates/info.html
 Discord\ (main\ hub)=Discord (main hub)
 
-#: resources/public/pebble_templates/info.html:77:68
+#: resources/public/pebble_templates/info.html
 Subreddit=Subreddit
 
-#: resources/public/pebble_templates/info.html:78:68
+#: resources/public/pebble_templates/info.html
 Twitter=Twitter
 
-#: resources/public/pebble_templates/info.html:79:66
+#: resources/public/pebble_templates/info.html
 GitHub=GitHub
 
 #. link to piskelapp.com
-#: resources/public/pebble_templates/info.html:81:71
+#: resources/public/pebble_templates/info.html
 Single-player\ mode=Single-player mode
 
-#: resources/public/pebble_templates/info.html:84:62
+#: resources/public/pebble_templates/info.html
 Statistics=Statistics
 
-#: resources/public/pebble_templates/info.html:85:64
+#: resources/public/pebble_templates/info.html
 Profile\ (user\ info,\ factions,\ etc.)=Profile (user info, factions, etc.)
 
 #. link to pxlsfiddle.com
-#: resources/public/pebble_templates/info.html:87:68
+#: resources/public/pebble_templates/info.html
 Template\ generator,\ archives,\ timelapses,\ and\ other\ utilities=Template generator, archives, timelapses, and other utilities
 
 #. link to pxlsfiddle.com
-#: resources/public/pebble_templates/info.html:87:165
+#: resources/public/pebble_templates/info.html
 PxlsFiddle\ (templates,\ archives,\ etc.)=PxlsFiddle (templates, archives, etc.)
 
-#: resources/public/pebble_templates/info.html:93:10
+#: resources/public/pebble_templates/info.html
 Donate=Donate
 
-#: resources/public/pebble_templates/info.html:96:9
+#: resources/public/pebble_templates/info.html
 Donations\ are\ not\ accepted\ at\ this\ time,\ but\ this\ panel\ will\ be\ updated\ when\ they're\ open\ again\!=Donations are not accepted at this time, but this panel will be updated when they're open again\!
 
 #. eg "Alice's profile". Double singlequote is a java thing - needed if a replacement (such as this) contains a singlequote.
-#: resources/public/pebble_templates/profile.html:31:66
-#: resources/public/pebble_templates/profile.html:50:131
+#: resources/public/pebble_templates/profile.html
 {0}''s\ Profile={0}''s Profile
 
-#: resources/public/pebble_templates/profile.html:41:84
-#: resources/public/pebble_templates/40x.html:28:84
-#: resources/public/pebble_templates/40x.html:45:100
-#: resources/public/pebble_templates/40x.html:62:100
+#: resources/public/pebble_templates/profile.html
+#: resources/public/pebble_templates/40x.html
 My\ Profile=My Profile
 
-#: resources/public/pebble_templates/profile.html:42:85
-#: resources/public/pebble_templates/40x.html:29:85
+#: resources/public/pebble_templates/profile.html
+#: resources/public/pebble_templates/40x.html
 My\ Factions=My Factions
 
-#: resources/public/pebble_templates/profile.html:60:93
-#: resources/public/pebble_templates/profile.html:126:56
+#: resources/public/pebble_templates/profile.html
 Reports=Reports
 
-#: resources/public/pebble_templates/profile.html:63:94
+#: resources/public/pebble_templates/profile.html
 Factions=Factions
 
-#: resources/public/pebble_templates/profile.html:71:68
+#: resources/public/pebble_templates/profile.html
 You\ must\ be\ logged\ in\ to\ view\ your\ profile.=You must be logged in to view your profile.
 
-#: resources/public/pebble_templates/profile.html:77:72
+#: resources/public/pebble_templates/profile.html
 Registration\ Date=Registration Date
 
-#: resources/public/pebble_templates/profile.html:82:72
-#: resources/public/include/lookup.js:280:21
+#: resources/public/pebble_templates/profile.html
+#: resources/public/include/lookup.js
 Alltime\ Pixels=Alltime Pixels
 
-#: resources/public/pebble_templates/profile.html:86:72
+#: resources/public/pebble_templates/profile.html
 Current\ Canvas\ Pixels=Current Canvas Pixels
 
-#: resources/public/pebble_templates/profile.html:91:72
+#: resources/public/pebble_templates/profile.html
 Discord\ Tag=Discord Tag
 
-#: resources/public/pebble_templates/profile.html:95:72
-#: resources/public/include/lookup.js:235:21
+#: resources/public/pebble_templates/profile.html
+#: resources/public/include/lookup.js
 Faction=Faction
 
-#: resources/public/pebble_templates/profile.html:96:259
+#: resources/public/pebble_templates/profile.html
 None=None
 
-#: resources/public/pebble_templates/profile.html:99:72
-#: resources/public/admin/admin.js:198:16
+#: resources/public/pebble_templates/profile.html
+#: resources/public/admin/admin.js
 Roles=Roles
 
-#: resources/public/pebble_templates/profile.html:104:72
+#: resources/public/pebble_templates/profile.html
 Canvas\ Ban\ Expiry=Canvas Ban Expiry
 
-#: resources/public/pebble_templates/profile.html:105:101
-#: resources/public/pebble_templates/profile.html:111:105
+#: resources/public/pebble_templates/profile.html
 Never=Never
 
-#: resources/public/pebble_templates/profile.html:110:72
+#: resources/public/pebble_templates/profile.html
 Chat\ Ban\ Expiry=Chat Ban Expiry
 
-#: resources/public/pebble_templates/profile.html:117:36
+#: resources/public/pebble_templates/profile.html
 View\ rankings\ and\ other\ stats\ <a\ href\="/stats">here</a>.=View rankings and other stats <a href\="/stats">here</a>.
 
-#: resources/public/pebble_templates/profile.html:124:68
+#: resources/public/pebble_templates/profile.html
 You\ must\ be\ logged\ in\ to\ view\ your\ reports.=You must be logged in to view your reports.
 
-#: resources/public/pebble_templates/profile.html:130:64
+#: resources/public/pebble_templates/profile.html
 Canvas\ Reports\ ({0}/{1}\ open)=Canvas Reports ({0}/{1} open)
 
 #. eg "Report on Bob (closed)
-#: resources/public/pebble_templates/profile.html:142:56
-#: resources/public/pebble_templates/profile.html:177:56
+#: resources/public/pebble_templates/profile.html
 Report\ on\ {0}\ (closed)=Report on {0} (closed)
 
 #. eg "Report on Bob (open)
-#: resources/public/pebble_templates/profile.html:145:56
-#: resources/public/pebble_templates/profile.html:179:56
+#: resources/public/pebble_templates/profile.html
 Report\ on\ {0}\ (open)=Report on {0} (open)
 
 #. eg "Reported Bob on Jan 1, 1970, 00:00:00 AM (UTC)
-#: resources/public/pebble_templates/profile.html:152:60
-#: resources/public/pebble_templates/profile.html:185:60
+#: resources/public/pebble_templates/profile.html
 Reported\ {0}\ on\ {1}=Reported {0} on {1}
 
-#: resources/public/pebble_templates/profile.html:158:47
+#: resources/public/pebble_templates/profile.html
 There\ are\ no\ canvas\ reports\ to\ show.=There are no canvas reports to show.
 
-#: resources/public/pebble_templates/profile.html:166:64
+#: resources/public/pebble_templates/profile.html
 Chat\ Reports\ ({0}/{1}\ open)=Chat Reports ({0}/{1} open)
 
-#: resources/public/pebble_templates/profile.html:191:47
+#: resources/public/pebble_templates/profile.html
 There\ are\ no\ chat\ reports\ to\ show.=There are no chat reports to show.
 
-#: resources/public/pebble_templates/profile.html:200:68
+#: resources/public/pebble_templates/profile.html
 You\ must\ be\ logged\ in\ to\ manage\ your\ factions.=You must be logged in to manage your factions.
 
-#: resources/public/pebble_templates/profile.html:205:36
+#: resources/public/pebble_templates/profile.html
 You\ are\ faction\ restricted\ and\ cannot\ create\ new\ factions.\ If\ you\ believe\ this\ is\ an\ error,\ please\ contact\ a\ moderator.=You are faction restricted and cannot create new factions. If you believe this is an error, please contact a moderator.
 
-#: resources/public/pebble_templates/profile.html:207:36
+#: resources/public/pebble_templates/profile.html
 You\ are\ canvas\ banned\ and\ cannot\ create\ new\ factions.\ If\ you\ believe\ this\ is\ an\ error,\ please\ contact\ a\ moderator.=You are canvas banned and cannot create new factions. If you believe this is an error, please contact a moderator.
 
-#: resources/public/pebble_templates/profile.html:212:76
+#: resources/public/pebble_templates/profile.html
 You\ must\ have\ at\ least\ {0}\ all-time\ pixels\ to\ create\ a\ faction.=You must have at least {0} all-time pixels to create a faction.
 
-#: resources/public/pebble_templates/profile.html:215:300
+#: resources/public/pebble_templates/profile.html
 Create=Create
 
-#: resources/public/pebble_templates/profile.html:216:191
+#: resources/public/pebble_templates/profile.html
 Join=Join
 
-#: resources/public/pebble_templates/profile.html:225:118
+#: resources/public/pebble_templates/profile.html
 This\ is\ your\ currently\ displayed\ faction.=This is your currently displayed faction.
 
 #. eg "Pixelers (members: 100, ID: 1)"
-#: resources/public/pebble_templates/profile.html:228:44
+#: resources/public/pebble_templates/profile.html
 {0}\ (members\:\ {1},\ ID\:\ {2}={0} (members\: {1}, ID\: {2}
 
-#: resources/public/pebble_templates/profile.html:231:69
+#: resources/public/pebble_templates/profile.html
 Owner\:\ {0}=Owner\: {0}
 
 #. makes the faction no longer the one displayed for the current user
-#: resources/public/pebble_templates/profile.html:236:175
+#: resources/public/pebble_templates/profile.html
 Remove\ Displayed=Remove Displayed
 
 #. makes the faction the one displayed for the current user
-#: resources/public/pebble_templates/profile.html:239:172
+#: resources/public/pebble_templates/profile.html
 Set\ Displayed=Set Displayed
 
-#: resources/public/pebble_templates/profile.html:242:235
+#: resources/public/pebble_templates/profile.html
 Members=Members
 
-#: resources/public/pebble_templates/profile.html:243:169
+#: resources/public/pebble_templates/profile.html
 Edit=Edit
 
-#: resources/public/pebble_templates/profile.html:244:168
-#: resources/public/include/chat.js:1462:24
+#: resources/public/pebble_templates/profile.html
+#: resources/public/include/chat.js
 Delete=Delete
 
-#: resources/public/pebble_templates/profile.html:246:174
+#: resources/public/pebble_templates/profile.html
 Leave=Leave
 
-#: resources/public/pebble_templates/profile.html:253:68
+#: resources/public/pebble_templates/profile.html
 You\ are\ not\ in\ any\ factions\ yet\!=You are not in any factions yet\!
 
-#: resources/public/pebble_templates/profile.html:269:52
+#: resources/public/pebble_templates/profile.html
 Members\ of\ {0}\ ([{1}])=Members of {0} ([{1}])
 
-#: resources/public/pebble_templates/profile.html:270:97
-#: resources/public/pebble_templates/profile.html:329:97
-#: resources/public/pebble_templates/profile.html:342:97
-#: resources/public/pebble_templates/profile.html:366:97
+#: resources/public/pebble_templates/profile.html
 Close=Close
 
-#: resources/public/pebble_templates/profile.html:278:60
+#: resources/public/pebble_templates/profile.html
 Faction\ Members=Faction Members
 
-#: resources/public/pebble_templates/profile.html:292:128
+#: resources/public/pebble_templates/profile.html
 Transfer\ Ownership=Transfer Ownership
 
 #. bans a user from the faction
-#: resources/public/pebble_templates/profile.html:294:122
-#: resources/public/include/chat.js:1733:60
+#: resources/public/pebble_templates/profile.html
+#: resources/public/include/chat.js
 Ban=Ban
 
-#: resources/public/pebble_templates/profile.html:300:79
-#: resources/public/pebble_templates/profile.html:322:79
+#: resources/public/pebble_templates/profile.html
 Nothing\ to\ see\ here\!=Nothing to see here\!
 
-#: resources/public/pebble_templates/profile.html:308:60
+#: resources/public/pebble_templates/profile.html
 Faction\ Bans=Faction Bans
 
-#: resources/public/pebble_templates/profile.html:318:125
-#: resources/public/include/chat.js:1629:36
-#: resources/public/include/chat.js:1733:46
-#: resources/public/admin/admin.js:320:88
-#: resources/public/admin/admin.js:347:52
+#: resources/public/pebble_templates/profile.html
+#: resources/public/include/chat.js resources/public/admin/admin.js
 Unban=Unban
 
-#: resources/public/pebble_templates/profile.html:341:52
+#: resources/public/pebble_templates/profile.html
 Find\ A\ Faction=Find A Faction
 
-#: resources/public/pebble_templates/profile.html:351:99
+#: resources/public/pebble_templates/profile.html
 Search\:=Search\:
 
-#: resources/public/pebble_templates/profile.html:361:66
+#: resources/public/pebble_templates/profile.html
 Enter\ a\ search\ term\ to\ get\ started.=Enter a search term to get started.
 
-#: resources/public/pebble_templates/profile.html:363:116
+#: resources/public/pebble_templates/profile.html
 Load\ More=Load More
 
 #. HTTP status code name
-#: resources/public/pebble_templates/40x.html:39:24
+#: resources/public/pebble_templates/40x.html
 Not\ Found=Not Found
 
-#: resources/public/pebble_templates/40x.html:41:23
+#: resources/public/pebble_templates/40x.html
 The\ content\ you\ requested\ could\ not\ be\ found\ at\ this\ URL.\ If\ you\ believe\ this\ is\ an\ error,\ please\ contact\ a\ developer.=The content you requested could not be found at this URL. If you believe this is an error, please contact a developer.
 
 #. links to the homepage (the app itself)
-#: resources/public/pebble_templates/40x.html:44:99
-#: resources/public/pebble_templates/40x.html:53:99
-#: resources/public/pebble_templates/40x.html:61:99
+#: resources/public/pebble_templates/40x.html
 Back\ to\ Pxls=Back to Pxls
 
 #. HTTP status code name
-#: resources/public/pebble_templates/40x.html:49:24
+#: resources/public/pebble_templates/40x.html
 Not\ Authenticated=Not Authenticated
 
-#: resources/public/pebble_templates/40x.html:51:23
+#: resources/public/pebble_templates/40x.html
 You\ must\ be\ logged\ in\ to\ access\ this\ data.\ Please\ go\ back\ to\ pxls\ and\ go\ through\ the\ authentication\ process.=You must be logged in to access this data. Please go back to pxls and go through the authentication process.
 
 #. HTTP status code name
-#: resources/public/pebble_templates/40x.html:57:24
+#: resources/public/pebble_templates/40x.html
 Not\ Allowed=Not Allowed
 
-#: resources/public/pebble_templates/40x.html:59:23
+#: resources/public/pebble_templates/40x.html
 The\ action\ you\ attempted\ to\ perform\ is\ not\ allowed\ or\ resulted\ in\ an\ error.\ Please\ ensure\ you\ have\ access\ to\ the\ endpoint\ and\ try\ again\ later.=The action you attempted to perform is not allowed or resulted in an error. Please ensure you have access to the endpoint and try again later.
 
-#: resources/public/pxls.js:134:38
+#: resources/public/pxls.js
 Alert=Alert
 
 #. Snapshot save name
-#: resources/public/include/board.js:806:100
+#: resources/public/include/board.js
 pxls\ canvas=pxls canvas
 
 #. template link action
-#: resources/public/include/chat.js:80:21
+#: resources/public/include/chat.js
 Ask=Ask
 
-#: resources/public/include/chat.js:84:21
+#: resources/public/include/chat.js
 Open\ in\ a\ new\ tab=Open in a new tab
 
-#: resources/public/include/chat.js:88:21
+#: resources/public/include/chat.js
 Open\ in\ current\ tab\ (replacing\ template)=Open in current tab (replacing template)
 
-#: resources/public/include/chat.js:92:21
+#: resources/public/include/chat.js
 Jump\ to\ coordinates\ without\ replacing\ template=Jump to coordinates without replacing template
 
-#: resources/public/include/chat.js:437:55
-#: resources/public/include/chat.js:956:53
+#: resources/public/include/chat.js
 You\ must\ be\ logged\ in\ to\ chat.=You must be logged in to chat.
 
-#: resources/public/include/chat.js:1260:42
-#: resources/public/include/chat.js:1753:27
+#: resources/public/include/chat.js
 none\ provided=none provided
 
-#: resources/public/include/chat.js:1261:38
+#: resources/public/include/chat.js
 Purged\ by\ ${purge.initiator}\ with\ reason\:\ ${reason}=Purged by ${purge.initiator} with reason\: ${reason}
 
-#: resources/public/include/chat.js:1279:26
+#: resources/public/include/chat.js
 template\:=template\:
 
-#: resources/public/include/chat.js:1331:56
-#: resources/public/include/chat.js:2057:56
+#: resources/public/include/chat.js
 Open\ Failed=Open Failed
 
-#: resources/public/include/chat.js:1333:32
-#: resources/public/include/chat.js:2059:32
+#: resources/public/include/chat.js
 Failed\ to\ automatically\ open\ in\ a\ new\ tab=Failed to automatically open in a new tab
 
-#: resources/public/include/chat.js:1337:24
-#: resources/public/include/chat.js:2063:24
+#: resources/public/include/chat.js
 Click\ here\ to\ open\ in\ a\ new\ tab\ instead=Click here to open in a new tab instead
 
-#: resources/public/include/chat.js:1351:52
+#: resources/public/include/chat.js
 Open\ Template=Open Template
 
-#: resources/public/include/chat.js:1353:54
+#: resources/public/include/chat.js
 This\ link\ will\ overwrite\ your\ current\ template.\ What\ would\ you\ like\ to\ do?=This link will overwrite your current template. What would you like to do?
 
-#: resources/public/include/chat.js:1364:55
+#: resources/public/include/chat.js
 Note\:\ You\ can\ set\ a\ default\ action\ in\ the\ settings\ menu\ which\ bypasses\ this\ popup\ completely.=Note\: You can set a default action in the settings menu which bypasses this popup completely.
 
-#: resources/public/include/chat.js:1455:24
-#: resources/public/include/chat.js:1534:18
-#: resources/public/include/lookup.js:18:90
+#: resources/public/include/chat.js resources/public/include/lookup.js
 Report=Report
 
-#: resources/public/include/chat.js:1456:24
+#: resources/public/include/chat.js
 Mention=Mention
 
-#: resources/public/include/chat.js:1457:24
+#: resources/public/include/chat.js
 Ignore=Ignore
 
-#: resources/public/include/chat.js:1458:102
-#: resources/public/admin/admin.js:193:16
+#: resources/public/include/chat.js resources/public/admin/admin.js
 Profile=Profile
 
-#: resources/public/include/chat.js:1459:24
+#: resources/public/include/chat.js
 Chat\ (un)ban=Chat (un)ban
 
-#: resources/public/include/chat.js:1461:43
-#: resources/public/include/chat.js:1911:54
+#: resources/public/include/chat.js
 Purge\ User=Purge User
 
-#: resources/public/include/chat.js:1463:24
+#: resources/public/include/chat.js
 Mod\ Lookup=Mod Lookup
 
-#: resources/public/include/chat.js:1464:24
+#: resources/public/include/chat.js
 Chat\ Lookup=Chat Lookup
 
-#: resources/public/include/chat.js:1536:30
+#: resources/public/include/chat.js
 Enter\ a\ reason\ for\ your\ report=Enter a reason for your report
 
-#: resources/public/include/chat.js:1565:26
-#: resources/public/include/chat.js:1686:18
-#: resources/public/include/chat.js:1845:22
-#: resources/public/include/chat.js:1893:22
-#: resources/public/include/chat.js:1961:22
-#: resources/public/include/chat.js:2021:22
-#: resources/public/include/lookup.js:64:91
-#: resources/public/include/user.js:73:87
-#: resources/public/admin/admin.js:334:20
+#: resources/public/include/chat.js resources/public/include/lookup.js
+#: resources/public/include/user.js resources/public/admin/admin.js
 Cancel=Cancel
 
-#: resources/public/include/chat.js:1580:34
-#: resources/public/include/lookup.js:45:30
+#: resources/public/include/chat.js resources/public/include/lookup.js
 Error\ sending\ report.=Error sending report.
 
-#: resources/public/include/chat.js:1585:54
+#: resources/public/include/chat.js
 Report\ User=Report User
 
-#: resources/public/include/chat.js:1599:34
+#: resources/public/include/chat.js
 User\ ignored.\ You\ can\ unignore\ from\ chat\ settings.=User ignored. You can unignore from chat settings.
 
-#: resources/public/include/chat.js:1601:34
+#: resources/public/include/chat.js
 Failed\ to\ ignore\ user.\ Either\ they\\'re\ already\ ignored,\ or\ an\ error\ occurred.\ If\ the\ problem\ persists,\ contact\ a\ developer.=Failed to ignore user. Either they\\'re already ignored, or an error occurred. If the problem persists, contact a developer.
 
-#: resources/public/include/chat.js:1629:55
+#: resources/public/include/chat.js
 Permanent=Permanent
 
-#: resources/public/include/chat.js:1629:78
+#: resources/public/include/chat.js
 Temporary=Temporary
 
-#: resources/public/include/chat.js:1656:32
+#: resources/public/include/chat.js
 Rule\ 3\:\ Spam=Rule 3\: Spam
 
-#: resources/public/include/chat.js:1657:32
+#: resources/public/include/chat.js
 Rule\ 1\:\ Chat\ civility=Rule 1\: Chat civility
 
-#: resources/public/include/chat.js:1658:32
+#: resources/public/include/chat.js
 Rule\ 2\:\ Hate\ Speech=Rule 2\: Hate Speech
 
-#: resources/public/include/chat.js:1659:32
+#: resources/public/include/chat.js
 Rule\ 5\:\ NSFW=Rule 5\: NSFW
 
-#: resources/public/include/chat.js:1660:32
-#: resources/public/include/chat.js:1738:58
-#: resources/public/include/chat.js:1759:45
+#: resources/public/include/chat.js
 Custom=Custom
 
-#: resources/public/include/chat.js:1693:33
+#: resources/public/include/chat.js
 Banning\:=Banning\:
 
-#: resources/public/include/chat.js:1693:50
+#: resources/public/include/chat.js
 Message\:=Message\:
 
-#: resources/public/include/chat.js:1695:26
+#: resources/public/include/chat.js
 Ban\ Length=Ban Length
 
-#: resources/public/include/chat.js:1702:28
+#: resources/public/include/chat.js
 Reason=Reason
 
-#: resources/public/include/chat.js:1707:28
+#: resources/public/include/chat.js
 Purge\ Messages=Purge Messages
 
-#: resources/public/include/chat.js:1711:27
+#: resources/public/include/chat.js
 Purging\ all\ messages\ is\ disabled\ during\ snip\ mode=Purging all messages is disabled during snip mode
 
-#: resources/public/include/chat.js:1714:79
-#: resources/public/include/user.js:174:22
-#: resources/public/admin/admin.js:185:41
-#: resources/public/admin/admin.js:187:94
+#: resources/public/include/chat.js resources/public/include/user.js
+#: resources/public/admin/admin.js
 Yes=Yes
 
-#: resources/public/include/chat.js:1715:78
-#: resources/public/include/user.js:178:22
-#: resources/public/admin/admin.js:185:53
-#: resources/public/admin/admin.js:187:106
+#: resources/public/include/chat.js resources/public/include/user.js
+#: resources/public/admin/admin.js
 No=No
 
-#: resources/public/include/chat.js:1739:63
+#: resources/public/include/chat.js
 Custom\ reason=Custom reason
 
-#: resources/public/include/chat.js:1739:85
-#: resources/public/include/lookup.js:59:30
+#: resources/public/include/chat.js resources/public/include/lookup.js
 Additional\ information\ (if\ applicable)=Additional information (if applicable)
 
-#: resources/public/include/chat.js:1764:45
+#: resources/public/include/chat.js
 Additional\ information\:=Additional information\:
 
-#: resources/public/include/chat.js:1786:34
+#: resources/public/include/chat.js
 Error\ occurred\ while\ chatbanning=Error occurred while chatbanning
 
-#: resources/public/include/chat.js:1790:54
+#: resources/public/include/chat.js
 Chatban=Chatban
 
-#: resources/public/include/chat.js:1810:32
+#: resources/public/include/chat.js
 Failed\ to\ delete=Failed to delete
 
-#: resources/public/include/chat.js:1821:32
-#: resources/public/include/chat.js:1863:32
+#: resources/public/include/chat.js
 ID\:\ =ID\: 
 
-#: resources/public/include/chat.js:1825:32
-#: resources/public/include/chat.js:1873:32
+#: resources/public/include/chat.js
 User\:\ =User\: 
 
-#: resources/public/include/chat.js:1829:32
-#: resources/public/include/chat.js:1867:32
+#: resources/public/include/chat.js
 Message\:\ =Message\: 
 
-#: resources/public/include/chat.js:1833:32
+#: resources/public/include/chat.js
 Reason\:\ =Reason\: 
 
-#: resources/public/include/chat.js:1850:54
+#: resources/public/include/chat.js
 Delete\ Message=Delete Message
 
-#: resources/public/include/chat.js:1858:106
+#: resources/public/include/chat.js
 Purge=Purge
 
-#: resources/public/include/chat.js:1879:28
+#: resources/public/include/chat.js
 Selected\ Message=Selected Message
 
-#: resources/public/include/chat.js:1882:30
+#: resources/public/include/chat.js
 Purge\ Reason=Purge Reason
 
-#: resources/public/include/chat.js:1907:34
+#: resources/public/include/chat.js
 Error\ sending\ purge.=Error sending purge.
 
-#: resources/public/include/chat.js:1936:98
+#: resources/public/include/chat.js
 On=On
 
-#: resources/public/include/chat.js:1949:28
+#: resources/public/include/chat.js
 Toggle\ Rename\ Request=Toggle Rename Request
 
-#: resources/public/include/chat.js:1950:27
+#: resources/public/include/chat.js
 Select\ one\ of\ the\ options\ below\ to\ set\ the\ current\ rename\ request\ state.=Select one of the options below to set the current rename request state.
 
-#: resources/public/include/chat.js:1975:30
-#: resources/public/include/chat.js:2034:30
+#: resources/public/include/chat.js
 An\ unknown\ error\ occurred.\ Please\ contact\ a\ developer=An unknown error occurred. Please contact a developer
 
-#: resources/public/include/chat.js:2001:52
+#: resources/public/include/chat.js
 New\ Name\:\ =New Name\: 
 
-#: resources/public/include/chat.js:2011:27
+#: resources/public/include/chat.js
 Enter\ the\ new\ name\ for\ the\ user\ below.\ Please\ note\ that\ if\ you\\'re\ trying\ to\ change\ the\ caps,\ you\\'ll\ have\ to\ rename\ to\ something\ else\ first.=Enter the new name for the user below. Please note that if you\\'re trying to change the caps, you\\'ll have to rename to something else first.
 
-#: resources/public/include/chat.js:2049:54
+#: resources/public/include/chat.js
 Force\ Rename=Force Rename
 
-#: resources/public/include/chat.js:2088:118
+#: resources/public/include/chat.js
 You\ cannot\ use\ chat\ while\ canvas\ banned.=You cannot use chat while canvas banned.
 
-#: resources/public/include/lookup.js:21:32
+#: resources/public/include/lookup.js
 Sending...=Sending...
 
-#: resources/public/include/lookup.js:28:32
+#: resources/public/include/lookup.js
 You\ must\ specify\ the\ details.=You must specify the details.
 
-#: resources/public/include/lookup.js:33:27
+#: resources/public/include/lookup.js
 additional\ information\:=additional information\:
 
-#: resources/public/include/lookup.js:49:50
+#: resources/public/include/lookup.js
 Report\ Pixel=Report Pixel
 
-#: resources/public/include/lookup.js:52:32
+#: resources/public/include/lookup.js
 Rule\ \#1\:\ Hateful/derogatory\ speech\ or\ symbols=Rule \#1\: Hateful/derogatory speech or symbols
 
-#: resources/public/include/lookup.js:53:32
+#: resources/public/include/lookup.js
 Rule\ \#2\:\ Nudity,\ genitalia,\ or\ non-PG-13\ content=Rule \#2\: Nudity, genitalia, or non-PG-13 content
 
-#: resources/public/include/lookup.js:54:32
+#: resources/public/include/lookup.js
 Rule\ \#3\:\ Multi-account=Rule \#3\: Multi-account
 
-#: resources/public/include/lookup.js:55:32
+#: resources/public/include/lookup.js
 Rule\ \#4\:\ Botting=Rule \#4\: Botting
 
-#: resources/public/include/lookup.js:56:52
+#: resources/public/include/lookup.js
 Other\ (specify\ below)=Other (specify below)
 
-#: resources/public/include/lookup.js:168:62
+#: resources/public/include/lookup.js
 Hide\ sensitive\ information=Hide sensitive information
 
-#: resources/public/include/lookup.js:207:120
+#: resources/public/include/lookup.js
 An\ error\ occurred,\ either\ you\ aren't\ logged\ in\ or\ you\ may\ be\ attempting\ to\ look\ up\ users\ too\ fast.\ Please\ try\ again\ in\ 60\ seconds=An error occurred, either you aren't logged in or you may be attempting to look up users too fast. Please try again in 60 seconds
 
-#: resources/public/include/lookup.js:218:21
+#: resources/public/include/lookup.js
 Coords=Coords
 
-#: resources/public/include/lookup.js:223:21
-#: resources/public/admin/admin.js:189:16
+#: resources/public/include/lookup.js resources/public/admin/admin.js
 Username=Username
 
-#: resources/public/include/lookup.js:229:28
+#: resources/public/include/lookup.js
 View\ Profile=View Profile
 
-#: resources/public/include/lookup.js:239:21
+#: resources/public/include/lookup.js
 Origin=Origin
 
-#: resources/public/include/lookup.js:243:28
+#: resources/public/include/lookup.js
 Part\ of\ a\ nuke=Part of a nuke
 
-#: resources/public/include/lookup.js:245:28
+#: resources/public/include/lookup.js
 Placed\ by\ a\ staff\ member\ using\ placement\ overrides=Placed by a staff member using placement overrides
 
-#: resources/public/include/lookup.js:252:21
+#: resources/public/include/lookup.js
 Time=Time
 
-#: resources/public/include/lookup.js:263:36
+#: resources/public/include/lookup.js
 just\ now=just now
 
-#: resources/public/include/lookup.js:271:36
+#: resources/public/include/lookup.js
 ${hoursStr}\:${minuteStr}\:${secsStr}\ ago=${hoursStr}\:${minuteStr}\:${secsStr} ago
 
-#: resources/public/include/lookup.js:284:21
+#: resources/public/include/lookup.js
 Discord=Discord
 
-#: resources/public/include/notifications.js:60:58
+#: resources/public/include/notifications.js
 Posted\ by\ ${notification.who}=Posted by ${notification.who}
 
-#: resources/public/include/notifications.js:63:111
+#: resources/public/include/notifications.js
 Expires\ ${expiry}=Expires ${expiry}
 
-#: resources/public/include/template.js:440:50
+#: resources/public/include/template.js
 There\ was\ an\ error\ getting\ the\ image=There was an error getting the image
 
-#: resources/public/include/timer.js:42:53
+#: resources/public/include/timer.js
 Your\ next\ pixel\ will\ be\ available\ in\ ${delay}\ seconds\!=Your next pixel will be available in ${delay} seconds\!
 
-#: resources/public/include/timer.js:87:61
+#: resources/public/include/timer.js
 Your\ next\ pixel\ has\ been\ available\ for\ ${alertDelay}\ seconds\!=Your next pixel has been available for ${alertDelay} seconds\!
 
-#: resources/public/include/timer.js:101:59
+#: resources/public/include/timer.js
 Your\ next\ pixel\ is\ available\!=Your next pixel is available\!
 
 #. theme name
-#: resources/public/include/uiHelper.js:48:19
+#: resources/public/include/uiHelper.js
 Dark=Dark
 
 #. theme name
-#: resources/public/include/uiHelper.js:54:19
+#: resources/public/include/uiHelper.js
 Darker=Darker
 
 #. theme name
-#: resources/public/include/uiHelper.js:60:19
+#: resources/public/include/uiHelper.js
 Blue=Blue
 
 #. theme name
-#: resources/public/include/uiHelper.js:66:19
+#: resources/public/include/uiHelper.js
 Purple=Purple
 
 #. theme name
-#: resources/public/include/uiHelper.js:72:19
+#: resources/public/include/uiHelper.js
 Green=Green
 
 #. theme name
-#: resources/public/include/uiHelper.js:78:19
+#: resources/public/include/uiHelper.js
 Matte=Matte
 
 #. theme name
-#: resources/public/include/uiHelper.js:84:19
+#: resources/public/include/uiHelper.js
 Terminal=Terminal
 
 #. theme name
-#: resources/public/include/uiHelper.js:90:19
+#: resources/public/include/uiHelper.js
 Red=Red
 
-#: resources/public/include/uiHelper.js:467:30
+#: resources/public/include/uiHelper.js
 Discord\ name\ updated\ successfully=Discord name updated successfully
 
-#: resources/public/include/uiHelper.js:474:32
+#: resources/public/include/uiHelper.js
 Couldn\\'t\ change\ discord\ name\:\ =Couldn\\'t change discord name\: 
 
-#: resources/public/include/user.js:81:28
+#: resources/public/include/user.js
 Sign\ in\ with...=Sign in with...
 
-#: resources/public/include/user.js:94:149
+#: resources/public/include/user.js
 New\ Accounts\ Disabled=New Accounts Disabled
 
-#: resources/public/include/user.js:167:52
+#: resources/public/include/user.js
 Sign\ Out=Sign Out
 
-#: resources/public/include/user.js:169:27
+#: resources/public/include/user.js
 Are\ you\ sure\ you\ want\ to\ sign\ out?=Are you sure you want to sign out?
 
-#: resources/public/include/user.js:223:39
+#: resources/public/include/user.js
 You\ are\ permanently\ banned.=You are permanently banned.
 
-#: resources/public/include/user.js:227:39
+#: resources/public/include/user.js
 You\ are\ temporarily\ banned\ and\ will\ not\ be\ allowed\ to\ place\ until\ ${timestamp}=You are temporarily banned and will not be allowed to place until ${timestamp}
 
-#: resources/public/include/user.js:255:27
+#: resources/public/include/user.js
 If\ you\ think\ this\ was\ an\ error,\ please\ contact\ us\ using\ one\ of\ the\ links\ in\ the\ info\ tab.=If you think this was an error, please contact us using one of the links in the info tab.
 
-#: resources/public/include/user.js:256:27
+#: resources/public/include/user.js
 Ban\ reason\:=Ban reason\:
 
-#: resources/public/include/user.js:260:28
-#: resources/public/admin/admin.js:203:16
+#: resources/public/include/user.js resources/public/admin/admin.js
 Banned=Banned
 
-#: resources/public/include/user.js:330:23
+#: resources/public/include/user.js
 Staff\ have\ required\ you\ to\ change\ your\ username,\ this\ usually\ means\ your\ name\ breaks\ one\ of\ our\ rules.=Staff have required you to change your username, this usually means your name breaks one of our rules.
 
-#: resources/public/include/user.js:331:23
+#: resources/public/include/user.js
 If\ you\ disagree,\ please\ contact\ us\ on\ Discord\ (link\ in\ the\ info\ panel).=If you disagree, please contact us on Discord (link in the info panel).
 
-#: resources/public/include/user.js:332:27
+#: resources/public/include/user.js
 New\ Username\:=New Username\:
 
-#: resources/public/include/user.js:345:89
+#: resources/public/include/user.js
 Not\ now=Not now
 
-#: resources/public/include/user.js:346:86
+#: resources/public/include/user.js
 Change=Change
 
-#: resources/public/include/user.js:350:50
-#: resources/public/admin/admin.js:201:16
+#: resources/public/include/user.js resources/public/admin/admin.js
 Rename\ Requested=Rename Requested
 
-#: resources/public/admin/admin.js:101:38
+#: resources/public/admin/admin.js
 Something\ went\ wrong\!\ Perhaps\ insufficient\ permissions?=Something went wrong\! Perhaps insufficient permissions?
 
-#: resources/public/admin/admin.js:106:45
+#: resources/public/admin/admin.js
 Shadowban\ user=Shadowban user
 
-#: resources/public/admin/admin.js:106:67
+#: resources/public/admin/admin.js
 Shadowbanned\ user=Shadowbanned user
 
-#: resources/public/admin/admin.js:109:45
+#: resources/public/admin/admin.js
 Permaban\ user=Permaban user
 
-#: resources/public/admin/admin.js:109:66
+#: resources/public/admin/admin.js
 Permabanned\ user=Permabanned user
 
-#: resources/public/admin/admin.js:112:45
+#: resources/public/admin/admin.js
 Ban\ user=Ban user
 
-#: resources/public/admin/admin.js:112:61
+#: resources/public/admin/admin.js
 Banned\ user=Banned user
 
-#: resources/public/admin/admin.js:126:36
+#: resources/public/admin/admin.js
 Unbanned\ user\ ${username}=Unbanned user ${username}
 
 #. Context: ban type
-#: resources/public/admin/admin.js:179:27
+#: resources/public/admin/admin.js
 shadow=shadow
 
-#: resources/public/admin/admin.js:180:29
-#: resources/public/admin/admin.js:183:29
+#: resources/public/admin/admin.js
 never=never
 
-#: resources/public/admin/admin.js:182:27
+#: resources/public/admin/admin.js
 permanent=permanent
 
-#: resources/public/admin/admin.js:187:51
+#: resources/public/admin/admin.js
 Yes\ (permanent)=Yes (permanent)
 
-#: resources/public/admin/admin.js:194:16
-#: resources/public/admin/admin.js:454:21
+#: resources/public/admin/admin.js
 Logins=Logins
 
-#: resources/public/admin/admin.js:200:16
+#: resources/public/admin/admin.js
 All\ Time\ Pixels=All Time Pixels
 
-#: resources/public/admin/admin.js:202:16
+#: resources/public/admin/admin.js
 Discord\ Name=Discord Name
 
-#: resources/public/admin/admin.js:204:16
+#: resources/public/admin/admin.js
 Chatbanned=Chatbanned
 
-#: resources/public/admin/admin.js:207:27
+#: resources/public/admin/admin.js
 Ban\ Reason=Ban Reason
 
-#: resources/public/admin/admin.js:208:27
+#: resources/public/admin/admin.js
 Ban\ Expiracy=Ban Expiracy
 
-#: resources/public/admin/admin.js:211:27
+#: resources/public/admin/admin.js
 Chatban\ Reason=Chatban Reason
 
-#: resources/public/admin/admin.js:211:102
+#: resources/public/admin/admin.js
 (canvas\ ban)=(canvas ban)
 
-#: resources/public/admin/admin.js:213:97
+#: resources/public/admin/admin.js
 when\ canvas\ ban\ ends=when canvas ban ends
 
-#: resources/public/admin/admin.js:214:29
+#: resources/public/admin/admin.js
 Chatban\ Expires=Chatban Expires
 
 #. Admin check. Example: type = 'username', arg = 'pxlsuser94'
-#: resources/public/admin/admin.js:316:36
+#: resources/public/admin/admin.js
 ${type}\ ${arg}\ not\ found.=${type} ${arg} not found.
 
-#: resources/public/admin/admin.js:322:50
+#: resources/public/admin/admin.js
 Unban\ Reason\:=Unban Reason\:
 
-#: resources/public/admin/admin.js:327:25
+#: resources/public/admin/admin.js
 Unbanning\ ${username}=Unbanning ${username}
 
-#: resources/public/admin/admin.js:449:20
+#: resources/public/admin/admin.js
 profile=profile
 
-#: resources/public/admin/admin.js:473:21
+#: resources/public/admin/admin.js
 User\ Agent=User Agent
 
-#: resources/public/admin/admin.js:478:21
+#: resources/public/admin/admin.js
 Send\ Alert=Send Alert
 
-#: resources/public/admin/admin.js:483:21
+#: resources/public/admin/admin.js
 Mod\ Actions=Mod Actions

--- a/resources/Localization_fr.properties
+++ b/resources/Localization_fr.properties
@@ -1,1710 +1,1641 @@
-!=Project-Id-Version\: Pxls\nPOT-Creation-Date\: 2021-11-23T21\:32\:45.968Z\nLanguage\: \nContent-Type\: text/plain; charset\=UTF-8\n
+!=Project-Id-Version\: Pxls\nPOT-Creation-Date\: 2021-12-03T07\:36\:36.932Z\nLanguage\: \nContent-Type\: text/plain; charset\=UTF-8\n
 
 #. Site description
-#: resources/public/pebble_templates/index.html:8:42
+#: resources/public/pebble_templates/index.html
 Place\ pixels\ with\ people\ to\ create\ art=Place des pixels avec d'autres pour cr\u00e9er des \u0153uvres d'art
 
-#: resources/public/pebble_templates/index.html:56:27
+#: resources/public/pebble_templates/index.html
 Lost\ connection\ to\ server,\ reconnecting...=Connexion au serveur perdue, reconnexion en cours...
 
-#: resources/public/pebble_templates/index.html:71:76
+#: resources/public/pebble_templates/index.html
 Loading\ Heatmap\ (press\ <kbd>H</kbd>\ to\ cancel)=Chargement de la carte d'activit\u00e9 (appuie sur <kbd>H</kbd> pour annuler)
 
-#: resources/public/pebble_templates/index.html:72:78
+#: resources/public/pebble_templates/index.html
 Loading\ Virginmap\ (press\ <kbd>X</kbd>\ to\ cancel)=Chargement de la virginmap (appuie sur <kbd>X</kbd> pour annuler)
 
-#: resources/public/pebble_templates/index.html:80:67
+#: resources/public/pebble_templates/index.html
 Logout=D\u00e9connexion
 
 #. Canvas pixel count
-#: resources/public/pebble_templates/index.html:86:38
+#: resources/public/pebble_templates/index.html
 Canvas\:=Canvas \:
 
 #. Canvas pixel count
 #. All time pixel count
-#: resources/public/pebble_templates/index.html:86:118
-#: resources/public/pebble_templates/index.html:88:120
-#: resources/public/pebble_templates/index.html:100:51
-#: resources/public/pebble_templates/index.html:126:123
+#: resources/public/pebble_templates/index.html
 N/A=N/A
 
 #. All time pixel count
-#: resources/public/pebble_templates/index.html:88:38
+#: resources/public/pebble_templates/index.html
 All\ Time\:=Total \:
 
-#: resources/public/pebble_templates/index.html:93:48
+#: resources/public/pebble_templates/index.html
 Loading\ online\ user\ count&hellip;=Chargement du nombre d'utilisateurs en ligne&hellip;
 
-#: resources/public/pebble_templates/index.html:101:30
-#: resources/public/include/lookup.js:276:21
-#: resources/public/admin/admin.js:199:16
+#: resources/public/pebble_templates/index.html
+#: resources/public/include/lookup.js resources/public/admin/admin.js
 Pixels=Pixels
 
-#: resources/public/pebble_templates/index.html:112:54
+#: resources/public/pebble_templates/index.html
 Undo=Annuler
 
-#: resources/public/pebble_templates/index.html:114:20
+#: resources/public/pebble_templates/index.html
 You\ are\ not\ signed\ in.&nbsp;<a\ href\="\#">Sign\ in\ with...</a>=Tu n'es pas connect\u00e9.&nbsp;<a href\="\#">Se connecter avec...</a>
 
-#: resources/public/pebble_templates/index.html:124:28
+#: resources/public/pebble_templates/index.html
 Loading...=Chargement...
 
-#: resources/public/pebble_templates/index.html:132:14
-#: resources/public/pebble_templates/index.html:142:67
+#: resources/public/pebble_templates/index.html
 Sign\ up=S'inscrire
 
-#: resources/public/pebble_templates/index.html:133:14
+#: resources/public/pebble_templates/index.html
 Pick\ a\ username=Choisis ton pseudo
 
-#: resources/public/pebble_templates/index.html:136:43
+#: resources/public/pebble_templates/index.html
 Username\:=Pseudo \:
 
-#: resources/public/pebble_templates/index.html:154:65
-#: resources/public/pebble_templates/profile.html:56:96
+#: resources/public/pebble_templates/index.html
+#: resources/public/pebble_templates/profile.html
 Info=Info
 
-#: resources/public/pebble_templates/index.html:168:66
-#: resources/public/pebble_templates/index.html:206:66
-#: resources/public/pebble_templates/index.html:761:66
-#: resources/public/pebble_templates/index.html:774:66
+#: resources/public/pebble_templates/index.html
 Close\ Panel=Fermer le panneau
 
-#: resources/public/pebble_templates/index.html:170:61
+#: resources/public/pebble_templates/index.html
 Chat=Chat
 
-#: resources/public/pebble_templates/index.html:172:45
+#: resources/public/pebble_templates/index.html
 Pings=Mentions
 
-#: resources/public/pebble_templates/index.html:173:45
-#: resources/public/pebble_templates/index.html:209:58
+#: resources/public/pebble_templates/index.html
 Settings=Param\u00e8tres
 
-#: resources/public/pebble_templates/index.html:186:30
+#: resources/public/pebble_templates/index.html
 Jump\ To\ Bottom=Sauter \u00e0 la fin
 
 #. Open emoji picker
-#: resources/public/pebble_templates/index.html:194:49
+#: resources/public/pebble_templates/index.html
 Emoji=Emoji
 
-#: resources/public/pebble_templates/index.html:214:73
+#: resources/public/pebble_templates/index.html
 Search=Recherche
 
-#: resources/public/pebble_templates/index.html:215:56
+#: resources/public/pebble_templates/index.html
 keybinds;keys;keyboard;hotkeys=touches;contr\u00f4les;clavier;raccourcis clavier
 
-#: resources/public/pebble_templates/index.html:217:24
+#: resources/public/pebble_templates/index.html
 Keybinds=Contr\u00f4les
 
-#: resources/public/pebble_templates/index.html:220:44
+#: resources/public/pebble_templates/index.html
 general=g\u00e9n\u00e9ral
 
 #. General settings
-#: resources/public/pebble_templates/index.html:222:28
-#: resources/public/pebble_templates/index.html:664:28
+#: resources/public/pebble_templates/index.html
 General=G\u00e9n\u00e9ral
 
-#: resources/public/pebble_templates/index.html:223:42
+#: resources/public/pebble_templates/index.html
 move;moving;panning;drag=bouger;d\u00e9placement
 
-#: resources/public/pebble_templates/index.html:223:102
+#: resources/public/pebble_templates/index.html
 Mouse/arrows/wasd\ to\ pan=Souris/fl\u00e8ches/wasd pour d\u00e9placer le canvas
 
-#: resources/public/pebble_templates/index.html:224:42
+#: resources/public/pebble_templates/index.html
 mousewheel;zooming=roulette;molette;zoom
 
-#: resources/public/pebble_templates/index.html:224:96
+#: resources/public/pebble_templates/index.html
 Scroll/pinch\ to\ zoom=Scroll/pincer pour zoomer
 
-#: resources/public/pebble_templates/index.html:225:42
+#: resources/public/pebble_templates/index.html
 scroll;zooming=scroll;zoom
 
-#: resources/public/pebble_templates/index.html:225:92
+#: resources/public/pebble_templates/index.html
 <kbd>+</kbd>/<kbd>-</kbd>\ or\ <kbd>Q</kbd>/<kbd>E</kbd>\ to\ zoom=<kbd>+</kbd>/<kbd>-</kbd> ou <kbd>Q</kbd>/<kbd>E</kbd> pour zoomer
 
-#: resources/public/pebble_templates/index.html:226:42
+#: resources/public/pebble_templates/index.html
 lookups=inspections
 
-#: resources/public/pebble_templates/index.html:226:85
+#: resources/public/pebble_templates/index.html
 <kbd>Shift</kbd>\ +\ Click/Hold\ touch\ to\ lookup\ pixel=<kbd>Shift</kbd> + Click/Garder appuy\u00e9 pour inspecter un pixel
 
-#: resources/public/pebble_templates/index.html:227:42
-#: resources/public/pebble_templates/index.html:489:44
+#: resources/public/pebble_templates/index.html
 overlays;alignment;grid\ hidden;grid\ shown;hide\ grid;show\ grid=calques;alignement;grille cach\u00e9e;grille;cacher la grille;afficher la grille
 
-#: resources/public/pebble_templates/index.html:227:139
+#: resources/public/pebble_templates/index.html
 <kbd>G</kbd>\ to\ toggle\ grid=<kbd>G</kbd> pour activer/d\u00e9sactiver la grille
 
-#: resources/public/pebble_templates/index.html:228:42
+#: resources/public/pebble_templates/index.html
 close;information\ shown;information\ hidden;info\ shown;info\ hidden;hide\ information;show\ information=fermer;information;information cach\u00e9e;info;info cach\u00e9e;ouvrir l'information;cacher l'information;afficher l'information
 
-#: resources/public/pebble_templates/index.html:228:177
+#: resources/public/pebble_templates/index.html
 <kbd>I</kbd>\ to\ open\ info=<kbd>I</kbd> pour ouvrir l'info
 
-#: resources/public/pebble_templates/index.html:229:42
+#: resources/public/pebble_templates/index.html
 close;settings\ hidden;settings\ shown;hide\ settings;show\ settings=fermer;param\u00e8tres cach\u00e9s;cacher les param\u00e8tres;ouvrir les param\u00e8tres;afficher les param\u00e8tres
 
-#: resources/public/pebble_templates/index.html:229:142
+#: resources/public/pebble_templates/index.html
 <kbd>T</kbd>\ to\ open\ settings=<kbd>T</kbd> pour ouvrir les param\u00e8tres
 
-#: resources/public/pebble_templates/index.html:230:42
+#: resources/public/pebble_templates/index.html
 close;chat\ hidden;chat\ shown;hide\ chat;show\ chat=fermer;chat cach\u00e9;chat ouvert;cacher le chat;ouvrir le chat;afficher le chat
 
-#: resources/public/pebble_templates/index.html:230:126
+#: resources/public/pebble_templates/index.html
 <kbd>B</kbd>\ to\ open\ chat=<kbd>B</kbd> pour ouvrir le chat
 
-#: resources/public/pebble_templates/index.html:231:42
+#: resources/public/pebble_templates/index.html
 canvas\ locked;move;moving;zoom;zooming=canvas verrouill\u00e9;bouger;zoom
 
-#: resources/public/pebble_templates/index.html:231:116
+#: resources/public/pebble_templates/index.html
 <kbd>L</kbd>\ to\ toggle\ locking\ panning\ of\ the\ canvas=<kbd>L</kbd> pour verrouiller/d\u00e9verrouiller le d\u00e9placement sur le canvas
 
-#: resources/public/pebble_templates/index.html:232:42
+#: resources/public/pebble_templates/index.html
 take\ screenshot;image;download;picture;canvas=capture d'\u00e9cran;image;t\u00e9l\u00e9charger;canvas
 
-#: resources/public/pebble_templates/index.html:232:123
+#: resources/public/pebble_templates/index.html
 <kbd>P</kbd>\ to\ take\ a\ snapshot=<kbd>P</kbd> pour t\u00e9l\u00e9charger une image du canvas
 
-#: resources/public/pebble_templates/index.html:233:42
-#: resources/public/pebble_templates/index.html:443:44
+#: resources/public/pebble_templates/index.html
 overlays;user\ activity;pixels\ placed\ pixels;heatmap\ hidden;heatmap\ shown;hide\ heatmap;show\ heatmap=calques;activit\u00e9;pixels plac\u00e9s;heatmap;carte d'activit\u00e9;afficher carte d'activit\u00e9;cacher carte d'activit\u00e9
 
-#: resources/public/pebble_templates/index.html:233:176
+#: resources/public/pebble_templates/index.html
 <kbd>H</kbd>\ to\ toggle\ heatmap=<kbd>H</kbd> pour activer/d\u00e9sactiver la carte d'activit\u00e9
 
-#: resources/public/pebble_templates/index.html:234:42
-#: resources/public/pebble_templates/index.html:463:44
+#: resources/public/pebble_templates/index.html
 overlays;user\ activity;pixels\ unplaced\ pixels;virginmap\ hidden;virginmap\ shown;hide\ virginmap;show\ virginmap=calques;activit\u00e9;pixels non touch\u00e9s;virginmap;afficher virginmap;cacher virginmap
 
-#: resources/public/pebble_templates/index.html:234:186
+#: resources/public/pebble_templates/index.html
 <kbd>X</kbd>\ to\ toggle\ virginmap=<kbd>X</kbd> pour activer/d\u00e9sactiver la virginmap
 
-#: resources/public/pebble_templates/index.html:235:42
+#: resources/public/pebble_templates/index.html
 overlays;user\ activity;pixels\ placed\ pixels;wipe;clean;=calques;activit\u00e9;pixels plac\u00e9s;r\u00e9initialiser;effacer
 
-#: resources/public/pebble_templates/index.html:235:133
+#: resources/public/pebble_templates/index.html
 <kbd>O</kbd>\ to\ clear\ heatmap=<kbd>O</kbd> pour r\u00e9initialiser la carte d'activit\u00e9
 
-#: resources/public/pebble_templates/index.html:236:42
+#: resources/public/pebble_templates/index.html
 overlays;user\ activity;pixels\ unplaced\ pixels;wipe;clean;=calques;activit\u00e9;pixels plac\u00e9s;r\u00e9initialiser;effacer
 
-#: resources/public/pebble_templates/index.html:236:135
+#: resources/public/pebble_templates/index.html
 <kbd>U</kbd>\ to\ clear\ virginmap=<kbd>U</kbd> pour r\u00e9initialiser la virginmap
 
-#: resources/public/pebble_templates/index.html:237:42
+#: resources/public/pebble_templates/index.html
 next\ color;previous\ color=couleur pr\u00e9c\u00e9dente;couleur suivante
 
-#: resources/public/pebble_templates/index.html:237:103
+#: resources/public/pebble_templates/index.html
 <kbd>J</kbd>/<kbd>K</kbd>\ to\ cycle\ through\ palette\ colors=<kbd>J</kbd>/<kbd>K</kbd> pour d\u00e9filer parmi les couleurs de la palette
 
-#: resources/public/pebble_templates/index.html:238:42
+#: resources/public/pebble_templates/index.html
 current\ coordinates;coords=coordonn\u00e9es
 
-#: resources/public/pebble_templates/index.html:238:104
+#: resources/public/pebble_templates/index.html
 <kbd>C</kbd>\ to\ copy\ link\ of\ moused-over\ coordinates=<kbd>C</kbd> pour copier le lien des coordonn\u00e9es survol\u00e9es par le curseur
 
-#: resources/public/pebble_templates/index.html:239:42
+#: resources/public/pebble_templates/index.html
 cancel\ selection=annuler la s\u00e9lection
 
-#: resources/public/pebble_templates/index.html:239:94
+#: resources/public/pebble_templates/index.html
 <kbd>ESC</kbd>\ to\ deselect\ current\ pixel=<kbd>ESC</kbd> pour d\u00e9selectionner le pixel actif
 
-#: resources/public/pebble_templates/index.html:240:42
+#: resources/public/pebble_templates/index.html
 recenter;jump;center\ on\ template;guides;focus=recentrer;centrer sur le mod\u00e8le;guide;focus
 
-#: resources/public/pebble_templates/index.html:240:123
+#: resources/public/pebble_templates/index.html
 <kbd>R</kbd>\ to\ center\ the\ board\ on\ the\ current\ template=<kbd>R</kbd> pour centrer l'\u00e9cran sur le mod\u00e8le actif
 
-#: resources/public/pebble_templates/index.html:243:44
+#: resources/public/pebble_templates/index.html
 templates;guides=mod\u00e8le;templates;guide
 
-#: resources/public/pebble_templates/index.html:244:28
-#: resources/public/pebble_templates/index.html:579:24
+#: resources/public/pebble_templates/index.html
 Template=Mod\u00e8le
 
-#: resources/public/pebble_templates/index.html:245:42
-#: resources/public/pebble_templates/index.html:246:42
+#: resources/public/pebble_templates/index.html
 transparency=Transparence
 
-#: resources/public/pebble_templates/index.html:245:90
+#: resources/public/pebble_templates/index.html
 <kbd>Page\ Up</kbd>\ to\ increase\ opacity=<kbd>Page Up</kbd> pour augmenter l'opacit\u00e9
 
-#: resources/public/pebble_templates/index.html:246:90
+#: resources/public/pebble_templates/index.html
 <kbd>Page\ Down</kbd>\ to\ decrease\ opacity=<kbd>Page Down</kbd> pour diminuer l'opacit\u00e9
 
-#: resources/public/pebble_templates/index.html:247:42
+#: resources/public/pebble_templates/index.html
 hidden;shown;hide;show=cach\u00e9;affich\u00e9;cacher;afficher
 
-#: resources/public/pebble_templates/index.html:247:100
+#: resources/public/pebble_templates/index.html
 <kbd>V</kbd>\ to\ toggle\ visibility=<kbd>V</kbd> pour activer/d\u00e9sactiver la visibilit\u00e9 d'un mod\u00e8le
 
-#: resources/public/pebble_templates/index.html:252:24
+#: resources/public/pebble_templates/index.html
 Note\:\ These\ values\ are\ based\ on\ QWERTY\ keyboards.\ For\ other\ layouts,\ use\ the\ keys\ corresponding\ to\ the\ same\ position\ on\ a\ QWERTY\ keyboard.=Note \: Ces touches sont bas\u00e9es sur les claviers QWERTY. Pour d'autres claviers, utilise les touches correspondantes aux positions sur un clavier QWERTY.
 
-#: resources/public/pebble_templates/index.html:256:36
+#: resources/public/pebble_templates/index.html
 ui;interface=interface utilisateur;interface
 
-#: resources/public/pebble_templates/index.html:258:24
+#: resources/public/pebble_templates/index.html
 UI\ Settings=Param\u00e8tres de l'interface utilisateur
 
-#: resources/public/pebble_templates/index.html:262:44
+#: resources/public/pebble_templates/index.html
 themes;look;stylesheets;visuals=th\u00e8mes;look;graphiques;visuels
 
-#: resources/public/pebble_templates/index.html:264:57
+#: resources/public/pebble_templates/index.html
 Theme\:=Th\u00e8me \:
 
-#: resources/public/pebble_templates/index.html:266:64
+#: resources/public/pebble_templates/index.html
 Default=Par d\u00e9faut
 
-#: resources/public/pebble_templates/index.html:270:44
+#: resources/public/pebble_templates/index.html
 hide\ reticule;hide\ reticle;reticule\ shown\ reticle\ shown;reticule\ hidden;reticle\ hidden=cacher r\u00e9ticule;r\u00e9ticule visible;afficher r\u00e9ticule;cacher r\u00e9ticule
 
-#: resources/public/pebble_templates/index.html:273:57
+#: resources/public/pebble_templates/index.html
 Show\ reticule=Afficher le r\u00e9ticule
 
-#: resources/public/pebble_templates/index.html:276:44
+#: resources/public/pebble_templates/index.html
 hide\ cursor;cursor\ shown;cursor\ hidden=cacher curseur;curseur affich\u00e9;curseur cach\u00e9
 
-#: resources/public/pebble_templates/index.html:279:57
+#: resources/public/pebble_templates/index.html
 Show\ cursor=Afficher le curseur
 
-#: resources/public/pebble_templates/index.html:282:44
+#: resources/public/pebble_templates/index.html
 darkness\ filter=filtre
 
-#: resources/public/pebble_templates/index.html:285:57
+#: resources/public/pebble_templates/index.html
 Enable\ color\ brightness=Activer le param\u00e8tre de luminosit\u00e9 des couleurs
 
-#: resources/public/pebble_templates/index.html:288:76
+#: resources/public/pebble_templates/index.html
 Warning\:\ Known\ to\ cause\ fuzziness\ in\ Chrome\ on\ some\ Mac/Linux\ installs=Attention\: peut causer des probl\u00e8mes de nettet\u00e9 dans Chrome sur certaines versions de Mac/Linux
 
-#: resources/public/pebble_templates/index.html:291:57
+#: resources/public/pebble_templates/index.html
 Color\ brightness\:=Luminosit\u00e9 des couleurs \:
 
-#: resources/public/pebble_templates/index.html:295:44
+#: resources/public/pebble_templates/index.html
 keep\ current\ selected;keep\ curent\ color;place=garder la couleur s\u00e9lectionn\u00e9e;placer
 
-#: resources/public/pebble_templates/index.html:298:57
+#: resources/public/pebble_templates/index.html
 Deselect\ color\ after\ placing=D\u00e9selectionner la couleur apr\u00e8s l'avoir plac\u00e9e
 
-#: resources/public/pebble_templates/index.html:301:44
+#: resources/public/pebble_templates/index.html
 mousewheel;palette\ scrolling=molette de souris;roulette de souris;scroller dans la palette
 
-#: resources/public/pebble_templates/index.html:304:57
+#: resources/public/pebble_templates/index.html
 Enable\ scrolling\ on\ the\ palette\ to\ switch\ colors=Changer de couleur en scrollant dans la palette
 
-#: resources/public/pebble_templates/index.html:306:68
+#: resources/public/pebble_templates/index.html
 reverse\ scrolling;mousewheel;palette\ scrolling;enable\ scrolling\ on\ the\ palette\ to\ switch\ colors=inverser le scrolling;molette de souris;roulette de souris
 
-#: resources/public/pebble_templates/index.html:309:61
+#: resources/public/pebble_templates/index.html
 Invert\ scroll\ direction=Inverser la direction de scrolling
 
-#: resources/public/pebble_templates/index.html:313:44
+#: resources/public/pebble_templates/index.html
 indexed\ colors;palette\ indicies=index des couleurs;indices des couleurs;num\u00e9ros des couleurs
 
-#: resources/public/pebble_templates/index.html:316:57
+#: resources/public/pebble_templates/index.html
 Add\ numbers\ to\ palette\ entries=Ajouter des num\u00e9ros aux couleurs de la palette
 
-#: resources/public/pebble_templates/index.html:319:44
+#: resources/public/pebble_templates/index.html
 scrollbar;palette\ scrolling=barre de d\u00e9filement;scrolling
 
-#: resources/public/pebble_templates/index.html:322:57
+#: resources/public/pebble_templates/index.html
 Enable\ thin\ scrollbar=Activer la bare de d\u00e9filement fine
 
-#: resources/public/pebble_templates/index.html:325:44
+#: resources/public/pebble_templates/index.html
 scrollbar;palette\ scrolling;palette\ stack=barre de d\u00e9filement;palette
 
-#: resources/public/pebble_templates/index.html:328:57
+#: resources/public/pebble_templates/index.html
 Enable\ palette\ stacking=Empiler la palette
 
-#: resources/public/pebble_templates/index.html:331:44
+#: resources/public/pebble_templates/index.html
 floating\ bubble\ location=emplacement de la bulle flottante
 
-#: resources/public/pebble_templates/index.html:333:57
+#: resources/public/pebble_templates/index.html
 Bubble\ position\:=Emplacement de la bulle d'information \:
 
-#: resources/public/pebble_templates/index.html:335:61
+#: resources/public/pebble_templates/index.html
 Top\ left=Coin sup\u00e9rieur gauche
 
-#: resources/public/pebble_templates/index.html:336:62
+#: resources/public/pebble_templates/index.html
 Top\ right=Coin sup\u00e9rieur droit
 
-#: resources/public/pebble_templates/index.html:337:73
+#: resources/public/pebble_templates/index.html
 Bottom\ left=Coin inf\u00e9rieur gauche
 
-#: resources/public/pebble_templates/index.html:338:65
+#: resources/public/pebble_templates/index.html
 Bottom\ right=Coin inf\u00e9rieur droit
 
-#: resources/public/pebble_templates/index.html:342:44
+#: resources/public/pebble_templates/index.html
 broken;offset\ workaround=bug;d\u00e9calage
 
-#: resources/public/pebble_templates/index.html:345:57
+#: resources/public/pebble_templates/index.html
 Attempt\ to\ fix\ canvas\ displacement\ bug\ in\ Chrome\ 78+=Essayer de r\u00e9gler le probl\u00e8me de d\u00e9calage du canvas sous Chrome 78+
 
-#: resources/public/pebble_templates/index.html:351:36
+#: resources/public/pebble_templates/index.html
 chat;message;ping\ sound=chat;message;bruit de mention;bruit de notification
 
-#: resources/public/pebble_templates/index.html:353:24
+#: resources/public/pebble_templates/index.html
 Chat\ Settings=Param\u00e8tres du chat
 
-#: resources/public/pebble_templates/index.html:356:44
+#: resources/public/pebble_templates/index.html
 username;color;colour=pseudo;couleur
 
-#: resources/public/pebble_templates/index.html:359:57
+#: resources/public/pebble_templates/index.html
 Username\ Color\:=Couleur du nom d'utilisateur \:
 
-#: resources/public/pebble_templates/index.html:365:44
+#: resources/public/pebble_templates/index.html
 chat\ message;chat\ ui=message du chat;visuel du chat
 
-#: resources/public/pebble_templates/index.html:366:28
+#: resources/public/pebble_templates/index.html
 Interface=Interface
 
-#: resources/public/pebble_templates/index.html:367:44
+#: resources/public/pebble_templates/index.html
 chat\ size;chat\ font=taille du chat;police du chat
 
-#: resources/public/pebble_templates/index.html:369:57
+#: resources/public/pebble_templates/index.html
 Font\ Size\:=Taille de caract\u00e8re \:
 
-#: resources/public/pebble_templates/index.html:373:44
+#: resources/public/pebble_templates/index.html
 time;timestamps=temps;date;horodatage
 
-#: resources/public/pebble_templates/index.html:376:57
+#: resources/public/pebble_templates/index.html
 24\ Hour\ Timestamps=Format de l'horodatage par 24h
 
-#: resources/public/pebble_templates/index.html:379:44
+#: resources/public/pebble_templates/index.html
 badges;pixel\ count;pixels\ placed=badges;nombres de pixels;pixels plac\u00e9s
 
-#: resources/public/pebble_templates/index.html:382:57
+#: resources/public/pebble_templates/index.html
 Show\ pixel-placed\ badges=Afficher les badges de nombre de pixels
 
-#: resources/public/pebble_templates/index.html:385:44
+#: resources/public/pebble_templates/index.html
 badges;factions=badges;factions
 
-#: resources/public/pebble_templates/index.html:388:57
+#: resources/public/pebble_templates/index.html
 Show\ faction\ tags=Afficher les insignes de factions
 
-#: resources/public/pebble_templates/index.html:391:44
+#: resources/public/pebble_templates/index.html
 template\ urls;template\ links;template\ name=urls de mod\u00e8les;liens de mod\u00e8les;nom de mod\u00e8le
 
-#: resources/public/pebble_templates/index.html:394:57
+#: resources/public/pebble_templates/index.html
 Replace\ template\ titles\ with\ URLs\ in\ chat\ where\ applicable=Remplacer les noms de mod\u00e8les par des URLs dans le chat quand c'est possible
 
-#: resources/public/pebble_templates/index.html:397:44
+#: resources/public/pebble_templates/index.html
 chat\ orientation;chat\ position=orientation du chat;position du chat
 
-#: resources/public/pebble_templates/index.html:400:57
+#: resources/public/pebble_templates/index.html
 Enable\ horizontal\ chat=Activer le chat horizontal
 
-#: resources/public/pebble_templates/index.html:403:44
+#: resources/public/pebble_templates/index.html
 banner;animation=banni\u00e8re;bandeau;animation
 
-#: resources/public/pebble_templates/index.html:406:57
+#: resources/public/pebble_templates/index.html
 Enable\ the\ rotating\ banner\ under\ chat=Animer le bandeau sous le chat
 
-#: resources/public/pebble_templates/index.html:409:44
+#: resources/public/pebble_templates/index.html
 max;messages;truncate=max;messages;tronquer;troncature
 
-#: resources/public/pebble_templates/index.html:411:57
+#: resources/public/pebble_templates/index.html
 Maximum\ amount\ of\ chat\ messages\:=Maximum de messages visibles dans le chat
 
-#: resources/public/pebble_templates/index.html:415:44
+#: resources/public/pebble_templates/index.html
 link;url;behaviour=lien;url
 
-#: resources/public/pebble_templates/index.html:417:57
+#: resources/public/pebble_templates/index.html
 Default\ internal\ link\ action\ click\:=Action par d\u00e9faut au clic sur un lien interne \:
 
-#: resources/public/pebble_templates/index.html:422:44
+#: resources/public/pebble_templates/index.html
 ignored;ignores;unignore;blocked;blocking;unblock=ignor\u00e9s;ignorer;bloqu\u00e9;bloquer
 
-#: resources/public/pebble_templates/index.html:423:28
+#: resources/public/pebble_templates/index.html
 Ignores=Ignor\u00e9s
 
-#: resources/public/pebble_templates/index.html:424:44
+#: resources/public/pebble_templates/index.html
 unignore;unblock=d\u00e9signorer;ne plus ignorer
 
-#: resources/public/pebble_templates/index.html:429:85
+#: resources/public/pebble_templates/index.html
 Unignore=Ne plus ignorer
 
-#: resources/public/pebble_templates/index.html:436:36
+#: resources/public/pebble_templates/index.html
 overlays;virginmap;heatmap;grid=calques;virginmap;heatmap;carte d'activit\u00e9;grille
 
-#: resources/public/pebble_templates/index.html:438:24
+#: resources/public/pebble_templates/index.html
 Overlay\ Settings=Param\u00e8tres des calques
 
-#: resources/public/pebble_templates/index.html:441:44
+#: resources/public/pebble_templates/index.html
 heatmap;heatmap\ opacity;clear\ heatmap=heatmap;carte d'activit\u00e9
 
-#: resources/public/pebble_templates/index.html:442:28
+#: resources/public/pebble_templates/index.html
 Heatmap=Carte d'activit\u00e9
 
-#: resources/public/pebble_templates/index.html:446:57
+#: resources/public/pebble_templates/index.html
 Turn\ on\ heatmap=Afficher la carte d'activit\u00e9
 
-#: resources/public/pebble_templates/index.html:448:70
+#: resources/public/pebble_templates/index.html
 (toggle\ with\ <kbd>H</kbd>)=(activer/d\u00e9sactiver avec <kbd>H</kbd>)
 
-#: resources/public/pebble_templates/index.html:450:44
+#: resources/public/pebble_templates/index.html
 overlays;activity;pixels\ placed\ pixels;wipe;clean=calques;activit\u00e9;pixels plac\u00e9s;r\u00e9initialiser
 
-#: resources/public/pebble_templates/index.html:451:71
+#: resources/public/pebble_templates/index.html
 Clear\ heatmap=R\u00e9initialiser la carte d'activit\u00e9
 
-#: resources/public/pebble_templates/index.html:452:51
+#: resources/public/pebble_templates/index.html
 (hotkey\:\ <kbd>O</kbd>)=(raccourci \: <kbd>O</kbd>)
 
-#: resources/public/pebble_templates/index.html:454:44
+#: resources/public/pebble_templates/index.html
 overlays;user\ activity;pixels\ placed\ pixels;transparency=calques;activit\u00e9 utilisateur;pixels plac\u00e9s;transparence
 
-#: resources/public/pebble_templates/index.html:456:57
+#: resources/public/pebble_templates/index.html
 Heatmap\ background\ opacity\:=Opacit\u00e9 du fond de la carte d'activit\u00e9 \:
 
-#: resources/public/pebble_templates/index.html:461:44
+#: resources/public/pebble_templates/index.html
 virginmap;virginmap\ opacity;clear\ virginmap=virginmap;opacit\u00e9;r\u00e9initialiser
 
-#: resources/public/pebble_templates/index.html:462:28
+#: resources/public/pebble_templates/index.html
 Virginmap=Virginmap
 
-#: resources/public/pebble_templates/index.html:466:57
+#: resources/public/pebble_templates/index.html
 Turn\ on\ virginmap=Afficher la virginmap
 
-#: resources/public/pebble_templates/index.html:468:72
+#: resources/public/pebble_templates/index.html
 (toggle\ with\ <kbd>X</kbd>)=(activer/d\u00e9sactiver avec <kbd>X</kbd>)
 
-#: resources/public/pebble_templates/index.html:470:44
+#: resources/public/pebble_templates/index.html
 overlays;user\ activity;pixels\ unplaced\ pixels;transparency=calques;activit\u00e9 utilisateur;pixels non plac\u00e9s;transparence
 
-#: resources/public/pebble_templates/index.html:472:57
+#: resources/public/pebble_templates/index.html
 Virginmap\ background\ opacity\:=Opacit\u00e9 du fond de la virginmap \:
 
-#: resources/public/pebble_templates/index.html:476:44
+#: resources/public/pebble_templates/index.html
 overlays;activity;pixels\ unplaced\ pixels;wipe;clean=calques;activit\u00e9;pixels non plac\u00e9s;r\u00e9initialiser
 
-#: resources/public/pebble_templates/index.html:477:71
+#: resources/public/pebble_templates/index.html
 Clear\ virginmap=R\u00e9initialiser la virginmap
 
-#: resources/public/pebble_templates/index.html:478:51
+#: resources/public/pebble_templates/index.html
 (hotkey\:\ <kbd>U</kbd>)=(raccourci \: <kbd>U</kbd>)
 
-#: resources/public/pebble_templates/index.html:483:57
+#: resources/public/pebble_templates/index.html
 Layer\ template\ underneath\ heatmap=Faire passer le mod\u00e8le sous la carte d'activit\u00e9
 
-#: resources/public/pebble_templates/index.html:487:44
+#: resources/public/pebble_templates/index.html
 grid;toggle\ grid=grille
 
-#: resources/public/pebble_templates/index.html:488:28
+#: resources/public/pebble_templates/index.html
 Grid=Grille
 
-#: resources/public/pebble_templates/index.html:492:57
+#: resources/public/pebble_templates/index.html
 Turn\ on\ grid=Activer la grille
 
-#: resources/public/pebble_templates/index.html:494:67
+#: resources/public/pebble_templates/index.html
 (toggle\ with\ <kbd>G</kbd>)=(activer/d\u00e9sactiver avec <kbd>G</kbd>)
 
-#: resources/public/pebble_templates/index.html:499:36
+#: resources/public/pebble_templates/index.html
 controls;zooming;panning;movement=contr\u00f4les;zoom;mouvement\:d\u00e9placement
 
-#: resources/public/pebble_templates/index.html:501:24
+#: resources/public/pebble_templates/index.html
 Control\ Settings=Param\u00e8tres des Contr\u00f4les
 
-#: resources/public/pebble_templates/index.html:504:44
+#: resources/public/pebble_templates/index.html
 zooming;scrolling;scale;scaling=zoom;scrolling;taille;\u00e9chelle
 
-#: resources/public/pebble_templates/index.html:505:28
+#: resources/public/pebble_templates/index.html
 Zooming=Zoomer
 
-#: resources/public/pebble_templates/index.html:506:44
+#: resources/public/pebble_templates/index.html
 scrolling\ sensitivity;zooming\ sensitivity;mousewheel\ sensitivity=sensibilit\u00e9 du zoom;zoom;molette de souris;roulette de souris
 
-#: resources/public/pebble_templates/index.html:508:57
+#: resources/public/pebble_templates/index.html
 Zoom\ sensitivity\:=Sensibilit\u00e9 du zoom \:
 
-#: resources/public/pebble_templates/index.html:512:44
+#: resources/public/pebble_templates/index.html
 zooming\ limit;scrolling\ limit;mousewheel;zooming\ minimum;zooming\ maximum=limites du zoom;limites du scroll;roulette de souris;molette de souris;minimum du zoom;maximum du zoom
 
-#: resources/public/pebble_templates/index.html:514:57
+#: resources/public/pebble_templates/index.html
 Minimum\ scale\:=\u00c9chelle minimale \:
 
-#: resources/public/pebble_templates/index.html:518:57
+#: resources/public/pebble_templates/index.html
 Maximum\ scale\:=\u00c9chelle maximale \:
 
-#: resources/public/pebble_templates/index.html:522:44
+#: resources/public/pebble_templates/index.html
 rounding;zooming;scrolling;mousewheel;integer;decimal=arrondissement;zoom;scrolling;roulette de souris;molette de souris;nombre entier
 
-#: resources/public/pebble_templates/index.html:525:57
+#: resources/public/pebble_templates/index.html
 Round\ zoom\ values\ to\ nearest\ whole\ number=Arrondir les valeurs de zoom \u00e0 l'entier le plus proche
 
-#: resources/public/pebble_templates/index.html:529:44
+#: resources/public/pebble_templates/index.html
 controls;miscellaneous=contr\u00f4les;divers
 
-#: resources/public/pebble_templates/index.html:534:57
+#: resources/public/pebble_templates/index.html
 Lock\ the\ canvas\ (disallow\ canvas\ drag/zoom\ with\ mouse/fingers)=Verrouiller le canvas (emp\u00eacher le mouvement/zoom avec la souris ou les doigts)
 
-#: resources/public/pebble_templates/index.html:537:44
+#: resources/public/pebble_templates/index.html
 MMB\ picker;mouse\ picker;selection;palette\ picker=s\u00e9lectionner une couleur;\u00e9chantillonner une couleur
 
-#: resources/public/pebble_templates/index.html:540:57
+#: resources/public/pebble_templates/index.html
 Enable\ middle\ mouse\ button\ selecting\ color\ from\ board=Activer l'\u00e9chantillonnage de couleur sur le canvas avec le clic du milieu
 
-#: resources/public/pebble_templates/index.html:543:44
+#: resources/public/pebble_templates/index.html
 right\ click\ action=raccourci clic droit
 
-#: resources/public/pebble_templates/index.html:545:57
+#: resources/public/pebble_templates/index.html
 Right-click\ action\:=Action du clic droit \:
 
-#: resources/public/pebble_templates/index.html:547:60
+#: resources/public/pebble_templates/index.html
 Nothing=Rien
 
-#: resources/public/pebble_templates/index.html:548:58
+#: resources/public/pebble_templates/index.html
 Clear\ color=Retirer la couleur
 
-#: resources/public/pebble_templates/index.html:549:57
+#: resources/public/pebble_templates/index.html
 Copy\ color=Copier la couleur
 
-#: resources/public/pebble_templates/index.html:550:59
+#: resources/public/pebble_templates/index.html
 Lookup=inspection du pixel
 
-#: resources/public/pebble_templates/index.html:551:64
+#: resources/public/pebble_templates/index.html
 Clear\ color\ +\ Lookup=Retirer la couleur + inspection du pixel
 
-#: resources/public/pebble_templates/index.html:558:36
+#: resources/public/pebble_templates/index.html
 snapshots;screenshot;download;picture;canvas=captures;capture d'\u00e9cran;t\u00e9l\u00e9charger;image;canvas
 
-#: resources/public/pebble_templates/index.html:560:24
+#: resources/public/pebble_templates/index.html
 Snapshot\ Settings=Param\u00e8tres de capture
 
-#: resources/public/pebble_templates/index.html:563:44
+#: resources/public/pebble_templates/index.html
 screenshot;snapshot;download;board;canvas=captures;capture d'\u00e9cran;t\u00e9l\u00e9charger;canvas
 
-#: resources/public/pebble_templates/index.html:564:44
+#: resources/public/pebble_templates/index.html
 take\ screenshot;image;download\ format;picture;canvas;board=prendre une capture;image;t\u00e9l\u00e9charger;format;image;canvas
 
-#: resources/public/pebble_templates/index.html:566:57
+#: resources/public/pebble_templates/index.html
 Snapshot\ image\ format\:=Format de la capture du canvas \:
 
-#: resources/public/pebble_templates/index.html:568:71
+#: resources/public/pebble_templates/index.html
 PNG=PNG
 
-#: resources/public/pebble_templates/index.html:569:63
+#: resources/public/pebble_templates/index.html
 JPEG=JPEG
 
-#: resources/public/pebble_templates/index.html:570:63
+#: resources/public/pebble_templates/index.html
 WEBP\ (Chrome\ only)=WEBP (seulement pour Chrome)
 
-#: resources/public/pebble_templates/index.html:577:36
+#: resources/public/pebble_templates/index.html
 templates;overlays;guides=mod\u00e8les;calques;guides
 
-#: resources/public/pebble_templates/index.html:582:44
+#: resources/public/pebble_templates/index.html
 templates;overlays;image;pixel\ art=mod\u00e8les;calques;image;pixel art;pixelart
 
-#: resources/public/pebble_templates/index.html:583:44
+#: resources/public/pebble_templates/index.html
 template\ enabled;template\ disabled;show\ template;hide\ template;template\ shown;template\ hidden=mod\u00e8le activ\u00e9;mod\u00e8le d\u00e9sactiv\u00e9;afficher mod\u00e8le;cacher mod\u00e8le
 
-#: resources/public/pebble_templates/index.html:586:57
+#: resources/public/pebble_templates/index.html
 Use\ template=Afficher le mod\u00e8le
 
-#: resources/public/pebble_templates/index.html:589:27
+#: resources/public/pebble_templates/index.html
 Hold\ down\ <kbd>Ctrl</kbd>\ (or\ <kbd>Option</kbd>\ on\ mac)\ to\ drag\ the\ template\ around=Garder <kbd>Ctrl</kbd> appuy\u00e9 (ou <kbd>Option</kbd> sur mac) avec le clic pour d\u00e9placer le mod\u00e8le sur le canvas
 
-#: resources/public/pebble_templates/index.html:590:44
+#: resources/public/pebble_templates/index.html
 template\ title;template\ name;tab\ name;tab\ title;title\==titre du mod\u00e8le;nom du mod\u00e8le;nom de l'onglet;titre de l'onglet;title\=
 
-#: resources/public/pebble_templates/index.html:592:57
+#: resources/public/pebble_templates/index.html
 Title\:=Titre \:
 
-#: resources/public/pebble_templates/index.html:596:44
+#: resources/public/pebble_templates/index.html
 !template\ location\ source;template\ source\ URL;template\ URL;template\==
 
-#: resources/public/pebble_templates/index.html:598:57
+#: resources/public/pebble_templates/index.html
 URL\:=URL \:
 
-#: resources/public/pebble_templates/index.html:603:44
+#: resources/public/pebble_templates/index.html
 template\ position;template\ x;template\ y;template\ location;\ template\ vertical;\ template\ horizontal;ox\=;oy\==position du mod\u00e8le;coordonn\u00e9es du mod\u00e8le;ox\=;oy\=
 
-#: resources/public/pebble_templates/index.html:605:57
+#: resources/public/pebble_templates/index.html
 Horizontal\ position\:=Position horizontale \:
 
-#: resources/public/pebble_templates/index.html:609:57
+#: resources/public/pebble_templates/index.html
 Vertical\ position\:=Position verticale \:
 
-#: resources/public/pebble_templates/index.html:613:44
+#: resources/public/pebble_templates/index.html
 template\ width;tw\==largeur du mod\u00e8le;tw\=
 
-#: resources/public/pebble_templates/index.html:615:57
+#: resources/public/pebble_templates/index.html
 Width\:=Largeur \:
 
-#: resources/public/pebble_templates/index.html:618:82
-#: resources/public/pebble_templates/index.html:688:79
+#: resources/public/pebble_templates/index.html
 Reset=R\u00e9initialiser
 
-#: resources/public/pebble_templates/index.html:620:44
+#: resources/public/pebble_templates/index.html
 !template\ style;custom\ template=
 
-#: resources/public/pebble_templates/index.html:622:57
+#: resources/public/pebble_templates/index.html
 !Style\:=
 
-#: resources/public/pebble_templates/index.html:624:53
+#: resources/public/pebble_templates/index.html
 !Use\ Source\ Style=
 
-#: resources/public/pebble_templates/index.html:625:239
+#: resources/public/pebble_templates/index.html
 !Dotted\ (Small,\ 1\:2)=
 
-#: resources/public/pebble_templates/index.html:626:271
+#: resources/public/pebble_templates/index.html
 !Dotted\ (Big,\ 2\:2)=
 
-#: resources/public/pebble_templates/index.html:627:1803
+#: resources/public/pebble_templates/index.html
 !Numbers=
 
-#: resources/public/pebble_templates/index.html:628:85
+#: resources/public/pebble_templates/index.html
 !Custom\u2026=
 
-#: resources/public/pebble_templates/index.html:632:44
+#: resources/public/pebble_templates/index.html
 !template\ style\ source;template\ style\ URL;custom\ style\ URL;custom\ template=
 
-#: resources/public/pebble_templates/index.html:634:57
+#: resources/public/pebble_templates/index.html
 !Custom\ style\ URL\:=
 
-#: resources/public/pebble_templates/index.html:639:44
+#: resources/public/pebble_templates/index.html
 !template\ conversion;template\ palette\ conversion;convert\ to\ palette=
 
-#: resources/public/pebble_templates/index.html:641:57
+#: resources/public/pebble_templates/index.html
 !Color\ Conversion\ Mode\:=
 
-#: resources/public/pebble_templates/index.html:643:64
+#: resources/public/pebble_templates/index.html
 !Unconverted=
 
-#: resources/public/pebble_templates/index.html:644:66
+#: resources/public/pebble_templates/index.html
 !Nearest\ Custom=
 
-#: resources/public/pebble_templates/index.html:648:44
+#: resources/public/pebble_templates/index.html
 template\ transparency;template\ opacity;oo\==transparence du mod\u00e8le;opacit\u00e9 du mod\u00e8le;oo\=
 
-#: resources/public/pebble_templates/index.html:650:57
+#: resources/public/pebble_templates/index.html
 Opacity\:=Opacit\u00e9 \:
 
-#: resources/public/pebble_templates/index.html:658:36
+#: resources/public/pebble_templates/index.html
 sound;notification;alert;notify;ping=son;notification;alerte;ping
 
-#: resources/public/pebble_templates/index.html:660:24
+#: resources/public/pebble_templates/index.html
 Sound\ and\ Notification\ Settings=Param\u00e8tres des Notifications/Sons
 
-#: resources/public/pebble_templates/index.html:665:44
+#: resources/public/pebble_templates/index.html
 audio;mute;noise;volume=audio;rendre muet;son;volume
 
-#: resources/public/pebble_templates/index.html:668:57
+#: resources/public/pebble_templates/index.html
 Enable\ sound=Activer le son
 
-#: resources/public/pebble_templates/index.html:671:44
+#: resources/public/pebble_templates/index.html
 notifs;notify;pixel\ notification=notifications;notifs;notification de pixel
 
-#: resources/public/pebble_templates/index.html:674:57
+#: resources/public/pebble_templates/index.html
 Enable\ pixel\ available\ notification=Activer la notification quand un pixel est pr\u00eat \u00e0 \u00eatre plac\u00e9
 
-#: resources/public/pebble_templates/index.html:678:44
+#: resources/public/pebble_templates/index.html
 notification;pixel\ ready;alert=notification;pixel pr\u00eat;alerte
 
-#: resources/public/pebble_templates/index.html:679:28
+#: resources/public/pebble_templates/index.html
 Pixel\ Ready\ Notification=Notification quand un pixel est pr\u00eat
 
-#: resources/public/pebble_templates/index.html:680:44
+#: resources/public/pebble_templates/index.html
 alert\ source;notify\ url;notify\ source;notification\ url;notification\ source=source du son;source de la notification;url de la notification;son
 
-#: resources/public/pebble_templates/index.html:682:57
+#: resources/public/pebble_templates/index.html
 Alert\ URL\:=URL du son d'alerte \:
 
-#: resources/public/pebble_templates/index.html:686:85
+#: resources/public/pebble_templates/index.html
 Update=Mettre \u00e0 jour
 
-#: resources/public/pebble_templates/index.html:687:83
+#: resources/public/pebble_templates/index.html
 Test=Tester
 
-#: resources/public/pebble_templates/index.html:691:44
+#: resources/public/pebble_templates/index.html
 sound\ level;audio\ level;mute\ audio;mute\ sound=niveau sonore;volume sonore;rendre muet
 
-#: resources/public/pebble_templates/index.html:693:57
+#: resources/public/pebble_templates/index.html
 Volume\:=Volume \:
 
-#: resources/public/pebble_templates/index.html:698:44
+#: resources/public/pebble_templates/index.html
 alert\ forewarning;alert\ delay;\ notification\ delay;\ notification\ forewarning=d\u00e9lai;d\u00e9lai de notification;d\u00e9lai d'alerte
 
-#: resources/public/pebble_templates/index.html:700:57
+#: resources/public/pebble_templates/index.html
 Delay\ (seconds)\:=D\u00e9lai (secondes) \:
 
-#: resources/public/pebble_templates/index.html:705:44
+#: resources/public/pebble_templates/index.html
 chat\ mentions;chat\ pings;chat\ sound=mentions de chat;notifications de chat;ping
 
-#: resources/public/pebble_templates/index.html:706:28
+#: resources/public/pebble_templates/index.html
 Chat\ Pings=Mentions de chat
 
-#: resources/public/pebble_templates/index.html:710:57
+#: resources/public/pebble_templates/index.html
 Enable\ pings=Autoriser les mentions de chat
 
-#: resources/public/pebble_templates/index.html:713:44
+#: resources/public/pebble_templates/index.html
 mention\ sound=son de mention;ping
 
-#: resources/public/pebble_templates/index.html:715:57
+#: resources/public/pebble_templates/index.html
 Play\ sound\ on\ ping\:=\u00c9mettre un son quand on est mentionn\u00e9 \:
 
-#: resources/public/pebble_templates/index.html:717:56
-#: resources/public/include/chat.js:1937:100
+#: resources/public/pebble_templates/index.html
+#: resources/public/include/chat.js
 Off=Jamais
 
-#: resources/public/pebble_templates/index.html:718:61
+#: resources/public/pebble_templates/index.html
 Only\ when\ necessary=Seulement quand n\u00e9cessaire
 
-#: resources/public/pebble_templates/index.html:719:59
+#: resources/public/pebble_templates/index.html
 Always=Toujours
 
-#: resources/public/pebble_templates/index.html:723:44
+#: resources/public/pebble_templates/index.html
 mention\ sound\ volume=volume;son;mention
 
-#: resources/public/pebble_templates/index.html:725:57
+#: resources/public/pebble_templates/index.html
 Ping\ sound\ volume\:=Volume du son de mention \:
 
-#: resources/public/pebble_templates/index.html:733:36
+#: resources/public/pebble_templates/index.html
 personal\ account=compte personnel
 
-#: resources/public/pebble_templates/index.html:735:24
+#: resources/public/pebble_templates/index.html
 Account\ Settings=Param\u00e8tres du Compte
 
-#: resources/public/pebble_templates/index.html:741:57
+#: resources/public/pebble_templates/index.html
 Public\ Discord\ name\:=Nom Public Discord \:
 
-#: resources/public/pebble_templates/index.html:745:83
-#: resources/public/include/chat.js:1939:92
-#: resources/public/include/chat.js:2003:92
+#: resources/public/pebble_templates/index.html
+#: resources/public/include/chat.js
 Set=D\u00e9finir
 
-#: resources/public/pebble_templates/index.html:746:86
+#: resources/public/pebble_templates/index.html
 Remove=Retirer
 
 #. FAQ panel
-#: resources/public/pebble_templates/index.html:759:65
+#: resources/public/pebble_templates/index.html
 Help=Aide
 
-#: resources/public/pebble_templates/index.html:772:54
+#: resources/public/pebble_templates/index.html
 Notifications=Notifications
 
-#: resources/public/pebble_templates/faq.html:3:16
+#: resources/public/pebble_templates/faq.html
 FAQ=FAQ
 
-#: resources/public/pebble_templates/faq.html:7:20
+#: resources/public/pebble_templates/faq.html
 Why\ is\ the\ cooldown\ as\ long\ as\ it\ is?=Pourquoi est-ce que le temps \u00e0 attendre entre chaque pixel est aussi long\u00a0?
 
-#: resources/public/pebble_templates/faq.html:8:20
+#: resources/public/pebble_templates/faq.html
 The\ time\ it\ takes\ to\ get\ a\ pixel\ is\ dynamic,\ and\ changes\ based\ on\ how\ many\ people\ are\ online.\ The\ cooldown\ time\ is\ longer\ when\ more\ users\ are\ online.=Le temps que \u00e7a prend pour charger un pixel change en fonction du nombre de personnes en ligne. Ce temps sera plus long si plus de monde est en ligne.
 
-#: resources/public/pebble_templates/faq.html:9:20
+#: resources/public/pebble_templates/faq.html
 Why\ does\ it\ say\ 0/6\ pixels?=Pourquoi est-ce que \u00e7a dit que j'ai 0/6 pixels\u00a0?
 
-#: resources/public/pebble_templates/faq.html:10:20
+#: resources/public/pebble_templates/faq.html
 This\ means\ that\ you\ are\ waiting\ for\ your\ next\ pixel.\ When\ you\ place\ a\ pixel,\ there\ is\ a\ cooldown\ for\ when\ you\ can\ place\ the\ next\ one.\ Over\ time,\ you\ can\ gain\ up\ to\ 6\ "stacked"\ pixels\ to\ place\ at\ once.=\u00c7a veut dire que tu es en train d'attendre que ton prochain pixel soit pr\u00eat. Quand tu places un pixel, il y a un certain temps avant que tu puisses en placer un autre. Apr\u00e8s un certain temps, tu peux obtenir jusqu'\u00e0 6 pixels "stack\u00e9s"
 
-#: resources/public/pebble_templates/faq.html:11:20
+#: resources/public/pebble_templates/faq.html
 Why\ does\ it\ take\ so\ long\ to\ "stack"\ pixels?=Pourquoi est-ce que \u00e7a prend autant de temps pour "stacker" des pixels\u00a0?
 
-#: resources/public/pebble_templates/faq.html:12:20
+#: resources/public/pebble_templates/faq.html
 This\ is\ by\ design.\ It\ is\ better\ to\ place\ a\ pixel\ as\ soon\ as\ you\ get\ one.\ Pixel\ "stacking"\ is\ meant\ to\ give\ you\ a\ bump\ if\ you\ go\ AFK\ for\ a\ bit.\ It\ takes\ around\ 40\ minutes\ to\ get\ a\ full\ 6/6\ pixels,\ but\ it\ only\ takes\ around\ 3\ minutes\ to\ place\ 6\ pixels\ if\ you\ place\ them\ as\ soon\ as\ possible.=Simple design. C'est mieux de placer un pixel d\u00e8s que tu en as l'opportunit\u00e9. Le "stacking"est fait pour te donner un coup de pouce pour les moments o\u00f9 tu est AFK. \u00c7a peut prendre jusqu'\u00e0 40 minutes pour obtenir 6/6 pixels, mais \u00e7a prend jusqu'\u00e0 3 minutes d'en placer 6 si tu les places d\u00e8s que possible.
 
-#: resources/public/pebble_templates/faq.html:13:20
+#: resources/public/pebble_templates/faq.html
 How\ do\ I\ appeal\ a\ ban?=Comment puis-je faire appel \u00e0 un bannissement\u00a0?
 
-#: resources/public/pebble_templates/faq.html:14:20
+#: resources/public/pebble_templates/faq.html
 Contact\ us\ on\ <a\ href\="https\://pxls.space/discord"\ target\="_blank">Discord</a>\ or\ send\ an\ appeal\ to\ our\ <a\ href\="https\://pxls.space/appeal"\ target\="_blank">Google\ form</a>\ after\ reading\ the\ rules\ in\ the\ site's\ info\ panel.=Contacte-nous \u00e0 <a href\="https\://pxls.space/discord" target\="_blank">Discord</a> ou envoie un appel \u00e0 notre <a href\="https\://pxls.space/appeal" target\="_blank">Google form</a> apr\u00e8s avoir lu les r\u00e8gles dans le panel des infos du site.
 
-#: resources/public/pebble_templates/faq.html:15:20
+#: resources/public/pebble_templates/faq.html
 How\ do\ I\ make\ a\ template?=Comment cr\u00e9er un mod\u00e8le\u00a0?
 
-#: resources/public/pebble_templates/faq.html:16:20
+#: resources/public/pebble_templates/faq.html
 A\ template\ is\ an\ image\ link\ that\ is\ posted\ in\ the\ template\ textbox\ in\ the\ settings\ panel\ so\ you\ can\ place\ over\ it\ on\ the\ canvas.\ You\ may\ use\ a\ regular\ image\ link\ to\ your\ pixel\ art,\ but\ many\ people\ use\ the\ 3rd\ party\ tool\ <a\ href\="https\://pxlsfiddle.com"\ target\="_blank">PxlsFiddle</a>\ to\ turn\ pixel\ art\ into\ a\ fancier\ link.\ If\ you\ need\ to\ make\ pixel\ art\ yourself,\ you\ can\ use\ <a\ href\="https\://www.piskelapp.com/p/create"\ target\="_blank">Piskel</a>\ to\ create\ art\ to\ put\ into\ PxlsFiddle.=Un mod\u00e8le est un lien d'image qui est post\u00e9 dans la bo\u00eete de texte des mod\u00e8les dans les param\u00e8tres afin de pouvoir le placer sur le canvas. Tu peux utiliser un lien d'image normal pour ton pixel art, mais beaucoup de gens utilisent l'outil <a href\="https\://pxlsfiddle.com" target\="_blank">PxlsFiddle</a> pour transformer ton pixel art en un lien plus simple. Si tu as besoin de faire un pixel art toi m\u00eame, tu peux utliser <a href\="https\://www.piskelapp.com/p/create" target\="_blank">Piskel</a> pour cr\u00e9er un mod\u00e8le et le mettre ensuite dans PxlsFiddle.
 
-#: resources/public/pebble_templates/faq.html:17:20
+#: resources/public/pebble_templates/faq.html
 How\ do\ I\ move\ a\ template?=Comment est-ce que je d\u00e9place mon mod\u00e8le\u00a0?
 
-#: resources/public/pebble_templates/faq.html:18:20
+#: resources/public/pebble_templates/faq.html
 Hold\ <kbd>CTRL</kbd>\ (or\ <kbd>OPTION</kbd>\ on\ macOS)\ and\ click\ and\ drag\ to\ move\ it\ around.\ On\ mobile,\ you\ can\ tap\ and\ hold\ where\ you\ want\ to\ move\ the\ template\ and\ click\ "Move\ Template\ Here"\ in\ the\ pop-up.=Maintiens <kbd>CTRL</kbd> (ou <kbd>OPTION</kbd> sur macOS) et d\u00e9place le en laissant appuyer le clique gauche. Sur t\u00e9l\u00e9phone, tu peux taper et laisser appuyer ou tu veux d\u00e9placer ton mod\u00e8le et cliquer "D\u00e9placer le mod\u00e8le ici" dans le pop-up
 
-#: resources/public/pebble_templates/faq.html:19:20
+#: resources/public/pebble_templates/faq.html
 Does\ the\ canvas\ reset?\ When?=Est-ce que le canvas se r\u00e9initialise\u00a0? Quand\u00a0?
 
-#: resources/public/pebble_templates/faq.html:20:20
+#: resources/public/pebble_templates/faq.html
 Yes.\ The\ canvas\ resets\ when\ it\ is\ completely\ full.\ A\ reset\ date\ is\ not\ usually\ decided\ until\ the\ canvas\ is\ full,\ but\ the\ average\ canvas\ life-span\ is\ around\ 1\ month.\ Updates\ are\ posted\ in\ our\ <a\ href\="https\://pxls.space/discord"\ target\="_blank">Discord\ server</a>\ when\ a\ reset\ date\ is\ set.=Oui. Le canvas se r\u00e9initialise quand il est compl\u00e8tement rempli. Une date exacte est choisie seulement quand le canvas est plein, mais la dur\u00e9e de vie moyenne est de 1 mois. Les annonces sont publi\u00e9es dans notre <a href\="https\://pxls.space/discord" target\="_blank">serveur Discord</a> lorsqu'une date est choisie.
 
-#: resources/public/pebble_templates/faq.html:21:20
+#: resources/public/pebble_templates/faq.html
 Where\ can\ I\ see\ the\ past\ canvases?=O\u00f9 puis-je voir les anciens canvas\u00a0?
 
-#: resources/public/pebble_templates/faq.html:22:20
+#: resources/public/pebble_templates/faq.html
 The\ past\ canvases\ are\ featured\ on\ our\ <a\ href\="https\://pxls.space/discord"\ target\="_blank">Discord\ server</a>,\ or\ the\ 3rd\ party\ website\ <a\ href\="https\://pxlsfiddle.com"\ target\="_blank">PxlsFiddle</a>,\ which\ records\ timelapses\ and\ a\ lot\ of\ useful\ information\ on\ each\ canvas.=Les anciens canvas sont situ\u00e9s dans notre <a href\="https\://pxls.space/discord" target\="_blank">serveur Discord</a>, ou sur le site web third-party <a href\="https\://pxlsfiddle.com" target\="_blank">PxlsFiddle</a>, qui enregistre des timelapses et plein d'autres informations utiles pour chaque canvas.
 
-#: resources/public/pebble_templates/faq.html:23:20
+#: resources/public/pebble_templates/faq.html
 How\ do\ I\ see\ who\ placed\ a\ pixel?=Comment puis-je voir qui a plac\u00e9 un pixel\u00a0?
 
-#: resources/public/pebble_templates/faq.html:24:20
+#: resources/public/pebble_templates/faq.html
 By\ shift-clicking\ (or\ tap\ and\ hold\ on\ mobile)\ a\ pixel,\ you\ can\ see\ who\ placed\ a\ pixel,\ how\ many\ pixels\ they\ have\ placed,\ and\ when\ they\ placed\ it.=En shift-cliquant (ou en maintenant son doigt sur mobile) sur un pixel, vous pouvez voir qui l'a plac\u00e9, le nombre de pixels que l'individu a plac\u00e9, et le moment ou ce pixel a \u00e9t\u00e9 plac\u00e9.
 
-#: resources/public/pebble_templates/faq.html:25:20
+#: resources/public/pebble_templates/faq.html
 How\ do\ I\ report\ someone?=Comment est-ce que je signale quelqu'un\u00a0?
 
-#: resources/public/pebble_templates/faq.html:26:20
+#: resources/public/pebble_templates/faq.html
 Shift-click\ (or\ tap\ and\ hold\ on\ mobile)\ on\ a\ pixel,\ and\ click\ the\ Report\ button.=Shift-click (ou en maintenant son doigt sur mobile) sur un pixel, et appuyez sur le bouton Signaler.
 
-#: resources/public/pebble_templates/faq.html:27:20
+#: resources/public/pebble_templates/faq.html
 How\ do\ I\ change\ the\ color\ of\ my\ name\ in\ the\ chat?=Comment est-ce que je change la couleur de mon nom dans le chat\u00a0?
 
-#: resources/public/pebble_templates/faq.html:28:20
+#: resources/public/pebble_templates/faq.html
 There\ is\ a\ "Username\ Color"\ option\ near\ the\ bottom\ of\ the\ settings\ panel.=Il y a une option "Couleur du nom d'utilisateur" pr\u00e8s du bas des options.
 
-#: resources/public/pebble_templates/faq.html:29:20
+#: resources/public/pebble_templates/faq.html
 What\ is\ a\ "virginmap"?=Qu'est-ce que la "virginmap"\u00a0?
 
-#: resources/public/pebble_templates/faq.html:30:20
+#: resources/public/pebble_templates/faq.html
 The\ virginmap\ shows\ which\ pixels\ have\ not\ yet\ been\ placed\ on\ (or\ \u201cvirgin\u201d\ pixels).=La virginmap montre quels pixels n'ont pas encore \u00e9t\u00e9 touch\u00e9s (les pixels \u201cvierges\u201d).
 
-#: resources/public/pebble_templates/faq.html:31:20
+#: resources/public/pebble_templates/faq.html
 How\ do\ I\ report\ bugs?=Comment puis-je signaler un bug\u00a0?
 
-#: resources/public/pebble_templates/faq.html:32:20
+#: resources/public/pebble_templates/faq.html
 Submit\ bugs\ to\ the\ \#dev-and-bugs\ channel\ in\ the\ <a\ href\="https\://pxls.space/discord"\ target\="_blank">Discord\ server</a>.\ If\ you\ have\ found\ an\ exploit,\ please\ message\ one\ of\ the\ staff\ members\ privately\ (through\ DMs).=Publie ton probl\u00e8me dans le salon \#devs-and-bugs dans notre <a href\="https\://pxls.space/discord" target\="_blank">serveur Discord</a>. Si tu as trouv\u00e9 une m\u00e9thode pour exploiter le site, merci de contacter un membre du staff (en message priv\u00e9).
 
-#: resources/public/pebble_templates/faq.html:33:20
+#: resources/public/pebble_templates/faq.html
 How\ do\ I\ get\ more\ info\ or\ contact\ staff?=Comment puis-je avoir plus d'informations ou contacter le staff\u00a0?
 
-#: resources/public/pebble_templates/faq.html:34:20
+#: resources/public/pebble_templates/faq.html
 Check\ the\ info\ panel\ (the\ icon\ on\ the\ top\ left)\ for\ more\ details\ and\ links,\ or\ join\ our\ <a\ href\="https\://pxls.space/discord"\ target\="_blank">Discord\ server</a>,\ where\ a\ staff\ member\ will\ gladly\ respond.=Regarde l'onglet d'information (l'ic\u00f4ne dans le coin en haut \u00e0 gauche) pour plus de d\u00e9tails et des liens, ou rejoignez notre <a href\="https\://pxls.space/discord" target\="_blank">Discord server</a>, o\u00f9 un membre du staff te r\u00e9pondra avec plaisir.
 
-#: resources/public/pebble_templates/info.html:3:10
+#: resources/public/pebble_templates/info.html
 Welcome\!=Bienvenue \!
 
-#: resources/public/pebble_templates/info.html:6:9
+#: resources/public/pebble_templates/info.html
 Welcome\ to\ pxls.space\!\ Pxls\ is\ a\ multiplayer\ online\ collaborative\ canvas\ that\ allows\ you\ to\ create\ anything\ you\ can\ imagine,\ one\ pixel\ at\ a\ time.\ Join\ hundreds\ of\ other\ players\ in\ the\ Pxls\ community\ and\ create\ amazing\ works\ of\ art\ together\ as\ a\ team,\ or\ solo.=Bienvenue sur pxls.space \! Pxls est un canvas collaboratif en ligne qui te permet de cr\u00e9er tout ce que tu peux imaginer, pixel apr\u00e8s pixel. Rejoins des centaines de joueurs dans la communaut\u00e9 de Pxls et cr\u00e9e des \u0153uvres d'art en \u00e9quipe ou en solo.
 
-#: resources/public/pebble_templates/info.html:7:9
+#: resources/public/pebble_templates/info.html
 The\ best\ place\ to\ reach\ staff\ and\ fellow\ community\ is\ in\ the\ discord\!=Le meilleur endroit pour contacter le staff ou d'autres membres de la communaut\u00e9 est le serveur Discord \!
 
-#: resources/public/pebble_templates/info.html:8:9
+#: resources/public/pebble_templates/info.html
 Check\ out\ our\ social\ media\ pages,\ and\ please\ take\ the\ time\ to\ read\ the\ rules\ below.\ Have\ fun\ creating\ (or\ changing)\ art\!=Jette un \u0153il \u00e0 nos r\u00e9seaux sociaux, et n'oublie pas de lire les r\u00e8gles ci-dessous. Profite bien du site, et amuse-toi bien \u00e0 cr\u00e9er (ou modifier) de l'art \!
 
-#: resources/public/pebble_templates/info.html:13:27
+#: resources/public/pebble_templates/info.html
 Canvas\ Rules=R\u00e8gles du canvas
 
-#: resources/public/pebble_templates/info.html:16:9
+#: resources/public/pebble_templates/info.html
 We\ pride\ ourselves\ on\ trying\ to\ keep\ an\ open\ canvas\ for\ all\ free\ from\ outside\ interference\ on\ our\ end,\ and\ especially\ censorship.\ However,\ for\ the\ good\ of\ the\ community\ and\ on\ accounts\ of\ our\ own\ beliefs,\ please\ acknowledge\ and\ obey\ the\ following\ guidelines\:=Nous mettons un point d'honneur \u00e0 garder un canvas ouvert \u00e0 tous sans interf\u00e9rences de notre part, et surtout sans censure. Toutefois, pour le bien de la communaut\u00e9, nous te remercions de lire et ob\u00e9ir les quelques consignes suivantes \:
 
-#: resources/public/pebble_templates/info.html:18:11
+#: resources/public/pebble_templates/info.html
 No\ hateful\ imagery\ or\ derogatory\ speech.\ This\ includes\ but\ is\ not\ limited\ to\ words\ such\ as\ <i>faggot</i>,\ <i>nigger</i>,\ etc;\ as\ well\ as\ the\ Swastika,\ Hammer\ and\ Sickle,\ and\ any\ symbols\ of\ terrorism.=Pas d'imagerie haineuse ou propos d\u00e9rogatoires. Ceci inclut (liste non exhaustive) des mots tels que <i>faggot</i>, <i>p\u00e9d\u00e9</i>, <i>nigger</i>, etc, quelle que soit la langue utilis\u00e9e ; ainsi que la croix gamm\u00e9e et tout symbole de terrorisme.
 
-#: resources/public/pebble_templates/info.html:19:11
+#: resources/public/pebble_templates/info.html
 No\ NSFW\ or\ NSFL\ content.=Pas de contenu NSFW ou NSFL (Not Safe For Work ou Not Safe For Life, autrement dit, ind\u00e9cent)
 
-#: resources/public/pebble_templates/info.html:21:13
+#: resources/public/pebble_templates/info.html
 No\ nudity\ or\ otherwise\ sexually\ explicit\ content=Pas de nudit\u00e9 ou autre contenu sexuellement explicite
 
-#: resources/public/pebble_templates/info.html:23:15
+#: resources/public/pebble_templates/info.html
 No\ female-presenting\ nipples/bare\ breasts,\ genitalia,\ sexual\ fluids=Pas de t\u00e9tons f\u00e9minins/seins nus, organes g\u00e9nitaux, fluides sexuels
 
-#: resources/public/pebble_templates/info.html:26:13
+#: resources/public/pebble_templates/info.html
 No\ sexual\ imagery/erotica=Pas d'imagerie pornographique/\u00e9rotique
 
-#: resources/public/pebble_templates/info.html:27:13
+#: resources/public/pebble_templates/info.html
 No\ excessive\ blood\ or\ otherwise\ obscene/shocking\ content=Pas de sang excessif ou autre contenu obsc\u00e8ne/choquant
 
-#: resources/public/pebble_templates/info.html:30:11
+#: resources/public/pebble_templates/info.html
 No\ more\ than\ <b>one</b>\ account\ per\ user,\ no\ exceptions.\ Multiple\ account\ users\ will\ be\ banned\ from\ creating\ art\ on\ the\ canvas.=Pas plus d'<b>un</b> compte par personne, pas d'exceptions. Les utilisateurs utilisant plus d'un compte seront bannis d\u00e9finitivement du canvas sur tous leurs comptes.
 
-#: resources/public/pebble_templates/info.html:31:11
+#: resources/public/pebble_templates/info.html
 No\ auto-placement\ tools\ of\ any\ kind,\ you\ must\ place\ the\ pixels\ manually.=Pas d'outil d'autoplacement d'aucune sorte, les pixels doivent \u00eatre plac\u00e9s manuellement.
 
-#: resources/public/pebble_templates/info.html:32:11
+#: resources/public/pebble_templates/info.html
 Do\ not\ abuse\ site\ functionality,\ such\ as\ reports\ or\ lookups.\ (e.g.\ automated\ reporting/lookups,\ etc.)=Pas d'utilisation abusive de fonctionnalit\u00e9s du site, telles que les signalements ou les inspections. (Par exemple signalements/inspections automatis\u00e9es, etc.)
 
-#: resources/public/pebble_templates/info.html:33:11
+#: resources/public/pebble_templates/info.html
 Any\ automated\ aggregation\ of\ data\ from\ user\ lookups\ is\ not\ allowed,\ and\ will\ result\ in\ a\ ban.=Toute accumulation automatis\u00e9e d'information utilisateur par inspections est interdite, et r\u00e9sultera en un bannissement.
 
-#: resources/public/pebble_templates/info.html:34:11
-#: resources/public/pebble_templates/info.html:62:11
+#: resources/public/pebble_templates/info.html
 Staff\ have\ final\ say\ in\ any\ rule\ disputes=Le staff a le dernier mot dans tout d\u00e9bat concernant les r\u00e8gles
 
-#: resources/public/pebble_templates/info.html:35:12
-#: resources/public/pebble_templates/info.html:64:13
+#: resources/public/pebble_templates/info.html
 If\ you\ feel\ a\ moderator\ has\ acted\ inappropriately,\ please\ report\ it\ to\ an\ administrator.=Si tu penses qu'un mod\u00e9rateur a agi de fa\u00e7on inappropri\u00e9e, merci de le signaler \u00e0 un administrateur.
 
-#: resources/public/pebble_templates/info.html:38:9
+#: resources/public/pebble_templates/info.html
 If\ you\ believe\ you\ have\ been\ falsely\ banned\ you\ may\ contact\ a\ moderator\ or\ administrator.=Si tu penses avoir \u00e9t\u00e9 banni \u00e0 tort, tu peux contacter un mod\u00e9rateur ou un administrateur.
 
-#: resources/public/pebble_templates/info.html:43:27
+#: resources/public/pebble_templates/info.html
 Chat\ Rules=R\u00e8gles du chat
 
-#: resources/public/pebble_templates/info.html:47:11
+#: resources/public/pebble_templates/info.html
 Keep\ chat\ civil.\ No\ harassment\ or\ homophobic/transphobic/disablist\ language.=Garde le chat civil. Pas de harc\u00e8lement ou de propos homophobes/transphobes/d\u00e9nigrant envers les personnes handicap\u00e9es.
 
-#: resources/public/pebble_templates/info.html:48:11
+#: resources/public/pebble_templates/info.html
 No\ hate\ speech.\ This\ includes\ emoji/symbols/ASCII\ art.=Pas de langage haineux, y compris dans les \u00e9mojis/symboles/l'art ASCII.
 
-#: resources/public/pebble_templates/info.html:50:13
+#: resources/public/pebble_templates/info.html
 Normal\ swearing/etc\ is\ allowed=Les jurons normaux sont autoris\u00e9s
 
-#: resources/public/pebble_templates/info.html:53:11
+#: resources/public/pebble_templates/info.html
 No\ spamming=Pas de spam
 
-#: resources/public/pebble_templates/info.html:55:13
+#: resources/public/pebble_templates/info.html
 This\ includes\ excessive\ ASCII\ art/emojis/symbols/whitespace=Cela inclut l'usage excessif d'art ASCII/\u00e9mojis/symboles/blancs
 
-#: resources/public/pebble_templates/info.html:58:11
+#: resources/public/pebble_templates/info.html
 No\ "copy\ pasta"s=Pas de "copy pasta"s
 
-#: resources/public/pebble_templates/info.html:59:11
+#: resources/public/pebble_templates/info.html
 No\ links\ to\ sites\ that\ actively\ break\ the\ canvas\ or\ chat\ rules\ (e.g.\ porn\ sites)=Pas de liens vers des sites qui enfreignent aux r\u00e8gles du canvas ou du chat (par exemple des sites pornographiques)
 
-#: resources/public/pebble_templates/info.html:60:11
+#: resources/public/pebble_templates/info.html
 No\ symbology\ which\ break\ the\ canvas\ or\ chat\ rules\ (e.g.\ NSFW\ ASCII\ art)=Pas de symboles qui enfreignent les r\u00e8gles du canvas ou du chat (par exemple de l'art ASCII NSFW)
 
-#: resources/public/pebble_templates/info.html:61:16
+#: resources/public/pebble_templates/info.html
 No\ personal\ information=Pas d'information personnelle
 
-#: resources/public/pebble_templates/info.html:72:10
+#: resources/public/pebble_templates/info.html
 Links=Liens
 
-#: resources/public/pebble_templates/info.html:76:64
+#: resources/public/pebble_templates/info.html
 Discord\ (main\ hub)=Discord (hub principal)
 
-#: resources/public/pebble_templates/info.html:77:68
+#: resources/public/pebble_templates/info.html
 Subreddit=Subreddit
 
-#: resources/public/pebble_templates/info.html:78:68
+#: resources/public/pebble_templates/info.html
 Twitter=Twitter
 
-#: resources/public/pebble_templates/info.html:79:66
+#: resources/public/pebble_templates/info.html
 GitHub=GitHub
 
 #. link to piskelapp.com
-#: resources/public/pebble_templates/info.html:81:71
+#: resources/public/pebble_templates/info.html
 Single-player\ mode=Mode solo
 
-#: resources/public/pebble_templates/info.html:84:62
+#: resources/public/pebble_templates/info.html
 Statistics=Statistiques
 
-#: resources/public/pebble_templates/info.html:85:64
+#: resources/public/pebble_templates/info.html
 Profile\ (user\ info,\ factions,\ etc.)=Profil (informations sur les utilisateurs, factions, etc.)
 
 #. link to pxlsfiddle.com
-#: resources/public/pebble_templates/info.html:87:68
+#: resources/public/pebble_templates/info.html
 Template\ generator,\ archives,\ timelapses,\ and\ other\ utilities=G\u00e9n\u00e9rateur de mod\u00e8les, archives, timelapses et autres outils
 
 #. link to pxlsfiddle.com
-#: resources/public/pebble_templates/info.html:87:165
+#: resources/public/pebble_templates/info.html
 PxlsFiddle\ (templates,\ archives,\ etc.)=PxlsFiddle (mod\u00e8les, archives, etc.)
 
-#: resources/public/pebble_templates/info.html:93:10
+#: resources/public/pebble_templates/info.html
 Donate=Don
 
-#: resources/public/pebble_templates/info.html:96:9
+#: resources/public/pebble_templates/info.html
 Donations\ are\ not\ accepted\ at\ this\ time,\ but\ this\ panel\ will\ be\ updated\ when\ they're\ open\ again\!=Les dons ne sont pas accept\u00e9s en ce moment, mais cet onglet sera mis \u00e0 jour quand ils seront de retour\!
 
 #. eg "Alice's profile". Double singlequote is a java thing - needed if a replacement (such as this) contains a singlequote.
-#: resources/public/pebble_templates/profile.html:31:66
-#: resources/public/pebble_templates/profile.html:50:131
+#: resources/public/pebble_templates/profile.html
 {0}''s\ Profile=Profil de {0}
 
-#: resources/public/pebble_templates/profile.html:41:84
-#: resources/public/pebble_templates/40x.html:28:84
-#: resources/public/pebble_templates/40x.html:45:100
-#: resources/public/pebble_templates/40x.html:62:100
+#: resources/public/pebble_templates/profile.html
+#: resources/public/pebble_templates/40x.html
 My\ Profile=Mon Profil
 
-#: resources/public/pebble_templates/profile.html:42:85
-#: resources/public/pebble_templates/40x.html:29:85
+#: resources/public/pebble_templates/profile.html
+#: resources/public/pebble_templates/40x.html
 My\ Factions=Mes Factions
 
-#: resources/public/pebble_templates/profile.html:60:93
-#: resources/public/pebble_templates/profile.html:126:56
+#: resources/public/pebble_templates/profile.html
 Reports=Signalements
 
-#: resources/public/pebble_templates/profile.html:63:94
+#: resources/public/pebble_templates/profile.html
 Factions=Factions
 
-#: resources/public/pebble_templates/profile.html:71:68
+#: resources/public/pebble_templates/profile.html
 You\ must\ be\ logged\ in\ to\ view\ your\ profile.=Tu dois \u00eatre connect\u00e9 pour consulter ton profil.
 
-#: resources/public/pebble_templates/profile.html:77:72
+#: resources/public/pebble_templates/profile.html
 Registration\ Date=Date d'inscription
 
-#: resources/public/pebble_templates/profile.html:82:72
-#: resources/public/include/lookup.js:280:21
+#: resources/public/pebble_templates/profile.html
+#: resources/public/include/lookup.js
 Alltime\ Pixels=Pixels totaux
 
-#: resources/public/pebble_templates/profile.html:86:72
+#: resources/public/pebble_templates/profile.html
 Current\ Canvas\ Pixels=Pixels plac\u00e9s ce canvas
 
-#: resources/public/pebble_templates/profile.html:91:72
+#: resources/public/pebble_templates/profile.html
 Discord\ Tag=Tag Discord
 
-#: resources/public/pebble_templates/profile.html:95:72
-#: resources/public/include/lookup.js:235:21
+#: resources/public/pebble_templates/profile.html
+#: resources/public/include/lookup.js
 Faction=Faction
 
-#: resources/public/pebble_templates/profile.html:96:259
+#: resources/public/pebble_templates/profile.html
 None=Aucune
 
-#: resources/public/pebble_templates/profile.html:99:72
-#: resources/public/admin/admin.js:198:16
+#: resources/public/pebble_templates/profile.html
+#: resources/public/admin/admin.js
 Roles=R\u00f4les
 
-#: resources/public/pebble_templates/profile.html:104:72
+#: resources/public/pebble_templates/profile.html
 Canvas\ Ban\ Expiry=Expiration du bannissement de canvas
 
-#: resources/public/pebble_templates/profile.html:105:101
-#: resources/public/pebble_templates/profile.html:111:105
+#: resources/public/pebble_templates/profile.html
 Never=Jamais
 
-#: resources/public/pebble_templates/profile.html:110:72
+#: resources/public/pebble_templates/profile.html
 Chat\ Ban\ Expiry=Expiration du bannissement de chat
 
-#: resources/public/pebble_templates/profile.html:117:36
+#: resources/public/pebble_templates/profile.html
 View\ rankings\ and\ other\ stats\ <a\ href\="/stats">here</a>.=Consulter les classements et d'autres statistiques <a href\="/stats">ici</a>.
 
-#: resources/public/pebble_templates/profile.html:124:68
+#: resources/public/pebble_templates/profile.html
 You\ must\ be\ logged\ in\ to\ view\ your\ reports.=Tu dois \u00eatre connect\u00e9 pour consulter tes signalements.
 
-#: resources/public/pebble_templates/profile.html:130:64
+#: resources/public/pebble_templates/profile.html
 Canvas\ Reports\ ({0}/{1}\ open)=Signalements du canvas ({0}/{1} ouvert(s))
 
 #. eg "Report on Bob (closed)
-#: resources/public/pebble_templates/profile.html:142:56
-#: resources/public/pebble_templates/profile.html:177:56
+#: resources/public/pebble_templates/profile.html
 Report\ on\ {0}\ (closed)=Signalement sur {0} (ferm\u00e9)
 
 #. eg "Report on Bob (open)
-#: resources/public/pebble_templates/profile.html:145:56
-#: resources/public/pebble_templates/profile.html:179:56
+#: resources/public/pebble_templates/profile.html
 Report\ on\ {0}\ (open)=Signalement sur {0} (ouvert)
 
 #. eg "Reported Bob on Jan 1, 1970, 00:00:00 AM (UTC)
-#: resources/public/pebble_templates/profile.html:152:60
-#: resources/public/pebble_templates/profile.html:185:60
+#: resources/public/pebble_templates/profile.html
 Reported\ {0}\ on\ {1}=Signal\u00e9 {0} \u00e0 la date du {1}
 
-#: resources/public/pebble_templates/profile.html:158:47
+#: resources/public/pebble_templates/profile.html
 There\ are\ no\ canvas\ reports\ to\ show.=Il n'y a aucun signalement du canvas \u00e0 montrer.
 
-#: resources/public/pebble_templates/profile.html:166:64
+#: resources/public/pebble_templates/profile.html
 Chat\ Reports\ ({0}/{1}\ open)=Signalement du Chat ({0}/{1} ouvert)
 
-#: resources/public/pebble_templates/profile.html:191:47
+#: resources/public/pebble_templates/profile.html
 There\ are\ no\ chat\ reports\ to\ show.=Il n'y a aucun signalement du chat \u00e0 montrer.
 
-#: resources/public/pebble_templates/profile.html:200:68
+#: resources/public/pebble_templates/profile.html
 You\ must\ be\ logged\ in\ to\ manage\ your\ factions.=Tu dois \u00eatre connect\u00e9 pour modifier tes factions.
 
-#: resources/public/pebble_templates/profile.html:205:36
+#: resources/public/pebble_templates/profile.html
 You\ are\ faction\ restricted\ and\ cannot\ create\ new\ factions.\ If\ you\ believe\ this\ is\ an\ error,\ please\ contact\ a\ moderator.=Tu es banni de la cr\u00e9ation des factions et ne peux pas en cr\u00e9er des nouvelles. Si tu penses que ceci est une erreur, merci de contacter un mod\u00e9rateur.
 
-#: resources/public/pebble_templates/profile.html:207:36
+#: resources/public/pebble_templates/profile.html
 You\ are\ canvas\ banned\ and\ cannot\ create\ new\ factions.\ If\ you\ believe\ this\ is\ an\ error,\ please\ contact\ a\ moderator.=Tu es banni du canvas et ne peux pas cr\u00e9er de nouvelles factions. Si tu penses que ceci est une erreur, merci de contacter un mod\u00e9rateur.
 
-#: resources/public/pebble_templates/profile.html:212:76
+#: resources/public/pebble_templates/profile.html
 You\ must\ have\ at\ least\ {0}\ all-time\ pixels\ to\ create\ a\ faction.=Tu dois avoir au moins {0} pixels totaux pour cr\u00e9er une faction.
 
-#: resources/public/pebble_templates/profile.html:215:300
+#: resources/public/pebble_templates/profile.html
 Create=Cr\u00e9er
 
-#: resources/public/pebble_templates/profile.html:216:191
+#: resources/public/pebble_templates/profile.html
 Join=Rejoindre
 
-#: resources/public/pebble_templates/profile.html:225:118
+#: resources/public/pebble_templates/profile.html
 This\ is\ your\ currently\ displayed\ faction.=Ceci est ta faction affich\u00e9e actuelle.
 
 #. eg "Pixelers (members: 100, ID: 1)"
-#: resources/public/pebble_templates/profile.html:228:44
+#: resources/public/pebble_templates/profile.html
 {0}\ (members\:\ {1},\ ID\:\ {2}={0} (membres\: {1}, ID\: {2}
 
-#: resources/public/pebble_templates/profile.html:231:69
+#: resources/public/pebble_templates/profile.html
 Owner\:\ {0}=Propri\u00e9taire\: {0}
 
 #. makes the faction no longer the one displayed for the current user
-#: resources/public/pebble_templates/profile.html:236:175
+#: resources/public/pebble_templates/profile.html
 Remove\ Displayed=Enlever la faction affich\u00e9e
 
 #. makes the faction the one displayed for the current user
-#: resources/public/pebble_templates/profile.html:239:172
+#: resources/public/pebble_templates/profile.html
 Set\ Displayed=Choisir comme faction affich\u00e9e
 
-#: resources/public/pebble_templates/profile.html:242:235
+#: resources/public/pebble_templates/profile.html
 Members=Membres
 
-#: resources/public/pebble_templates/profile.html:243:169
+#: resources/public/pebble_templates/profile.html
 Edit=Modifier
 
-#: resources/public/pebble_templates/profile.html:244:168
-#: resources/public/include/chat.js:1462:24
+#: resources/public/pebble_templates/profile.html
+#: resources/public/include/chat.js
 Delete=Supprimer
 
-#: resources/public/pebble_templates/profile.html:246:174
+#: resources/public/pebble_templates/profile.html
 Leave=Quitter
 
-#: resources/public/pebble_templates/profile.html:253:68
+#: resources/public/pebble_templates/profile.html
 You\ are\ not\ in\ any\ factions\ yet\!=Tu n'es pas encore dans une faction \!
 
-#: resources/public/pebble_templates/profile.html:269:52
+#: resources/public/pebble_templates/profile.html
 Members\ of\ {0}\ ([{1}])=Membres de {0} ([{1}])
 
-#: resources/public/pebble_templates/profile.html:270:97
-#: resources/public/pebble_templates/profile.html:329:97
-#: resources/public/pebble_templates/profile.html:342:97
-#: resources/public/pebble_templates/profile.html:366:97
+#: resources/public/pebble_templates/profile.html
 Close=Fermer
 
-#: resources/public/pebble_templates/profile.html:278:60
+#: resources/public/pebble_templates/profile.html
 Faction\ Members=Membres de la Faction
 
-#: resources/public/pebble_templates/profile.html:292:128
+#: resources/public/pebble_templates/profile.html
 Transfer\ Ownership=Transf\u00e9rer la possession
 
 #. bans a user from the faction
-#: resources/public/pebble_templates/profile.html:294:122
-#: resources/public/include/chat.js:1733:60
+#: resources/public/pebble_templates/profile.html
+#: resources/public/include/chat.js
 Ban=Exclure
 
-#: resources/public/pebble_templates/profile.html:300:79
-#: resources/public/pebble_templates/profile.html:322:79
+#: resources/public/pebble_templates/profile.html
 Nothing\ to\ see\ here\!=Rien \u00e0 voir ici \!
 
-#: resources/public/pebble_templates/profile.html:308:60
+#: resources/public/pebble_templates/profile.html
 Faction\ Bans=Bannissements de la Faction
 
-#: resources/public/pebble_templates/profile.html:318:125
-#: resources/public/include/chat.js:1629:36
-#: resources/public/include/chat.js:1733:46
-#: resources/public/admin/admin.js:320:88
-#: resources/public/admin/admin.js:347:52
+#: resources/public/pebble_templates/profile.html
+#: resources/public/include/chat.js resources/public/admin/admin.js
 Unban=R\u00e9voquer le bannissement
 
-#: resources/public/pebble_templates/profile.html:341:52
+#: resources/public/pebble_templates/profile.html
 Find\ A\ Faction=Trouver une Faction
 
-#: resources/public/pebble_templates/profile.html:351:99
+#: resources/public/pebble_templates/profile.html
 Search\:=Rechercher \:
 
-#: resources/public/pebble_templates/profile.html:361:66
+#: resources/public/pebble_templates/profile.html
 Enter\ a\ search\ term\ to\ get\ started.=Entre un terme de recherche ici pour d\u00e9buter.
 
-#: resources/public/pebble_templates/profile.html:363:116
+#: resources/public/pebble_templates/profile.html
 Load\ More=Charger plus
 
 #. HTTP status code name
-#: resources/public/pebble_templates/40x.html:39:24
+#: resources/public/pebble_templates/40x.html
 Not\ Found=Pas trouv\u00e9
 
-#: resources/public/pebble_templates/40x.html:41:23
+#: resources/public/pebble_templates/40x.html
 The\ content\ you\ requested\ could\ not\ be\ found\ at\ this\ URL.\ If\ you\ believe\ this\ is\ an\ error,\ please\ contact\ a\ developer.=Le contenu que tu as demand\u00e9 n'a pas pu \u00eatre trouv\u00e9 sur ce lien. Si tu penses que c'est un erreur, merci de contacter un d\u00e9veloppeur.
 
 #. links to the homepage (the app itself)
-#: resources/public/pebble_templates/40x.html:44:99
-#: resources/public/pebble_templates/40x.html:53:99
-#: resources/public/pebble_templates/40x.html:61:99
+#: resources/public/pebble_templates/40x.html
 Back\ to\ Pxls=Retourner sur Pxls
 
 #. HTTP status code name
-#: resources/public/pebble_templates/40x.html:49:24
+#: resources/public/pebble_templates/40x.html
 Not\ Authenticated=Non Authentifi\u00e9
 
-#: resources/public/pebble_templates/40x.html:51:23
+#: resources/public/pebble_templates/40x.html
 You\ must\ be\ logged\ in\ to\ access\ this\ data.\ Please\ go\ back\ to\ pxls\ and\ go\ through\ the\ authentication\ process.=Tu dois \u00eatre connect\u00e9 pour acc\u00e9der cette information. Merci de retourner sur Pxls et de poursuivre le processus d'authentification. 
 
 #. HTTP status code name
-#: resources/public/pebble_templates/40x.html:57:24
+#: resources/public/pebble_templates/40x.html
 Not\ Allowed=Non Autoris\u00e9
 
-#: resources/public/pebble_templates/40x.html:59:23
+#: resources/public/pebble_templates/40x.html
 The\ action\ you\ attempted\ to\ perform\ is\ not\ allowed\ or\ resulted\ in\ an\ error.\ Please\ ensure\ you\ have\ access\ to\ the\ endpoint\ and\ try\ again\ later.=L'action que tu essayes d'effectuer n'est pas permise ou une erreur est survenue. Merci de t'assurer que tu as l'acc\u00e8s n\u00e9cessaire et de r\u00e9essayer plus tard.
 
-#: resources/public/pxls.js:134:38
+#: resources/public/pxls.js
 Alert=Alerte
 
 #. Snapshot save name
-#: resources/public/include/board.js:806:100
+#: resources/public/include/board.js
 pxls\ canvas=canvas de pxls
 
 #. template link action
-#: resources/public/include/chat.js:80:21
+#: resources/public/include/chat.js
 Ask=Demander
 
-#: resources/public/include/chat.js:84:21
+#: resources/public/include/chat.js
 Open\ in\ a\ new\ tab=Ouvrir dans un nouvel onglet
 
-#: resources/public/include/chat.js:88:21
+#: resources/public/include/chat.js
 Open\ in\ current\ tab\ (replacing\ template)=Ouvrir dans cet onglet (en rempla\u00e7ant le mod\u00e8le)
 
-#: resources/public/include/chat.js:92:21
+#: resources/public/include/chat.js
 Jump\ to\ coordinates\ without\ replacing\ template=Aller aux coordonn\u00e9es sans remplacer le mod\u00e8le
 
-#: resources/public/include/chat.js:437:55
-#: resources/public/include/chat.js:956:53
+#: resources/public/include/chat.js
 !You\ must\ be\ logged\ in\ to\ chat.=
 
-#: resources/public/include/chat.js:1260:42
-#: resources/public/include/chat.js:1753:27
+#: resources/public/include/chat.js
 none\ provided=aucune donn\u00e9e
 
-#: resources/public/include/chat.js:1261:38
+#: resources/public/include/chat.js
 Purged\ by\ ${purge.initiator}\ with\ reason\:\ ${reason}=Purg\u00e9 par ${purge.initiator} pour la raison\: ${reason}
 
-#: resources/public/include/chat.js:1279:26
+#: resources/public/include/chat.js
 template\:=mod\u00e8le \:
 
-#: resources/public/include/chat.js:1331:56
-#: resources/public/include/chat.js:2057:56
+#: resources/public/include/chat.js
 Open\ Failed=\u00c9chec de l'ouverture
 
-#: resources/public/include/chat.js:1333:32
-#: resources/public/include/chat.js:2059:32
+#: resources/public/include/chat.js
 Failed\ to\ automatically\ open\ in\ a\ new\ tab=\u00c9chec de l'ouverture automatique dans un nouvel onglet
 
-#: resources/public/include/chat.js:1337:24
-#: resources/public/include/chat.js:2063:24
+#: resources/public/include/chat.js
 Click\ here\ to\ open\ in\ a\ new\ tab\ instead=Clique ici pour ouvrir dans un nouveau onglet \u00e0 la place
 
-#: resources/public/include/chat.js:1351:52
+#: resources/public/include/chat.js
 Open\ Template=Ouvrir le Mod\u00e8le
 
-#: resources/public/include/chat.js:1353:54
+#: resources/public/include/chat.js
 This\ link\ will\ overwrite\ your\ current\ template.\ What\ would\ you\ like\ to\ do?=Ce lien va \u00e9craser ton mod\u00e8le actuel. Que voudrais-tu faire ?
 
-#: resources/public/include/chat.js:1364:55
+#: resources/public/include/chat.js
 Note\:\ You\ can\ set\ a\ default\ action\ in\ the\ settings\ menu\ which\ bypasses\ this\ popup\ completely.=Note \: Tu peux d\u00e9finir une action par d\u00e9faut dans les param\u00e8tres qui passera ce pop-up.
 
-#: resources/public/include/chat.js:1455:24
-#: resources/public/include/chat.js:1534:18
-#: resources/public/include/lookup.js:18:90
+#: resources/public/include/chat.js resources/public/include/lookup.js
 Report=Signaler
 
-#: resources/public/include/chat.js:1456:24
+#: resources/public/include/chat.js
 Mention=Mentionner
 
-#: resources/public/include/chat.js:1457:24
+#: resources/public/include/chat.js
 Ignore=Ignorer
 
-#: resources/public/include/chat.js:1458:102
-#: resources/public/admin/admin.js:193:16
+#: resources/public/include/chat.js resources/public/admin/admin.js
 Profile=Profil
 
-#: resources/public/include/chat.js:1459:24
+#: resources/public/include/chat.js
 Chat\ (un)ban=Bannir/R\u00e9voquer le bannissement du chat
 
-#: resources/public/include/chat.js:1461:43
-#: resources/public/include/chat.js:1911:54
+#: resources/public/include/chat.js
 Purge\ User=Purger l'utilisateur
 
-#: resources/public/include/chat.js:1463:24
+#: resources/public/include/chat.js
 Mod\ Lookup=Inspection mod\u00e9rateur
 
-#: resources/public/include/chat.js:1464:24
+#: resources/public/include/chat.js
 Chat\ Lookup=Inspection du chat
 
-#: resources/public/include/chat.js:1536:30
+#: resources/public/include/chat.js
 Enter\ a\ reason\ for\ your\ report=Entre une raison pour ton signalement
 
-#: resources/public/include/chat.js:1565:26
-#: resources/public/include/chat.js:1686:18
-#: resources/public/include/chat.js:1845:22
-#: resources/public/include/chat.js:1893:22
-#: resources/public/include/chat.js:1961:22
-#: resources/public/include/chat.js:2021:22
-#: resources/public/include/lookup.js:64:91
-#: resources/public/include/user.js:73:87
-#: resources/public/admin/admin.js:334:20
+#: resources/public/include/chat.js resources/public/include/lookup.js
+#: resources/public/include/user.js resources/public/admin/admin.js
 Cancel=Annuler
 
-#: resources/public/include/chat.js:1580:34
-#: resources/public/include/lookup.js:45:30
+#: resources/public/include/chat.js resources/public/include/lookup.js
 Error\ sending\ report.=Erreur lors de l'envoi du signalement.
 
-#: resources/public/include/chat.js:1585:54
+#: resources/public/include/chat.js
 Report\ User=Signaler l'utilisateur
 
-#: resources/public/include/chat.js:1599:34
+#: resources/public/include/chat.js
 User\ ignored.\ You\ can\ unignore\ from\ chat\ settings.=Utilisateur ignor\u00e9. Tu peux le d\u00e9signorer dans les param\u00e8tres du chat.
 
-#: resources/public/include/chat.js:1601:34
+#: resources/public/include/chat.js
 Failed\ to\ ignore\ user.\ Either\ they\\'re\ already\ ignored,\ or\ an\ error\ occurred.\ If\ the\ problem\ persists,\ contact\ a\ developer.=\u00c9chec \u00e0 ignorer l'utilisateur. Il/elle est d\u00e9j\u00e0 ignor\u00e9(e), ou une erreur s'est produite. Si le probl\u00e8me persiste, merci de contacter un d\u00e9veloppeur.
 
-#: resources/public/include/chat.js:1629:55
+#: resources/public/include/chat.js
 Permanent=Permanent
 
-#: resources/public/include/chat.js:1629:78
+#: resources/public/include/chat.js
 Temporary=Temporaire
 
-#: resources/public/include/chat.js:1656:32
+#: resources/public/include/chat.js
 Rule\ 3\:\ Spam=R\u00e8gle 3 \: Spam
 
-#: resources/public/include/chat.js:1657:32
+#: resources/public/include/chat.js
 Rule\ 1\:\ Chat\ civility=R\u00e8gle 1 \: Civilit\u00e9 du chat
 
-#: resources/public/include/chat.js:1658:32
+#: resources/public/include/chat.js
 Rule\ 2\:\ Hate\ Speech=R\u00e8gle 2 \: Propos haineux
 
-#: resources/public/include/chat.js:1659:32
+#: resources/public/include/chat.js
 Rule\ 5\:\ NSFW=R\u00e8gle 5 \: NSFW
 
-#: resources/public/include/chat.js:1660:32
-#: resources/public/include/chat.js:1738:58
-#: resources/public/include/chat.js:1759:45
+#: resources/public/include/chat.js
 Custom=Personalis\u00e9e
 
-#: resources/public/include/chat.js:1693:33
+#: resources/public/include/chat.js
 Banning\:=Bannir \:
 
-#: resources/public/include/chat.js:1693:50
+#: resources/public/include/chat.js
 Message\:=Message \:
 
-#: resources/public/include/chat.js:1695:26
+#: resources/public/include/chat.js
 Ban\ Length=Dur\u00e9e du bannissement
 
-#: resources/public/include/chat.js:1702:28
+#: resources/public/include/chat.js
 Reason=Raison
 
-#: resources/public/include/chat.js:1707:28
+#: resources/public/include/chat.js
 Purge\ Messages=Purger les messages
 
-#: resources/public/include/chat.js:1711:27
+#: resources/public/include/chat.js
 Purging\ all\ messages\ is\ disabled\ during\ snip\ mode=La purge de tous les messages est d\u00e9sactiv\u00e9e en mode snip
 
-#: resources/public/include/chat.js:1714:79
-#: resources/public/include/user.js:174:22
-#: resources/public/admin/admin.js:185:41
-#: resources/public/admin/admin.js:187:94
+#: resources/public/include/chat.js resources/public/include/user.js
+#: resources/public/admin/admin.js
 Yes=Oui
 
-#: resources/public/include/chat.js:1715:78
-#: resources/public/include/user.js:178:22
-#: resources/public/admin/admin.js:185:53
-#: resources/public/admin/admin.js:187:106
+#: resources/public/include/chat.js resources/public/include/user.js
+#: resources/public/admin/admin.js
 No=Non
 
-#: resources/public/include/chat.js:1739:63
+#: resources/public/include/chat.js
 Custom\ reason=Raison personalis\u00e9e
 
-#: resources/public/include/chat.js:1739:85
-#: resources/public/include/lookup.js:59:30
+#: resources/public/include/chat.js resources/public/include/lookup.js
 Additional\ information\ (if\ applicable)=Information suppl\u00e9mentaire (si applicable)
 
-#: resources/public/include/chat.js:1764:45
+#: resources/public/include/chat.js
 Additional\ information\:=Information suppl\u00e9mentaire \:
 
-#: resources/public/include/chat.js:1786:34
+#: resources/public/include/chat.js
 Error\ occurred\ while\ chatbanning=Une erreur s'est produite lors du bannissement de chat
 
-#: resources/public/include/chat.js:1790:54
+#: resources/public/include/chat.js
 Chatban=Bannissement du chat
 
-#: resources/public/include/chat.js:1810:32
+#: resources/public/include/chat.js
 Failed\ to\ delete=\u00c9chec de la suppression
 
-#: resources/public/include/chat.js:1821:32
-#: resources/public/include/chat.js:1863:32
+#: resources/public/include/chat.js
 ID\:\ =ID \:
 
-#: resources/public/include/chat.js:1825:32
-#: resources/public/include/chat.js:1873:32
+#: resources/public/include/chat.js
 User\:\ =Utilisateur \:
 
-#: resources/public/include/chat.js:1829:32
-#: resources/public/include/chat.js:1867:32
+#: resources/public/include/chat.js
 Message\:\ =Message \:
 
-#: resources/public/include/chat.js:1833:32
+#: resources/public/include/chat.js
 Reason\:\ =Raison \:
 
-#: resources/public/include/chat.js:1850:54
+#: resources/public/include/chat.js
 Delete\ Message=Supprimer le message \:
 
-#: resources/public/include/chat.js:1858:106
+#: resources/public/include/chat.js
 Purge=Purger
 
-#: resources/public/include/chat.js:1879:28
+#: resources/public/include/chat.js
 Selected\ Message=Message s\u00e9lectionn\u00e9
 
-#: resources/public/include/chat.js:1882:30
+#: resources/public/include/chat.js
 Purge\ Reason=Raison de la purge
 
-#: resources/public/include/chat.js:1907:34
+#: resources/public/include/chat.js
 Error\ sending\ purge.=Erreur lors de l'envoi de la purge
 
-#: resources/public/include/chat.js:1936:98
+#: resources/public/include/chat.js
 On=Activ\u00e9
 
-#: resources/public/include/chat.js:1949:28
+#: resources/public/include/chat.js
 Toggle\ Rename\ Request=Activer/D\u00e9sactiver la demande de renommage
 
-#: resources/public/include/chat.js:1950:27
+#: resources/public/include/chat.js
 Select\ one\ of\ the\ options\ below\ to\ set\ the\ current\ rename\ request\ state.=S\u00e9lectionner une des options ci-dessous pour d\u00e9finir le statut actuel de la demande de renommage
 
-#: resources/public/include/chat.js:1975:30
-#: resources/public/include/chat.js:2034:30
+#: resources/public/include/chat.js
 An\ unknown\ error\ occurred.\ Please\ contact\ a\ developer=Une erreur inconnue s'est produite. Merci de contacter un d\u00e9veloppeur.
 
-#: resources/public/include/chat.js:2001:52
+#: resources/public/include/chat.js
 New\ Name\:\ =Nouveau Nom \:
 
-#: resources/public/include/chat.js:2011:27
+#: resources/public/include/chat.js
 Enter\ the\ new\ name\ for\ the\ user\ below.\ Please\ note\ that\ if\ you\\'re\ trying\ to\ change\ the\ caps,\ you\\'ll\ have\ to\ rename\ to\ something\ else\ first.=Entre un nouveau nom pour l'utilisateur ci-dessous. Merci de prendre en compte que si tu essaies de changer la capitalization, il te faudra d'abord renommer en quelque chose d'autre.
 
-#: resources/public/include/chat.js:2049:54
+#: resources/public/include/chat.js
 Force\ Rename=Forcer le renommage
 
-#: resources/public/include/chat.js:2088:118
+#: resources/public/include/chat.js
 You\ cannot\ use\ chat\ while\ canvas\ banned.=Tu ne peux pas utiliser le chat si tu es banni sur le canvas.
 
-#: resources/public/include/lookup.js:21:32
+#: resources/public/include/lookup.js
 Sending...=Envoi...
 
-#: resources/public/include/lookup.js:28:32
+#: resources/public/include/lookup.js
 You\ must\ specify\ the\ details.=Tu dois sp\u00e9cifier les d\u00e9tails.
 
-#: resources/public/include/lookup.js:33:27
+#: resources/public/include/lookup.js
 additional\ information\:=information suppl\u00e9mentaire \:
 
-#: resources/public/include/lookup.js:49:50
+#: resources/public/include/lookup.js
 Report\ Pixel=Signaler un pixel
 
-#: resources/public/include/lookup.js:52:32
+#: resources/public/include/lookup.js
 Rule\ \#1\:\ Hateful/derogatory\ speech\ or\ symbols=R\u00e8gle \#1 \: Propos ou symboles haineux/d\u00e9rogatoires
 
-#: resources/public/include/lookup.js:53:32
+#: resources/public/include/lookup.js
 Rule\ \#2\:\ Nudity,\ genitalia,\ or\ non-PG-13\ content=R\u00e8gle \#2 \: Nudit\u00e9, organes g\u00e9nitaux ou contenu non adapt\u00e9 aux mineurs
 
-#: resources/public/include/lookup.js:54:32
+#: resources/public/include/lookup.js
 Rule\ \#3\:\ Multi-account=R\u00e8gle \#3 \: Multi-compte
 
-#: resources/public/include/lookup.js:55:32
+#: resources/public/include/lookup.js
 Rule\ \#4\:\ Botting=R\u00e8gle \#4 \: Usage de bot
 
-#: resources/public/include/lookup.js:56:52
+#: resources/public/include/lookup.js
 Other\ (specify\ below)=Autre (pr\u00e9ciser ci-dessous)
 
-#: resources/public/include/lookup.js:168:62
+#: resources/public/include/lookup.js
 Hide\ sensitive\ information=Cacher les informations sensibles
 
-#: resources/public/include/lookup.js:207:120
+#: resources/public/include/lookup.js
 An\ error\ occurred,\ either\ you\ aren't\ logged\ in\ or\ you\ may\ be\ attempting\ to\ look\ up\ users\ too\ fast.\ Please\ try\ again\ in\ 60\ seconds=Une erreur s'est produite, tu n'es pas connect\u00e9 ou tu essaies d'inspecter des pixels trop rapidement. Merci de r\u00e9essayer dans 60 secondes
 
-#: resources/public/include/lookup.js:218:21
+#: resources/public/include/lookup.js
 Coords=Coordonn\u00e9es
 
-#: resources/public/include/lookup.js:223:21
-#: resources/public/admin/admin.js:189:16
+#: resources/public/include/lookup.js resources/public/admin/admin.js
 Username=Nom d'utilisateur
 
-#: resources/public/include/lookup.js:229:28
+#: resources/public/include/lookup.js
 View\ Profile=Voir le profil
 
-#: resources/public/include/lookup.js:239:21
+#: resources/public/include/lookup.js
 Origin=Origine
 
-#: resources/public/include/lookup.js:243:28
+#: resources/public/include/lookup.js
 Part\ of\ a\ nuke=Fait partie d'un nuke
 
-#: resources/public/include/lookup.js:245:28
+#: resources/public/include/lookup.js
 Placed\ by\ a\ staff\ member\ using\ placement\ overrides=Plac\u00e9 par un membre de l'\u00e9quipe avec les outils du staff
 
-#: resources/public/include/lookup.js:252:21
+#: resources/public/include/lookup.js
 Time=Horaire
 
-#: resources/public/include/lookup.js:263:36
+#: resources/public/include/lookup.js
 just\ now=\u00e0 l'instant
 
-#: resources/public/include/lookup.js:271:36
+#: resources/public/include/lookup.js
 ${hoursStr}\:${minuteStr}\:${secsStr}\ ago=il y a ${hoursStr}\:${minuteStr}\:${secsStr}
 
-#: resources/public/include/lookup.js:284:21
+#: resources/public/include/lookup.js
 Discord=Discord
 
-#: resources/public/include/notifications.js:60:58
+#: resources/public/include/notifications.js
 Posted\ by\ ${notification.who}=Post\u00e9 par ${notification.who}
 
-#: resources/public/include/notifications.js:63:111
+#: resources/public/include/notifications.js
 Expires\ ${expiry}=Expire \u00e0
 
-#: resources/public/include/template.js:440:50
+#: resources/public/include/template.js
 There\ was\ an\ error\ getting\ the\ image=Erreur \u00e0 l'obtention de l'image
 
-#: resources/public/include/timer.js:42:53
+#: resources/public/include/timer.js
 Your\ next\ pixel\ will\ be\ available\ in\ ${delay}\ seconds\!=Ton prochain pixel sera disponible dans ${delay} secondes \!
 
-#: resources/public/include/timer.js:87:61
+#: resources/public/include/timer.js
 Your\ next\ pixel\ has\ been\ available\ for\ ${alertDelay}\ seconds\!=Ton nouveau pixel est disponible depuis ${alertDelay} secondes \!
 
-#: resources/public/include/timer.js:101:59
+#: resources/public/include/timer.js
 Your\ next\ pixel\ is\ available\!=Ton prochain pixel est disponible \!
 
 #. theme name
-#: resources/public/include/uiHelper.js:48:19
+#: resources/public/include/uiHelper.js
 Dark=Sombre
 
 #. theme name
-#: resources/public/include/uiHelper.js:54:19
+#: resources/public/include/uiHelper.js
 Darker=Plus sombre
 
 #. theme name
-#: resources/public/include/uiHelper.js:60:19
+#: resources/public/include/uiHelper.js
 Blue=Bleu
 
 #. theme name
-#: resources/public/include/uiHelper.js:66:19
+#: resources/public/include/uiHelper.js
 Purple=Violet
 
 #. theme name
-#: resources/public/include/uiHelper.js:72:19
+#: resources/public/include/uiHelper.js
 Green=Vert
 
 #. theme name
-#: resources/public/include/uiHelper.js:78:19
+#: resources/public/include/uiHelper.js
 Matte=Mat
 
 #. theme name
-#: resources/public/include/uiHelper.js:84:19
+#: resources/public/include/uiHelper.js
 Terminal=Terminal
 
 #. theme name
-#: resources/public/include/uiHelper.js:90:19
+#: resources/public/include/uiHelper.js
 Red=Rouge
 
-#: resources/public/include/uiHelper.js:467:30
+#: resources/public/include/uiHelper.js
 Discord\ name\ updated\ successfully=Le nom Discord a bien \u00e9t\u00e9 mis \u00e0 jour
 
-#: resources/public/include/uiHelper.js:474:32
+#: resources/public/include/uiHelper.js
 Couldn\\'t\ change\ discord\ name\:\ =\u00c9chec du changement du nom Discord
 
-#: resources/public/include/user.js:81:28
+#: resources/public/include/user.js
 Sign\ in\ with...=Se connecter avec...
 
-#: resources/public/include/user.js:94:149
+#: resources/public/include/user.js
 New\ Accounts\ Disabled=Nouveaux comptes d\u00e9sactiv\u00e9s
 
-#: resources/public/include/user.js:167:52
+#: resources/public/include/user.js
 Sign\ Out=Se d\u00e9connecter
 
-#: resources/public/include/user.js:169:27
+#: resources/public/include/user.js
 Are\ you\ sure\ you\ want\ to\ sign\ out?=Es-tu s\u00fbr(e) de vouloir te d\u00e9connecter ?
 
-#: resources/public/include/user.js:223:39
+#: resources/public/include/user.js
 You\ are\ permanently\ banned.=Tu es banni d\u00e9finitivement.
 
-#: resources/public/include/user.js:227:39
+#: resources/public/include/user.js
 You\ are\ temporarily\ banned\ and\ will\ not\ be\ allowed\ to\ place\ until\ ${timestamp}=Tu es banni temporairement et ne pourra pas placer de pixel jusqu'\u00e0 ${timestamp}
 
-#: resources/public/include/user.js:255:27
+#: resources/public/include/user.js
 If\ you\ think\ this\ was\ an\ error,\ please\ contact\ us\ using\ one\ of\ the\ links\ in\ the\ info\ tab.=Si tu penses que ceci est une erreur, merci de nous contacter en utilisant un des liens dans la barre d'informations.
 
-#: resources/public/include/user.js:256:27
+#: resources/public/include/user.js
 Ban\ reason\:=Raison du bannissement \:
 
-#: resources/public/include/user.js:260:28
-#: resources/public/admin/admin.js:203:16
+#: resources/public/include/user.js resources/public/admin/admin.js
 Banned=Banni
 
-#: resources/public/include/user.js:330:23
+#: resources/public/include/user.js
 Staff\ have\ required\ you\ to\ change\ your\ username,\ this\ usually\ means\ your\ name\ breaks\ one\ of\ our\ rules.=Le staff te demande de changer de nom d'utilisateur, ceci signifie g\u00e9n\u00e9ralement que ton nom enfreint une de nos r\u00e8gles.
 
-#: resources/public/include/user.js:331:23
+#: resources/public/include/user.js
 If\ you\ disagree,\ please\ contact\ us\ on\ Discord\ (link\ in\ the\ info\ panel).=Si tu n'es pas d'accord, merci de nous contacter sur Discord (lien dans la barre d'informations).
 
-#: resources/public/include/user.js:332:27
+#: resources/public/include/user.js
 New\ Username\:=Nouveau nom d'utilisateur \:
 
-#: resources/public/include/user.js:345:89
+#: resources/public/include/user.js
 Not\ now=Pas maintenant
 
-#: resources/public/include/user.js:346:86
+#: resources/public/include/user.js
 Change=Changer
 
-#: resources/public/include/user.js:350:50
-#: resources/public/admin/admin.js:201:16
+#: resources/public/include/user.js resources/public/admin/admin.js
 Rename\ Requested=Renommage demand\u00e9
 
-#: resources/public/admin/admin.js:101:38
+#: resources/public/admin/admin.js
 Something\ went\ wrong\!\ Perhaps\ insufficient\ permissions?=Il y a eu un probl\u00e8me \! Peut-\u00eatre un manque de permissions ?
 
-#: resources/public/admin/admin.js:106:45
+#: resources/public/admin/admin.js
 Shadowban\ user=Shadowban l'utilisateur
 
-#: resources/public/admin/admin.js:106:67
+#: resources/public/admin/admin.js
 Shadowbanned\ user=L'utilisateur a \u00e9t\u00e9 shadowban
 
-#: resources/public/admin/admin.js:109:45
+#: resources/public/admin/admin.js
 Permaban\ user=Bannir l'utilisateur d\u00e9finitivement
 
-#: resources/public/admin/admin.js:109:66
+#: resources/public/admin/admin.js
 Permabanned\ user=L'utilisateur a \u00e9t\u00e9 banni d\u00e9finitivement
 
-#: resources/public/admin/admin.js:112:45
+#: resources/public/admin/admin.js
 Ban\ user=Bannir l'utilisateur
 
-#: resources/public/admin/admin.js:112:61
+#: resources/public/admin/admin.js
 Banned\ user=L'utilisateur a \u00e9t\u00e9 banni
 
-#: resources/public/admin/admin.js:126:36
+#: resources/public/admin/admin.js
 Unbanned\ user\ ${username}=L'utilisateur ${username} n'est plus banni
 
 #. Context: ban type
-#: resources/public/admin/admin.js:179:27
+#: resources/public/admin/admin.js
 shadow=shadow
 
-#: resources/public/admin/admin.js:180:29
-#: resources/public/admin/admin.js:183:29
+#: resources/public/admin/admin.js
 never=jamais
 
-#: resources/public/admin/admin.js:182:27
+#: resources/public/admin/admin.js
 permanent=d\u00e9finitif
 
-#: resources/public/admin/admin.js:187:51
+#: resources/public/admin/admin.js
 Yes\ (permanent)=Oui (d\u00e9finitif)
 
-#: resources/public/admin/admin.js:194:16
-#: resources/public/admin/admin.js:454:21
+#: resources/public/admin/admin.js
 Logins=Logins
 
-#: resources/public/admin/admin.js:200:16
+#: resources/public/admin/admin.js
 All\ Time\ Pixels=Pixels totaux
 
-#: resources/public/admin/admin.js:202:16
+#: resources/public/admin/admin.js
 Discord\ Name=Nom Discord
 
-#: resources/public/admin/admin.js:204:16
+#: resources/public/admin/admin.js
 Chatbanned=Banni du chat
 
-#: resources/public/admin/admin.js:207:27
+#: resources/public/admin/admin.js
 Ban\ Reason=Raison du bannissement
 
-#: resources/public/admin/admin.js:208:27
+#: resources/public/admin/admin.js
 Ban\ Expiracy=Expiration du bannissement
 
-#: resources/public/admin/admin.js:211:27
+#: resources/public/admin/admin.js
 Chatban\ Reason=Raison du bannissement du chat
 
-#: resources/public/admin/admin.js:211:102
+#: resources/public/admin/admin.js
 (canvas\ ban)=(bannissement de canvas)
 
-#: resources/public/admin/admin.js:213:97
+#: resources/public/admin/admin.js
 when\ canvas\ ban\ ends=quand le bannissement de canvas prend fin
 
-#: resources/public/admin/admin.js:214:29
+#: resources/public/admin/admin.js
 Chatban\ Expires=Expiration du bannissement de chat
 
 #. Admin check. Example: type = 'username', arg = 'pxlsuser94'
-#: resources/public/admin/admin.js:316:36
+#: resources/public/admin/admin.js
 ${type}\ ${arg}\ not\ found.=${type} ${arg} non trouv\u00e9
 
-#: resources/public/admin/admin.js:322:50
+#: resources/public/admin/admin.js
 Unban\ Reason\:=Raison de la r\u00e9vocation du bannissement
 
-#: resources/public/admin/admin.js:327:25
+#: resources/public/admin/admin.js
 Unbanning\ ${username}=R\u00e9vocation du bannissement de ${username}
 
-#: resources/public/admin/admin.js:449:20
+#: resources/public/admin/admin.js
 profile=profil
 
-#: resources/public/admin/admin.js:473:21
+#: resources/public/admin/admin.js
 User\ Agent=Agent Utilisateur
 
-#: resources/public/admin/admin.js:478:21
+#: resources/public/admin/admin.js
 Send\ Alert=Envoyer une alerte
 
-#: resources/public/admin/admin.js:483:21
+#: resources/public/admin/admin.js
 Mod\ Actions=Actions mod\u00e9rateur


### PR DESCRIPTION
Linenumber and position are cool to have, but they cause too much noise in localization updates. Since filepaths tend not to change as often, those are kept.