### PR TITLE
Add ability to drag and drop URLs and images links for templates

### DIFF
--- a/po/Localization.po
+++ b/po/Localization.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Pxls\n"
-"POT-Creation-Date: 2022-03-23T01:02:39.456Z\n"
+"POT-Creation-Date: 2022-03-23T04:10:29.174Z\n"
 "Language: en\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 
@@ -2104,16 +2104,20 @@ msgid "Red"
 msgstr "Red"
 
 #: resources/public/include/uiHelper.js
+msgid "Cannot fetch local files. Use the file selector in template settings."
+msgstr "Cannot fetch local files. Use the file selector in template settings."
+
+#: resources/public/include/uiHelper.js
+msgid "Drag and dropped file must be a valid image."
+msgstr "Drag and dropped file must be a valid image."
+
+#: resources/public/include/uiHelper.js
 msgid "Redirect Warning"
 msgstr "Redirect Warning"
 
 #: resources/public/include/uiHelper.js
 msgid "Are you sure you want to redirect to the following URL?"
 msgstr "Are you sure you want to redirect to the following URL?"
-
-#: resources/public/include/uiHelper.js
-msgid "Drag and dropped file must be a valid image."
-msgstr "Drag and dropped file must be a valid image."
 
 #: resources/public/include/uiHelper.js
 msgid "Discord name updated successfully"

--- a/po/Localization.po
+++ b/po/Localization.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Pxls\n"
-"POT-Creation-Date: 2022-03-13T22:28:42.255Z\n"
+"POT-Creation-Date: 2022-03-23T01:02:39.456Z\n"
 "Language: en\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 
@@ -1627,7 +1627,6 @@ msgstr "Faction Bans"
 
 #: resources/public/pebble_templates/profile.html
 #: resources/public/include/chat.js resources/public/admin/admin.js
-#: resources/public/admin/admin.js
 msgid "Unban"
 msgstr "Unban"
 
@@ -1854,13 +1853,13 @@ msgstr "Purge Messages"
 msgid "Purging all messages is disabled during snip mode"
 msgstr "Purging all messages is disabled during snip mode"
 
-#: resources/public/include/chat.js resources/public/include/user.js
-#: resources/public/admin/admin.js
+#: resources/public/include/chat.js resources/public/include/uiHelper.js
+#: resources/public/include/user.js resources/public/admin/admin.js
 msgid "Yes"
 msgstr "Yes"
 
-#: resources/public/include/chat.js resources/public/include/user.js
-#: resources/public/admin/admin.js
+#: resources/public/include/chat.js resources/public/include/uiHelper.js
+#: resources/public/include/user.js resources/public/admin/admin.js
 msgid "No"
 msgstr "No"
 
@@ -2103,6 +2102,14 @@ msgstr "Terminal"
 #: resources/public/include/uiHelper.js
 msgid "Red"
 msgstr "Red"
+
+#: resources/public/include/uiHelper.js
+msgid "Redirect Warning"
+msgstr ""
+
+#: resources/public/include/uiHelper.js
+msgid "Are you sure you want to redirect to the following URL?"
+msgstr ""
 
 #: resources/public/include/uiHelper.js
 msgid "Drag and dropped file must be a valid image."

--- a/po/Localization.po
+++ b/po/Localization.po
@@ -2105,11 +2105,11 @@ msgstr "Red"
 
 #: resources/public/include/uiHelper.js
 msgid "Redirect Warning"
-msgstr ""
+msgstr "Redirect Warning"
 
 #: resources/public/include/uiHelper.js
 msgid "Are you sure you want to redirect to the following URL?"
-msgstr ""
+msgstr "Are you sure you want to redirect to the following URL?"
 
 #: resources/public/include/uiHelper.js
 msgid "Drag and dropped file must be a valid image."

--- a/po/Localization.pot
+++ b/po/Localization.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Pxls\n"
-"POT-Creation-Date: 2022-03-19T05:16:12.444Z\n"
+"POT-Creation-Date: 2022-03-23T01:02:39.456Z\n"
 "Language: \n"
 "Content-Type: text/plain; charset=UTF-8\n"
 
@@ -1854,13 +1854,13 @@ msgstr ""
 msgid "Purging all messages is disabled during snip mode"
 msgstr ""
 
-#: resources/public/include/chat.js resources/public/include/user.js
-#: resources/public/admin/admin.js
+#: resources/public/include/chat.js resources/public/include/uiHelper.js
+#: resources/public/include/user.js resources/public/admin/admin.js
 msgid "Yes"
 msgstr ""
 
-#: resources/public/include/chat.js resources/public/include/user.js
-#: resources/public/admin/admin.js
+#: resources/public/include/chat.js resources/public/include/uiHelper.js
+#: resources/public/include/user.js resources/public/admin/admin.js
 msgid "No"
 msgstr ""
 
@@ -2102,6 +2102,14 @@ msgstr ""
 #. theme name
 #: resources/public/include/uiHelper.js
 msgid "Red"
+msgstr ""
+
+#: resources/public/include/uiHelper.js
+msgid "Redirect Warning"
+msgstr ""
+
+#: resources/public/include/uiHelper.js
+msgid "Are you sure you want to redirect to the following URL?"
 msgstr ""
 
 #: resources/public/include/uiHelper.js

