### PR TITLE
Allow CORS for GET on /notifications

### DIFF
--- a/src/main/java/space/pxls/server/WebHandler.java
+++ b/src/main/java/space/pxls/server/WebHandler.java
@@ -1458,7 +1458,9 @@ public class WebHandler {
     }
 
     public void notificationsList(HttpServerExchange exchange) {
-        exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "application/json");
+        exchange.getResponseHeaders()
+            .put(Headers.CONTENT_TYPE, "application/json")
+            .add(HttpString.tryFromString("Access-Control-Allow-Origin"), "*");
         exchange.setStatusCode(200);
         exchange.getResponseSender().send(App.getGson().toJson(App.getDatabase().getNotifications(false)));
         exchange.endExchange();


### PR DESCRIPTION
This allows third-party web applications to fetch this endpoint and provide info based on it.