### PR TITLE
Improve panel header responsiveness

### DIFF
--- a/resources/public/include/modal.js
+++ b/resources/public/include/modal.js
@@ -1,18 +1,7 @@
 const modal = (function() {
   return {
     showText: function(text, opts) {
-      opts = Object.assign({}, { title: 'Pxls', footerButtons: [], modalOpts: {} }, opts);
-      if (opts.footerButtons != null && !Array.isArray(opts.footerButtons)) {
-        if (!(opts.footerButtons instanceof HTMLElement)) throw new Error('Invalid footerButtons provided. Expected HTMLElement[]');
-        opts.footerButtons = [opts.footerButtons];
-      }
-      /* let footer;
-      if (Array.isArray(opts.footerButtons)) {
-        const validButtons = opts.footerButtons.filter(x => x instanceof HTMLElement);
-        if (validButtons.length > 0) {
-          footer = crel('div', { class: 'modal-footer' }, validButtons);
-        }
-      } */
+      opts = Object.assign({}, { title: 'Pxls', modalOpts: {} }, opts);
       return modal.show(modal.buildDom(
         crel('h2', { class: 'modal-title' }, opts.title || 'Pxls'),
         crel('p', { style: 'margin: 0;' }, text)
@@ -43,15 +32,14 @@ const modal = (function() {
       button.addEventListener('click', () => modal.closeTop());
       return button;
     },
-    buildDom: function(headerContent, bodyContent, footerContent) {
+    buildDom: function(headerContent, bodyContent) {
       return crel('div', { class: 'modal panel', tabindex: '-1', role: 'dialog' },
         crel('div', { class: 'modal-wrapper', role: 'document' },
           headerContent == null ? null : crel('header', { class: 'modal-header panel-header' },
             crel('div', { class: 'left' }),
             crel('div', { class: 'mid' }, headerContent),
             crel('div', { class: 'right' }, this.buildCloser())),
-          bodyContent == null ? null : crel('div', { class: 'modal-body panel-body' }, bodyContent),
-          footerContent == null ? null : crel('footer', { class: 'modal-footer panel-footer' }, footerContent)
+          bodyContent == null ? null : crel('div', { class: 'modal-body panel-body' }, bodyContent)
         )
       );
     },

--- a/resources/public/pebble_templates/index.html
+++ b/resources/public/pebble_templates/index.html
@@ -151,7 +151,10 @@
     <header class="panel-header">
         <div class="left"></div>
         <div class="mid">
-            <h2><i class="fas fa-info-circle fa-is-left"></i>{{i18n('Localization', 'Info') | raw}}</h2>
+            <h2>
+                <i class="fas fa-info-circle fa-is-left"></i>
+                <span class="panel-title">{{i18n('Localization', 'Info') | raw}}</span>
+            </h2>
         </div>
         <div class="right">
             <button type="button" class="panel-closer"><i class="fas fa-times"></i></button>
@@ -167,7 +170,11 @@
         <div class="left">
             <button type="button" class="panel-closer" title="{{i18n('Localization', 'Close Panel') | raw}}"><i class="fas fa-times"></i></button>
         </div>
-        <h2><i class="fas fa-comment-alt fa-is-left"></i>{{i18n('Localization', 'Chat') | raw}} <span class="mobile-only" id="txtMobileChatCooldown"></span></h2>
+        <h2>
+            <i class="fas fa-comment-alt fa-is-left"></i>
+            <span class="panel-title">{{i18n('Localization', 'Chat') | raw}}</span>
+            <span class="mobile-only" id="txtMobileChatCooldown"></span>
+        </h2>
         <div class="right">
             <button type="button" title="{{i18n('Localization', 'Pings') | raw}}"><i class="fas fa-at" id="btnPings"></i></i></button>
             <button type="button" title="{{i18n('Localization', 'Settings') | raw}}"><i class="fas fa-cogs" id="btnChatSettings"></i></button>
@@ -206,7 +213,10 @@
             <button type="button" class="panel-closer" title="{{i18n('Localization', 'Close Panel') | raw}}"><i class="fas fa-times"></i></button>
         </div>
         <div class="mid">
-            <h2><i class="fas fa-cogs fa-is-left"></i>{{i18n('Localization', 'Settings') | raw}}</h2>
+            <h2>
+                <i class="fas fa-cogs fa-is-left"></i>
+                <span class="panel-title">{{i18n('Localization', 'Settings') | raw}}</span>
+            </h2>
         </div>
         <div class="right"></div>
     </header>
@@ -755,8 +765,11 @@
 <aside id="faq" data-panel="faq" class="panel left half-width">
     <header class="panel-header">
         <div class="left"></div>
-        {# FAQ panel #}
-        <h3><i class="fas fa-question-circle fa-is-left"></i>{{i18n('Localization', 'Help') | raw}}</h3>
+        <h2>
+            <i class="fas fa-question-circle fa-is-left"></i>
+            {# FAQ panel #}
+            <span class="panel-title">{{i18n('Localization', 'Help') | raw}}</span>
+        </h2>
         <div class="right">
             <button type="button" class="panel-closer" title="{{i18n('Localization', 'Close Panel') | raw}}"><i class="fas fa-times"></i></button>
         </div>
@@ -769,7 +782,10 @@
 <aside id="notifications" data-panel="notifications" class="panel left">
     <header class="panel-header">
         <div class="left"></div>
-        <h3><i class="fas fa-bell fa-is-left"></i>{{i18n('Localization', 'Notifications') | raw}}</h3>
+        <h2>
+            <i class="fas fa-bell fa-is-left"></i>
+            <span class="panel-title">{{i18n('Localization', 'Notifications') | raw}}</span>    
+        </h2>
         <div class="right">
             <button type="button" class="panel-closer" title="{{i18n('Localization', 'Close Panel') | raw}}"><i class="fas fa-times"></i></button>
         </div>

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -1246,7 +1246,10 @@ aside.panel.horizontal.right {
     word-wrap: break-word;
 }
 
-.panel-header, .panel-footer {
+.panel-header {
+    display: flex;
+    justify-content: center;
+    white-space: nowrap;
     height: 2.5rem;
     line-height: 2.5rem;
 }
@@ -1261,10 +1264,35 @@ aside.panel.horizontal.right {
     font-size: 2rem;
 }
 
-.panel-footer {
-    color: var(--panel-footer-text-color);
-    border-top: 1px solid var(--panel-border-color);
-    background: var(--panel-footer-background);
+.panel-header h1,
+.panel-header h2,
+.panel-header h3,
+.panel-header h4,
+.panel-header h5,
+.panel-header h6 {
+    flex-shrink: 1;
+    flex-grow: 0;
+    white-space: nowrap;
+    display: inline-flex;
+    align-items: center;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.panel-header h1 > .fas,
+.panel-header h2 > .fas,
+.panel-header h3 > .fas,
+.panel-header h4 > .fas,
+.panel-header h5 > .fas,
+.panel-header h6 > .fas {
+    flex-shrink: 1;
+    overflow: hidden;
+}
+
+.panel-title {
+    flex-shrink: 999999999;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .panel-trigger {
@@ -1342,7 +1370,12 @@ aside.panel.horizontal.right {
     margin: .5rem 0;
 }
 
-.panel-body article > header h1, .panel-body article > header h2, .panel-body article > header h3, .panel-body article > header h4, .panel-body article > header h5, .panel-body article > header h6 {
+.panel-body article > header h1,
+.panel-body article > header h2,
+.panel-body article > header h3,
+.panel-body article > header h4,
+.panel-body article > header h5,
+.panel-body article > header h6 {
     font-size: x-large;
     text-align: center;
     width:  100%;
@@ -1986,6 +2019,10 @@ body .emoji-picker {
 
 .mobile-only {
     display: none;
+}
+
+#txtMobileChatCooldown {
+    margin-left: 0.25em;
 }
 
 @media (max-width: 1500px) {


### PR DESCRIPTION
This allows the panel header to collapse when space is very limited. In particular, this applies to the mobile chat panel when the pixel timer is shown:
![image](https://user-images.githubusercontent.com/64389261/145664928-1ea01c26-5e7f-47b1-8a0d-cce91edd9611.png)


This also removes modal footer code since that's apparently dead code.