--- a/po/Localization.pot
+++ b/po/Localization.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Pxls\n"
-"POT-Creation-Date: 2022-03-23T01:02:39.456Z\n"
+"POT-Creation-Date: 2022-03-23T04:10:29.174Z\n"
 "Language: \n"
 "Content-Type: text/plain; charset=UTF-8\n"
 
@@ -1856,11 +1856,13 @@ msgstr ""
 
 #: resources/public/include/chat.js resources/public/include/uiHelper.js
 #: resources/public/include/user.js resources/public/admin/admin.js
+#: resources/public/admin/admin.js
 msgid "Yes"
 msgstr ""
 
 #: resources/public/include/chat.js resources/public/include/uiHelper.js
 #: resources/public/include/user.js resources/public/admin/admin.js
+#: resources/public/admin/admin.js
 msgid "No"
 msgstr ""
 
@@ -2105,15 +2107,19 @@ msgid "Red"
 msgstr ""
 
 #: resources/public/include/uiHelper.js
+msgid "Cannot fetch local files. Use the file selector in template settings."
+msgstr ""
+
+#: resources/public/include/uiHelper.js
+msgid "Drag and dropped file must be a valid image."
+msgstr ""
+
+#: resources/public/include/uiHelper.js
 msgid "Redirect Warning"
 msgstr ""
 
 #: resources/public/include/uiHelper.js
 msgid "Are you sure you want to redirect to the following URL?"
-msgstr ""
-
-#: resources/public/include/uiHelper.js
-msgid "Drag and dropped file must be a valid image."
 msgstr ""
 
 #: resources/public/include/uiHelper.js

--- a/po/Localization_bg.po
+++ b/po/Localization_bg.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Pxls\n"
-"POT-Creation-Date: 2022-03-13T22:28:42.255Z\n"
+"POT-Creation-Date: 2022-03-23T01:02:39.456Z\n"
 "Language: \n"
 "Content-Type: text/plain; charset=UTF-8\n"
 
@@ -1393,7 +1393,7 @@ msgid "My Profile"
 msgstr "Моят профил"
 
 #: resources/public/pebble_templates/profile.html
-#: resources/public/Fpebble_templates/40x.html
+#: resources/public/pebble_templates/40x.html
 msgid "My Factions"
 msgstr "Моите фракции"
 
@@ -1627,7 +1627,6 @@ msgstr "Премахнати от фракцията"
 
 #: resources/public/pebble_templates/profile.html
 #: resources/public/include/chat.js resources/public/admin/admin.js
-#: resources/public/admin/admin.js
 msgid "Unban"
 msgstr "Отмени наказанието"
 
@@ -1854,13 +1853,13 @@ msgstr ""
 msgid "Purging all messages is disabled during snip mode"
 msgstr ""
 
-#: resources/public/include/chat.js resources/public/include/user.js
-#: resources/public/admin/admin.js
+#: resources/public/include/chat.js resources/public/include/uiHelper.js
+#: resources/public/include/user.js resources/public/admin/admin.js
 msgid "Yes"
 msgstr ""
 
-#: resources/public/include/chat.js resources/public/include/user.js
-#: resources/public/admin/admin.js
+#: resources/public/include/chat.js resources/public/include/uiHelper.js
+#: resources/public/include/user.js resources/public/admin/admin.js
 msgid "No"
 msgstr ""
 
@@ -2103,6 +2102,14 @@ msgstr "Терминал"
 #: resources/public/include/uiHelper.js
 msgid "Red"
 msgstr "Червена"
+
+#: resources/public/include/uiHelper.js
+msgid "Redirect Warning"
+msgstr ""
+
+#: resources/public/include/uiHelper.js
+msgid "Are you sure you want to redirect to the following URL?"
+msgstr ""
 
 #: resources/public/include/uiHelper.js
 msgid "Drag and dropped file must be a valid image."

--- a/po/Localization_bg.po
+++ b/po/Localization_bg.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Pxls\n"
-"POT-Creation-Date: 2022-03-23T01:02:39.456Z\n"
+"POT-Creation-Date: 2022-03-23T04:10:29.174Z\n"
 "Language: \n"
 "Content-Type: text/plain; charset=UTF-8\n"
 
@@ -2104,15 +2104,19 @@ msgid "Red"
 msgstr "Червена"
 
 #: resources/public/include/uiHelper.js
+msgid "Cannot fetch local files. Use the file selector in template settings."
+msgstr ""
+
+#: resources/public/include/uiHelper.js
+msgid "Drag and dropped file must be a valid image."
+msgstr ""
+
+#: resources/public/include/uiHelper.js
 msgid "Redirect Warning"
 msgstr ""
 
 #: resources/public/include/uiHelper.js
 msgid "Are you sure you want to redirect to the following URL?"
-msgstr ""
-
-#: resources/public/include/uiHelper.js
-msgid "Drag and dropped file must be a valid image."
 msgstr ""
 
 #: resources/public/include/uiHelper.js

--- a/po/Localization_fr.po
+++ b/po/Localization_fr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Pxls\n"
-"POT-Creation-Date: 2022-03-13T22:28:42.255Z\n"
+"POT-Creation-Date: 2022-03-23T01:02:39.456Z\n"
 "Language: \n"
 "Content-Type: text/plain; charset=UTF-8\n"
 
