### PR TITLE
Add modal footer code back

### DIFF
--- a/resources/public/include/modal.js
+++ b/resources/public/include/modal.js
@@ -32,14 +32,15 @@ const modal = (function() {
       button.addEventListener('click', () => modal.closeTop());
       return button;
     },
-    buildDom: function(headerContent, bodyContent) {
+    buildDom: function(headerContent, bodyContent, footerContent) {
       return crel('div', { class: 'modal panel', tabindex: '-1', role: 'dialog' },
         crel('div', { class: 'modal-wrapper', role: 'document' },
           headerContent == null ? null : crel('header', { class: 'modal-header panel-header' },
             crel('div', { class: 'left' }),
             crel('div', { class: 'mid' }, headerContent),
             crel('div', { class: 'right' }, this.buildCloser())),
-          bodyContent == null ? null : crel('div', { class: 'modal-body panel-body' }, bodyContent)
+          bodyContent == null ? null : crel('div', { class: 'modal-body panel-body' }, bodyContent),
+          footerContent == null ? null : crel('footer', { class: 'modal-footer panel-footer' }, footerContent)
         )
       );
     },


### PR DESCRIPTION
I'm not sure what gave me the impression that this code was unused, but I was apparently wrong.

I haven't tested this thoroughly and it doesn't add all the code back, since I think the footer stuff in opts was actually unused. I could be wrong about this though (after all, I was wrong about this in the first place which is why we're here now).