### PR TITLE
Fix `negotiateLocale` erroring when no locales are requested

### DIFF
--- a/src/main/java/space/pxls/util/Util.java
+++ b/src/main/java/space/pxls/util/Util.java
@@ -45,9 +45,12 @@ public class Util {
     public static Locale negotiateLocale(HttpServerExchange exchange) {
         List<Locale> locales = LocaleUtils.getLocalesFromHeader(exchange.getRequestHeaders().get(Headers.ACCEPT_LANGUAGE));
         locales.retainAll(SUPPORTED_LOCALES);
-        locales.add(FALLBACK_LOCALE);
-
-        return locales.get(0);
+        
+        if (locales.size() > 0) {
+            return locales.get(0);
+        } else {
+            return FALLBACK_LOCALE;
+        }
     }
 
     public static List<Locale> SUPPORTED_LOCALES = List.of(Locale.forLanguageTag("en-US"), Locale.forLanguageTag("fr-FR"));


### PR DESCRIPTION
I still don't really know why this errored — my best guess is that `getLocalesFromHeader` returns some sort of immutable list when empty for some reason. That wouldn't explain `retainAll` working just fine though, so I really don't know.

Anyway, this fixes it.