@@ -1627,7 +1627,6 @@ msgstr "Bannissements de la Faction"
 
 #: resources/public/pebble_templates/profile.html
 #: resources/public/include/chat.js resources/public/admin/admin.js
-#: resources/public/admin/admin.js
 msgid "Unban"
 msgstr "Révoquer le bannissement"
 
@@ -1854,13 +1853,13 @@ msgstr "Purger les messages"
 msgid "Purging all messages is disabled during snip mode"
 msgstr "La purge de tous les messages est désactivée en mode snip"
 
-#: resources/public/include/chat.js resources/public/include/user.js
-#: resources/public/admin/admin.js
+#: resources/public/include/chat.js resources/public/include/uiHelper.js
+#: resources/public/include/user.js resources/public/admin/admin.js
 msgid "Yes"
 msgstr "Oui"
 
-#: resources/public/include/chat.js resources/public/include/user.js
-#: resources/public/admin/admin.js
+#: resources/public/include/chat.js resources/public/include/uiHelper.js
+#: resources/public/include/user.js resources/public/admin/admin.js
 msgid "No"
 msgstr "Non"
 
@@ -2103,6 +2102,14 @@ msgstr "Terminal"
 #: resources/public/include/uiHelper.js
 msgid "Red"
 msgstr "Rouge"
+
+#: resources/public/include/uiHelper.js
+msgid "Redirect Warning"
+msgstr ""
+
+#: resources/public/include/uiHelper.js
+msgid "Are you sure you want to redirect to the following URL?"
+msgstr ""
 
 #: resources/public/include/uiHelper.js
 msgid "Drag and dropped file must be a valid image."

--- a/po/Localization_fr.po
+++ b/po/Localization_fr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Pxls\n"
-"POT-Creation-Date: 2022-03-23T01:02:39.456Z\n"
+"POT-Creation-Date: 2022-03-23T04:10:29.174Z\n"
 "Language: \n"
 "Content-Type: text/plain; charset=UTF-8\n"
 
@@ -2104,15 +2104,19 @@ msgid "Red"
 msgstr "Rouge"
 
 #: resources/public/include/uiHelper.js
+msgid "Cannot fetch local files. Use the file selector in template settings."
+msgstr ""
+
+#: resources/public/include/uiHelper.js
+msgid "Drag and dropped file must be a valid image."
+msgstr ""
+
+#: resources/public/include/uiHelper.js
 msgid "Redirect Warning"
 msgstr ""
 
 #: resources/public/include/uiHelper.js
 msgid "Are you sure you want to redirect to the following URL?"
-msgstr ""
-
-#: resources/public/include/uiHelper.js
-msgid "Drag and dropped file must be a valid image."
 msgstr ""
 
 #: resources/public/include/uiHelper.js

--- a/po/Localization_ru.po
+++ b/po/Localization_ru.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Pxls\n"
-"POT-Creation-Date: 2022-03-13T22:28:42.255Z\n"
+"POT-Creation-Date: 2022-03-23T01:02:39.456Z\n"
 "Language: \n"
 "Content-Type: text/plain; charset=UTF-8\n"
 
@@ -1627,7 +1627,6 @@ msgstr "Баны фракции"
 
 #: resources/public/pebble_templates/profile.html
 #: resources/public/include/chat.js resources/public/admin/admin.js
-#: resources/public/admin/admin.js
 msgid "Unban"
 msgstr "Разбанить"
 
@@ -1854,13 +1853,13 @@ msgstr "Удалить сообщения"
 msgid "Purging all messages is disabled during snip mode"
 msgstr "Удаление всех сообщений отключено в режиме snip"
 
-#: resources/public/include/chat.js resources/public/include/user.js
-#: resources/public/admin/admin.js
+#: resources/public/include/chat.js resources/public/include/uiHelper.js
+#: resources/public/include/user.js resources/public/admin/admin.js
 msgid "Yes"
 msgstr "Да"
 
-#: resources/public/include/chat.js resources/public/include/user.js
-#: resources/public/admin/admin.js
+#: resources/public/include/chat.js resources/public/include/uiHelper.js
+#: resources/public/include/user.js resources/public/admin/admin.js
 msgid "No"
 msgstr "Нет"
 
@@ -2103,6 +2102,14 @@ msgstr "Матрица"
 #: resources/public/include/uiHelper.js
 msgid "Red"
 msgstr "Красная"
+
+#: resources/public/include/uiHelper.js
+msgid "Redirect Warning"
+msgstr ""
+
+#: resources/public/include/uiHelper.js
+msgid "Are you sure you want to redirect to the following URL?"
+msgstr ""
 
 #: resources/public/include/uiHelper.js
 msgid "Drag and dropped file must be a valid image."

--- a/po/Localization_ru.po
+++ b/po/Localization_ru.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Pxls\n"
-"POT-Creation-Date: 2022-03-23T01:02:39.456Z\n"
+"POT-Creation-Date: 2022-03-23T04:10:29.174Z\n"
 "Language: \n"
 "Content-Type: text/plain; charset=UTF-8\n"
 
@@ -2104,16 +2104,20 @@ msgid "Red"
 msgstr "Красная"
 
 #: resources/public/include/uiHelper.js
