### PR TITLE
Don't copy coordinates when ⌘ is held

### DIFF
--- a/resources/public/include/coords.js
+++ b/resources/public/include/coords.js
@@ -45,7 +45,7 @@ module.exports.coords = (function() {
           return;
         }
 
-        if (!event.ctrlKey && (event.key === 'c' || event.key === 'C' || event.keyCode === 67)) {
+        if (!event.ctrlKey && !event.metaKey && (event.key === 'c' || event.key === 'C' || event.keyCode === 67)) {
           self.copyCoords();
         }
       });


### PR DESCRIPTION
This will also have the side-effect of preventing copying the coordinates when the windows key is held on windows. I don't foresee that being an issue, but it is probably technically incorrect.

Closes #489.