### PR TITLE
Fix the canvas getting locked when pressing 'R' without template on a new tab

### DIFF
--- a/resources/public/include/template.js
+++ b/resources/public/include/template.js
@@ -103,8 +103,6 @@ module.exports.template = (function() {
       if (self.corsProxy.base !== undefined) {
         self.loading = true;
 
-        self.options.use = true;
-
         self.elements.imageErrorWarning.empty();
         self.elements.imageErrorWarning.hide();
 


### PR DESCRIPTION
This was due to the template always being displayed on init so if there was not actually a template, the coords were undefined which locks the canvas.