+msgid "Cannot fetch local files. Use the file selector in template settings."
+msgstr ""
+
+#: resources/public/include/uiHelper.js
+msgid "Drag and dropped file must be a valid image."
+msgstr "Перетаскиваемый файл должен быть допустимым изображением."
+
+#: resources/public/include/uiHelper.js
 msgid "Redirect Warning"
 msgstr ""
 
 #: resources/public/include/uiHelper.js
 msgid "Are you sure you want to redirect to the following URL?"
 msgstr ""
-
-#: resources/public/include/uiHelper.js
-msgid "Drag and dropped file must be a valid image."
-msgstr "Перетаскиваемый файл должен быть допустимым изображением."
 
 #: resources/public/include/uiHelper.js
 msgid "Discord name updated successfully"

--- a/resources/Localization.properties
+++ b/resources/Localization.properties
@@ -1,4 +1,4 @@
-!=Project-Id-Version\: Pxls\nPOT-Creation-Date\: 2022-03-13T22\:28\:42.255Z\nLanguage\: en\nContent-Type\: text/plain; charset\=UTF-8\n
+!=Project-Id-Version\: Pxls\nPOT-Creation-Date\: 2022-03-23T01\:02\:39.456Z\nLanguage\: en\nContent-Type\: text/plain; charset\=UTF-8\n
 
 #. Site description
 #: resources/public/pebble_templates/index.html
@@ -1396,12 +1396,12 @@ Purge\ Messages=Purge Messages
 #: resources/public/include/chat.js
 Purging\ all\ messages\ is\ disabled\ during\ snip\ mode=Purging all messages is disabled during snip mode
 
-#: resources/public/include/chat.js resources/public/include/user.js
-#: resources/public/admin/admin.js
+#: resources/public/include/chat.js resources/public/include/uiHelper.js
+#: resources/public/include/user.js resources/public/admin/admin.js
 Yes=Yes
 
-#: resources/public/include/chat.js resources/public/include/user.js
-#: resources/public/admin/admin.js
+#: resources/public/include/chat.js resources/public/include/uiHelper.js
+#: resources/public/include/user.js resources/public/admin/admin.js
 No=No
 
 #: resources/public/include/chat.js
@@ -1585,6 +1585,12 @@ Terminal=Terminal
 #. theme name
 #: resources/public/include/uiHelper.js
 Red=Red
+
+#: resources/public/include/uiHelper.js
+!Redirect\ Warning=
+
+#: resources/public/include/uiHelper.js
+!Are\ you\ sure\ you\ want\ to\ redirect\ to\ the\ following\ URL?=
 
 #: resources/public/include/uiHelper.js
 Drag\ and\ dropped\ file\ must\ be\ a\ valid\ image.=Drag and dropped file must be a valid image.

--- a/resources/Localization.properties
+++ b/resources/Localization.properties
@@ -1587,10 +1587,10 @@ Terminal=Terminal
 Red=Red
 
 #: resources/public/include/uiHelper.js
-!Redirect\ Warning=
+Redirect\ Warning=Redirect Warning
 
 #: resources/public/include/uiHelper.js
-!Are\ you\ sure\ you\ want\ to\ redirect\ to\ the\ following\ URL?=
+Are\ you\ sure\ you\ want\ to\ redirect\ to\ the\ following\ URL?=Are you sure you want to redirect to the following URL?
 
 #: resources/public/include/uiHelper.js
 Drag\ and\ dropped\ file\ must\ be\ a\ valid\ image.=Drag and dropped file must be a valid image.

--- a/resources/Localization.properties
+++ b/resources/Localization.properties
@@ -1,4 +1,4 @@
-!=Project-Id-Version\: Pxls\nPOT-Creation-Date\: 2022-03-23T01\:02\:39.456Z\nLanguage\: en\nContent-Type\: text/plain; charset\=UTF-8\n
+!=Project-Id-Version\: Pxls\nPOT-Creation-Date\: 2022-03-23T04\:10\:29.174Z\nLanguage\: en\nContent-Type\: text/plain; charset\=UTF-8\n
 
 #. Site description
 #: resources/public/pebble_templates/index.html
@@ -1587,13 +1587,16 @@ Terminal=Terminal
 Red=Red
 
 #: resources/public/include/uiHelper.js
+Cannot\ fetch\ local\ files.\ Use\ the\ file\ selector\ in\ template\ settings.=Cannot fetch local files. Use the file selector in template settings.
+
+#: resources/public/include/uiHelper.js
+Drag\ and\ dropped\ file\ must\ be\ a\ valid\ image.=Drag and dropped file must be a valid image.
+
+#: resources/public/include/uiHelper.js
 Redirect\ Warning=Redirect Warning
 
 #: resources/public/include/uiHelper.js
 Are\ you\ sure\ you\ want\ to\ redirect\ to\ the\ following\ URL?=Are you sure you want to redirect to the following URL?
-
-#: resources/public/include/uiHelper.js
-Drag\ and\ dropped\ file\ must\ be\ a\ valid\ image.=Drag and dropped file must be a valid image.
 
 #: resources/public/include/uiHelper.js
 Discord\ name\ updated\ successfully=Discord name updated successfully

--- a/resources/Localization_bg.properties
+++ b/resources/Localization_bg.properties
@@ -1,4 +1,4 @@
-!=Project-Id-Version\: Pxls\nPOT-Creation-Date\: 2022-03-13T22\:28\:42.255Z\nLanguage\: \nContent-Type\: text/plain; charset\=UTF-8\n
+!=Project-Id-Version\: Pxls\nPOT-Creation-Date\: 2022-03-23T01\:02\:39.456Z\nLanguage\: \nContent-Type\: text/plain; charset\=UTF-8\n
 
 #. Site description
 #: resources/public/pebble_templates/index.html
