### PR TITLE
Reduce the minimum window size before entering mobile view

### DIFF
--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -1169,10 +1169,8 @@ footer {
 aside.panel {
     position: fixed;
     top: 0;
-    /* NOTE ([  ]): Ideally this would be max-width and we could set an overriding fixed min-width.
-                    This is just width because the main ui currently can't know how much of the min-with is used
-                    and can't adjust its own width accordingly. */
     width: 30%;
+    min-width: 300px;
     height: 100%;
     z-index: 21;
     cursor: initial !important;
@@ -1185,7 +1183,8 @@ aside.panel[data-disabled] {
 aside.panel.left {
     right: initial;
     transition: left ease-in-out .25s;
-    left: -35%;
+    left: -30%;
+    left: min(-30%, -300px);
 }
 
 aside.panel.left.open, .panel.left[data-state=open] {
@@ -1195,7 +1194,8 @@ aside.panel.left.open, .panel.left[data-state=open] {
 aside.panel.right {
     left: initial;
     transition: right ease-in-out .25s;
-    right: -35%;
+    right: -30%;
+    right: min(-30%, -300px);
 }
 
 aside.panel.right.open, .panel.right[data-state=open] {
@@ -1210,6 +1210,7 @@ aside.panel .panel-body {
 
 aside.panel.half-width {
     width: 50%;
+    min-width: unset;
     max-width: 50%;
 }
 
@@ -1354,10 +1355,12 @@ aside.panel.horizontal.right {
 
 body.panel-open.panel-left #ui {
     left: 30%;
+    left: max(30%, 300px);
 }
 
 body.panel-open.panel-right #ui {
     right: 30%;
+    right: max(30%, 300px);
 }
 
 body.panel-open.panel-left.panel-left-halfwidth #ui {
@@ -1994,7 +1997,7 @@ body .emoji-picker {
     }
 }
 
-@media (max-width: 768px) {
+@media (max-width: 600px) {
     aside.panel {
         max-width: 100% !important;
         width: 100% !important;


### PR DESCRIPTION
This reduces the threshold for entering mobile view and causing side panels to fill the screen from 768px to 600px. At the same time, this adds a minimum width to panels of 300px to prevent them getting too small.

This can lead to scenarios where the main content is unreasonably small, but this is unlikely to be a problem in reality:
![image](https://user-images.githubusercontent.com/64389261/146907995-848da40e-fb20-4492-93d5-2b24d0f64f83.png)
