### PR TITLE
Add ability to temporarily collapse articles

### DIFF
--- a/resources/public/include/uiHelper.js
+++ b/resources/public/include/uiHelper.js
@@ -124,6 +124,11 @@ const uiHelper = (function() {
         new SLIDEIN.Slidein(__(`A new ${type} report has been received.`), 'info-circle').show().closeAfter(3000);
       });
 
+      $('article > header').on('click', event => {
+        const body = $(event.currentTarget).next();
+        body.toggleClass('display-none');
+      });
+
       settings.ui.palette.numbers.enable.listen(function(value) {
         place.setNumberedPaletteEnabled(value);
       });

--- a/resources/public/include/uiHelper.js
+++ b/resources/public/include/uiHelper.js
@@ -126,7 +126,7 @@ const uiHelper = (function() {
 
       $('article > header').on('click', event => {
         const body = $(event.currentTarget).next();
-        body.toggleClass('display-none');
+        body.toggleClass('hidden');
       });
 
       settings.ui.palette.numbers.enable.listen(function(value) {

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -460,10 +460,6 @@ dt {
     margin: 0 !important;
 }
 
-.display-none {
-    display: none;
-}
-
 /*//////////////////////////*\
 | Overlays
 \*\\\\\\\\\\\\\\\\\\\\\\\\\\*/

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -460,6 +460,10 @@ dt {
     margin: 0 !important;
 }
 
+.display-none {
+    display: none;
+}
+
 /*//////////////////////////*\
 | Overlays
 \*\\\\\\\\\\\\\\\\\\\\\\\\\\*/
@@ -1404,6 +1408,7 @@ aside.panel.horizontal.right {
     font-size: x-large;
     text-align: center;
     width:  100%;
+    cursor: pointer;
 }
 
 .panel-body article .pad-wrapper {


### PR DESCRIPTION
Adds a click event to all article headers that will toggle `display: hidden` on the next element, being the article padding (including contents). Collapses are not saved due to limitations of the simplicity of the change and will re-expand on reload.

<img src="https://files.f66.dev/uploads/GGYocrWhP7.gif">