@@ -1046,7 +1046,7 @@ Donations\ are\ not\ accepted\ at\ this\ time,\ but\ this\ panel\ will\ be\ upda
 My\ Profile=\u041c\u043e\u044f\u0442 \u043f\u0440\u043e\u0444\u0438\u043b
 
 #: resources/public/pebble_templates/profile.html
-#: resources/public/Fpebble_templates/40x.html
+#: resources/public/pebble_templates/40x.html
 My\ Factions=\u041c\u043e\u0438\u0442\u0435 \u0444\u0440\u0430\u043a\u0446\u0438\u0438
 
 #: resources/public/pebble_templates/profile.html
@@ -1396,12 +1396,12 @@ Failed\ to\ ignore\ user.\ Either\ they\\'re\ already\ ignored,\ or\ an\ error\ 
 #: resources/public/include/chat.js
 !Purging\ all\ messages\ is\ disabled\ during\ snip\ mode=
 
-#: resources/public/include/chat.js resources/public/include/user.js
-#: resources/public/admin/admin.js
+#: resources/public/include/chat.js resources/public/include/uiHelper.js
+#: resources/public/include/user.js resources/public/admin/admin.js
 !Yes=
 
-#: resources/public/include/chat.js resources/public/include/user.js
-#: resources/public/admin/admin.js
+#: resources/public/include/chat.js resources/public/include/uiHelper.js
+#: resources/public/include/user.js resources/public/admin/admin.js
 !No=
 
 #: resources/public/include/chat.js
@@ -1585,6 +1585,12 @@ Terminal=\u0422\u0435\u0440\u043c\u0438\u043d\u0430\u043b
 #. theme name
 #: resources/public/include/uiHelper.js
 Red=\u0427\u0435\u0440\u0432\u0435\u043d\u0430
+
+#: resources/public/include/uiHelper.js
+!Redirect\ Warning=
+
+#: resources/public/include/uiHelper.js
+!Are\ you\ sure\ you\ want\ to\ redirect\ to\ the\ following\ URL?=
 
 #: resources/public/include/uiHelper.js
 !Drag\ and\ dropped\ file\ must\ be\ a\ valid\ image.=

--- a/resources/Localization_bg.properties
+++ b/resources/Localization_bg.properties
@@ -1,4 +1,4 @@
-!=Project-Id-Version\: Pxls\nPOT-Creation-Date\: 2022-03-23T01\:02\:39.456Z\nLanguage\: \nContent-Type\: text/plain; charset\=UTF-8\n
+!=Project-Id-Version\: Pxls\nPOT-Creation-Date\: 2022-03-23T04\:10\:29.174Z\nLanguage\: \nContent-Type\: text/plain; charset\=UTF-8\n
 
 #. Site description
 #: resources/public/pebble_templates/index.html
@@ -1587,13 +1587,16 @@ Terminal=\u0422\u0435\u0440\u043c\u0438\u043d\u0430\u043b
 Red=\u0427\u0435\u0440\u0432\u0435\u043d\u0430
 
 #: resources/public/include/uiHelper.js
+!Cannot\ fetch\ local\ files.\ Use\ the\ file\ selector\ in\ template\ settings.=
+
+#: resources/public/include/uiHelper.js
+!Drag\ and\ dropped\ file\ must\ be\ a\ valid\ image.=
+
+#: resources/public/include/uiHelper.js
 !Redirect\ Warning=
 
 #: resources/public/include/uiHelper.js
 !Are\ you\ sure\ you\ want\ to\ redirect\ to\ the\ following\ URL?=
-
-#: resources/public/include/uiHelper.js
-!Drag\ and\ dropped\ file\ must\ be\ a\ valid\ image.=
 
 #: resources/public/include/uiHelper.js
 Discord\ name\ updated\ successfully=\u0412\u0430\u0448\u0438\u044f\u0442 \u0434\u0438\u0441\u043a\u043e\u0440\u0434 \u0442\u0430\u0433 \u0431\u0435 \u0440\u0435\u0434\u0430\u043a\u0442\u0438\u0440\u0430\u043d \u0443\u0441\u043f\u0435\u0448\u043d\u043e

--- a/resources/Localization_fr.properties
+++ b/resources/Localization_fr.properties
@@ -1,4 +1,4 @@
-!=Project-Id-Version\: Pxls\nPOT-Creation-Date\: 2022-03-13T22\:28\:42.255Z\nLanguage\: \nContent-Type\: text/plain; charset\=UTF-8\n
+!=Project-Id-Version\: Pxls\nPOT-Creation-Date\: 2022-03-23T01\:02\:39.456Z\nLanguage\: \nContent-Type\: text/plain; charset\=UTF-8\n
 
 #. Site description
 #: resources/public/pebble_templates/index.html
@@ -1396,12 +1396,12 @@ Purge\ Messages=Purger les messages
 #: resources/public/include/chat.js
 Purging\ all\ messages\ is\ disabled\ during\ snip\ mode=La purge de tous les messages est d\u00e9sactiv\u00e9e en mode snip
 
