### PR TITLE
Fix panels in fullscreen mode having a minimum width

### DIFF
--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -2085,6 +2085,7 @@ body .emoji-picker {
 
 @media (max-width: 600px) {
     aside.panel {
+        min-width: 0;
         max-width: 100% !important;
         width: 100% !important;
     }


### PR DESCRIPTION
Since they cover the whole screen, they may as well shrink down, even if the screen is unreasonably small.