-#: resources/public/include/chat.js resources/public/include/user.js
-#: resources/public/admin/admin.js
+#: resources/public/include/chat.js resources/public/include/uiHelper.js
+#: resources/public/include/user.js resources/public/admin/admin.js
 Yes=Oui
 
-#: resources/public/include/chat.js resources/public/include/user.js
-#: resources/public/admin/admin.js
+#: resources/public/include/chat.js resources/public/include/uiHelper.js
+#: resources/public/include/user.js resources/public/admin/admin.js
 No=Non
 
 #: resources/public/include/chat.js
@@ -1585,6 +1585,12 @@ Terminal=Terminal
 #. theme name
 #: resources/public/include/uiHelper.js
 Red=Rouge
+
+#: resources/public/include/uiHelper.js
+!Redirect\ Warning=
+
+#: resources/public/include/uiHelper.js
+!Are\ you\ sure\ you\ want\ to\ redirect\ to\ the\ following\ URL?=
 
 #: resources/public/include/uiHelper.js
 !Drag\ and\ dropped\ file\ must\ be\ a\ valid\ image.=

--- a/resources/Localization_fr.properties
+++ b/resources/Localization_fr.properties
@@ -1,4 +1,4 @@
-!=Project-Id-Version\: Pxls\nPOT-Creation-Date\: 2022-03-23T01\:02\:39.456Z\nLanguage\: \nContent-Type\: text/plain; charset\=UTF-8\n
+!=Project-Id-Version\: Pxls\nPOT-Creation-Date\: 2022-03-23T04\:10\:29.174Z\nLanguage\: \nContent-Type\: text/plain; charset\=UTF-8\n
 
 #. Site description
 #: resources/public/pebble_templates/index.html
@@ -1587,13 +1587,16 @@ Terminal=Terminal
 Red=Rouge
 
 #: resources/public/include/uiHelper.js
+!Cannot\ fetch\ local\ files.\ Use\ the\ file\ selector\ in\ template\ settings.=
+
+#: resources/public/include/uiHelper.js
+!Drag\ and\ dropped\ file\ must\ be\ a\ valid\ image.=
+
+#: resources/public/include/uiHelper.js
 !Redirect\ Warning=
 
 #: resources/public/include/uiHelper.js
 !Are\ you\ sure\ you\ want\ to\ redirect\ to\ the\ following\ URL?=
-
-#: resources/public/include/uiHelper.js
-!Drag\ and\ dropped\ file\ must\ be\ a\ valid\ image.=
 
 #: resources/public/include/uiHelper.js
 Discord\ name\ updated\ successfully=Le nom Discord a bien \u00e9t\u00e9 mis \u00e0 jour

--- a/resources/Localization_ru.properties
+++ b/resources/Localization_ru.properties
@@ -1,4 +1,4 @@
-!=Project-Id-Version\: Pxls\nPOT-Creation-Date\: 2022-03-13T22\:28\:42.255Z\nLanguage\: \nContent-Type\: text/plain; charset\=UTF-8\n
+!=Project-Id-Version\: Pxls\nPOT-Creation-Date\: 2022-03-23T01\:02\:39.456Z\nLanguage\: \nContent-Type\: text/plain; charset\=UTF-8\n
 
 #. Site description
 #: resources/public/pebble_templates/index.html
@@ -1396,12 +1396,12 @@ Purge\ Messages=\u0423\u0434\u0430\u043b\u0438\u0442\u044c \u0441\u043e\u043e\u0
 #: resources/public/include/chat.js
 Purging\ all\ messages\ is\ disabled\ during\ snip\ mode=\u0423\u0434\u0430\u043b\u0435\u043d\u0438\u0435 \u0432\u0441\u0435\u0445 \u0441\u043e\u043e\u0431\u0449\u0435\u043d\u0438\u0439 \u043e\u0442\u043a\u043b\u044e\u0447\u0435\u043d\u043e \u0432 \u0440\u0435\u0436\u0438\u043c\u0435 snip
 
-#: resources/public/include/chat.js resources/public/include/user.js
-#: resources/public/admin/admin.js
+#: resources/public/include/chat.js resources/public/include/uiHelper.js
+#: resources/public/include/user.js resources/public/admin/admin.js
 Yes=\u0414\u0430
 
-#: resources/public/include/chat.js resources/public/include/user.js
-#: resources/public/admin/admin.js
+#: resources/public/include/chat.js resources/public/include/uiHelper.js
+#: resources/public/include/user.js resources/public/admin/admin.js
 No=\u041d\u0435\u0442
 
 #: resources/public/include/chat.js
@@ -1585,6 +1585,12 @@ Terminal=\u041c\u0430\u0442\u0440\u0438\u0446\u0430
 #. theme name
 #: resources/public/include/uiHelper.js
 Red=\u041a\u0440\u0430\u0441\u043d\u0430\u044f
+
+#: resources/public/include/uiHelper.js
+!Redirect\ Warning=
+
+#: resources/public/include/uiHelper.js
+!Are\ you\ sure\ you\ want\ to\ redirect\ to\ the\ following\ URL?=
 
 #: resources/public/include/uiHelper.js
 Drag\ and\ dropped\ file\ must\ be\ a\ valid\ image.=\u041f\u0435\u0440\u0435\u0442\u0430\u0441\u043a\u0438\u0432\u0430\u0435\u043c\u044b\u0439 \u0444\u0430\u0439\u043b \u0434\u043e\u043b\u0436\u0435\u043d \u0431\u044b\u0442\u044c \u0434\u043e\u043f\u0443\u0441\u0442\u0438\u043c\u044b\u043c \u0438\u0437\u043e\u0431\u0440\u0430\u0436\u0435\u043d\u0438\u0435\u043c.

--- a/resources/Localization_ru.properties
+++ b/resources/Localization_ru.properties
@@ -1,4 +1,4 @@
-!=Project-Id-Version\: Pxls\nPOT-Creation-Date\: 2022-03-23T01\:02\:39.456Z\nLanguage\: \nContent-Type\: text/plain; charset\=UTF-8\n
+!=Project-Id-Version\: Pxls\nPOT-Creation-Date\: 2022-03-23T04\:10\:29.174Z\nLanguage\: \nContent-Type\: text/plain; charset\=UTF-8\n
 
 #. Site description
 #: resources/public/pebble_templates/index.html
@@ -1587,13 +1587,16 @@ Terminal=\u041c\u0430\u0442\u0440\u0438\u0446\u0430
 Red=\u041a\u0440\u0430\u0441\u043d\u0430\u044f
 
 #: resources/public/include/uiHelper.js
+!Cannot\ fetch\ local\ files.\ Use\ the\ file\ selector\ in\ template\ settings.=
+
+#: resources/public/include/uiHelper.js
+Drag\ and\ dropped\ file\ must\ be\ a\ valid\ image.=\u041f\u0435\u0440\u0435\u0442\u0430\u0441\u043a\u0438\u0432\u0430\u0435\u043c\u044b\u0439 \u0444\u0430\u0439\u043b \u0434\u043e\u043b\u0436\u0435\u043d \u0431\u044b\u0442\u044c \u0434\u043e\u043f\u0443\u0441\u0442\u0438\u043c\u044b\u043c \u0438\u0437\u043e\u0431\u0440\u0430\u0436\u0435\u043d\u0438\u0435\u043c.
+
+#: resources/public/include/uiHelper.js
 !Redirect\ Warning=
 
 #: resources/public/include/uiHelper.js
 !Are\ you\ sure\ you\ want\ to\ redirect\ to\ the\ following\ URL?=
-
-#: resources/public/include/uiHelper.js
-Drag\ and\ dropped\ file\ must\ be\ a\ valid\ image.=\u041f\u0435\u0440\u0435\u0442\u0430\u0441\u043a\u0438\u0432\u0430\u0435\u043c\u044b\u0439 \u0444\u0430\u0439\u043b \u0434\u043e\u043b\u0436\u0435\u043d \u0431\u044b\u0442\u044c \u0434\u043e\u043f\u0443\u0441\u0442\u0438\u043c\u044b\u043c \u0438\u0437\u043e\u0431\u0440\u0430\u0436\u0435\u043d\u0438\u0435\u043c.
 
 #: resources/public/include/uiHelper.js
 Discord\ name\ updated\ successfully=\u041d\u0438\u043a Discord \u0443\u0441\u043f\u0435\u0448\u043d\u043e \u043e\u0431\u043d\u043e\u0432\u043b\u0435\u043d

--- a/resources/public/include/uiHelper.js
+++ b/resources/public/include/uiHelper.js
@@ -299,54 +299,70 @@ const uiHelper = (function() {
        *   [InternetShortcut]
        *   URL=https://example.org/mycooltemplateimage.png
        */
-      document.addEventListener('drop', event => {
+      document.addEventListener('drop', async event => {
         event.preventDefault();
         self.elements.dragDropTarget.hide();
         self.elements.dragDrop.fadeOut(200);
         const data = event.dataTransfer;
-        const file = data.files[0];
-        if (file.name.endsWith('.url')) {
-          // URL or dragged image
-          const reader = new FileReader();
-          reader.onload = () => {
-            // data:application/octet-stream;base64,W0ludGVybmV0U2hvcnRjdXRdDQp ...
-            const linkFile = Buffer.from(reader.result.split(',')[1], 'base64').toString('ascii');
-            // [InternetShortcut]
-            // URL=https://example.org/mycooltemplateimage.png
-            const url = linkFile.split('URL=')[1].trim();
-            if (url.startsWith(window.location.origin)) {
-              // TODO: Perform same type of prompt when clicking template links in chat
-              modal.show(modal.buildDom(
-                crel('h2', { class: 'modal-title' }, __('Redirect Warning')),
-                crel('div',
-                  crel('p', __('Are you sure you want to redirect to the following URL?')),
-                  crel('pre', url),
-                  crel('div', { class: 'buttons' },
-                    crel('button', {
-                      class: 'dangerous-button text-button',
-                      onclick: () => {
-                        window.location.href = url;
-                      }
-                    }, __('Yes')),
-                    crel('button', {
-                      class: 'text-button',
-                      onclick: () => modal.closeAll()
-                    }, __('No'))
-                  )
-                )
-              ));
-              return;
-            }
-            template.update({ use: true, url: url, convertMode: 'nearestCustom' });
-          };
-          reader.readAsDataURL(file);
+        let url;
+        if (data.types.includes('Files')) {
+          const file = data.files[0];
+          url = await new Promise(resolve => {
+            const reader = new FileReader();
+            reader.onload = () => {
+              if (reader.result.startsWith('data:application/octet-stream')) {
+                // Windows only
+                const linkFile = Buffer.from(reader.result.split(',')[1], 'base64');
+                const linkFileStr = String.fromCharCode.apply(null, linkFile);
+                resolve(linkFileStr.split('URL=')[1].trim());
+              }
+              resolve(reader.result);
+            };
+            reader.readAsDataURL(file);
+          });
+        } else {
+          url = data.getData('text/plain');
+        }
+
+        if (url.startsWith('file:')) {
+          modal.showText(__('Cannot fetch local files. Use the file selector in template settings.'));
           return;
         }
-        if (!['image/png', 'image/jpeg', 'image/webp'].includes(file.type)) {
+
+        if (url.startsWith(window.location.origin)) {
+          modal.show(modal.buildDom(
+            crel('h2', { class: 'modal-title' }, __('Redirect Warning')),
+            crel('div',
+              crel('p', __('Are you sure you want to redirect to the following URL?')),
+              crel('p', {
+                style: 'font-family: monospace; max-width: 50vw;'
+              }, url),
+              crel('div', { class: 'buttons' },
+                crel('button', {
+                  class: 'dangerous-button text-button',
+                  onclick: () => {
+                    window.location.href = url;
+                    modal.closeAll();
+                  }
+                }, __('Yes')),
+                crel('button', {
+                  class: 'text-button',
+                  onclick: () => modal.closeAll()
+                }, __('No'))
+              )
+            )
+          ));
+          return;
+        }
+
+        // data:image/png;base64, ...
+        const mimeType = url.substring(5, url.indexOf(';'));
+        if (!['image/png', 'image/jpeg', 'image/webp'].includes(mimeType)) {
           modal.showText(__('Drag and dropped file must be a valid image.'));
           return;
         }
-        self.handleFile(data);
+
+        self.handleFileUrl(url);
       }, false);
     },
     prettifyRange: function (ranges) {
@@ -735,13 +751,20 @@ const uiHelper = (function() {
         });
     },
     /**
-     * Handles a file drop or upload.
-     * @param dataTransfer {DataTransfer} The data transfer.
+     * Handles a file upload through the file browser.
+     * @param {DataTransfer} dataTransfer The data transfer.
      */
     handleFile(dataTransfer) {
       const reader = new FileReader();
-      reader.onload = () => template.update({ use: true, url: reader.result, convertMode: 'nearestCustom' });
+      reader.onload = () => this.handleFileUrl(reader.result);
       reader.readAsDataURL(dataTransfer.files[0]);
+    },
+    /**
+     * Handles a file URL either through drag-and-drop or the file browser.
+     * @param {string} url The file URL.
+     */
+    handleFileUrl(url) {
+      template.update({ use: true, url, convertMode: 'nearestCustom' });
     }
   };
 

--- a/resources/public/include/uiHelper.js
+++ b/resources/public/include/uiHelper.js
@@ -355,11 +355,13 @@ const uiHelper = (function() {
           return;
         }
 
-        // data:image/png;base64, ...
-        const mimeType = url.substring(5, url.indexOf(';'));
-        if (!['image/png', 'image/jpeg', 'image/webp'].includes(mimeType)) {
-          modal.showText(__('Drag and dropped file must be a valid image.'));
-          return;
+        if (url.startsWith('data:')) {
+          // data:image/png;base64, ...
+          const mimeType = url.substring(5, url.indexOf(';'));
+          if (!['image/png', 'image/jpeg', 'image/webp'].includes(mimeType)) {
+            modal.showText(__('Drag and dropped file must be a valid image.'));
+            return;
+          }
         }
 
         self.handleFileUrl(url);

--- a/resources/public/include/uiHelper.js
+++ b/resources/public/include/uiHelper.js
@@ -316,7 +316,25 @@ const uiHelper = (function() {
             const url = linkFile.split('URL=')[1].trim();
             if (url.startsWith(window.location.origin)) {
               // TODO: Perform same type of prompt when clicking template links in chat
-              window.location.href = url;
+              modal.show(modal.buildDom(
+                crel('h2', { class: 'modal-title' }, __('Redirect Warning')),
+                crel('div',
+                  crel('p', __('Are you sure you want to redirect to the following URL?')),
+                  crel('pre', url),
+                  crel('div', { class: 'buttons' },
+                    crel('button', {
+                      class: 'dangerous-button text-button',
+                      onclick: () => {
+                        window.location.href = url;
+                      }
+                    }, __('Yes')),
+                    crel('button', {
+                      class: 'text-button',
+                      onclick: () => modal.closeAll()
+                    }, __('No'))
+                  )
+                )
+              ));
               return;
             }
             template.update({ use: true, url: url, convertMode: 'nearestCustom' });


### PR DESCRIPTION
This adds the ability to drag both URLs and embedded images (from Discord, for example) onto Pxls.

If the URL has the same origin as the webpage, it'll prompt the user whether they wish to redirect to the given URL (such as a template with a specific configuration).  Ideally doing so would pull up the same prompt as when clicking on template links in chat, but I found no modular way to do this without copy-pasting the code and tweaking it for this scenario--so I'll tackle that at another point.
The prompt was added for safety, just in case someone drags a link to an API call onto the site.

Demonstration video:

https://user-images.githubusercontent.com/19217244/159604278-31a7aade-16f8-4e60-b584-5d669c521966.mp4