### PR TITLE
Add checkbox for silent purges and deletions

### DIFF
--- a/po/Localization.po
+++ b/po/Localization.po
@@ -1876,6 +1876,10 @@ msgid "No"
 msgstr "No"
 
 #: resources/public/include/chat.js
+msgid "Silent (no purge message)"
+msgstr ""
+
+#: resources/public/include/chat.js
 msgid "Custom reason"
 msgstr "Custom reason"
 

--- a/po/Localization.pot
+++ b/po/Localization.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Pxls\n"
-"POT-Creation-Date: 2022-03-24T17:10:30.158Z\n"
+"POT-Creation-Date: 2022-04-03T04:05:27.870Z\n"
 "Language: \n"
 "Content-Type: text/plain; charset=UTF-8\n"
 
@@ -44,10 +44,6 @@ msgstr ""
 
 #: resources/public/pebble_templates/index.html
 msgid "Loading online user count&hellip;"
-msgstr ""
-
-#: resources/public/include/user.js
-msgid "online"
 msgstr ""
 
 #: resources/public/pebble_templates/index.html
@@ -1876,6 +1872,10 @@ msgstr ""
 #: resources/public/include/user.js resources/public/admin/admin.js
 #: resources/public/admin/admin.js
 msgid "No"
+msgstr ""
+
+#: resources/public/include/chat.js
+msgid "Silent (no purge message)"
 msgstr ""
 
 #: resources/public/include/chat.js

--- a/po/Localization_bg.po
+++ b/po/Localization_bg.po
@@ -1876,6 +1876,10 @@ msgid "No"
 msgstr ""
 
 #: resources/public/include/chat.js
+msgid "Silent (no purge message)"
+msgstr ""
+
+#: resources/public/include/chat.js
 msgid "Custom reason"
 msgstr ""
 

--- a/po/Localization_fr.po
+++ b/po/Localization_fr.po
@@ -1876,6 +1876,10 @@ msgid "No"
 msgstr "Non"
 
 #: resources/public/include/chat.js
+msgid "Silent (no purge message)"
+msgstr ""
+
+#: resources/public/include/chat.js
 msgid "Custom reason"
 msgstr "Raison personalisée"
 

--- a/po/Localization_ru.po
+++ b/po/Localization_ru.po
@@ -1876,6 +1876,10 @@ msgid "No"
 msgstr "Нет"
 
 #: resources/public/include/chat.js
+msgid "Silent (no purge message)"
+msgstr ""
+
+#: resources/public/include/chat.js
 msgid "Custom reason"
 msgstr "Другая причина"
 

--- a/resources/Localization.properties
+++ b/resources/Localization.properties
@@ -1414,6 +1414,9 @@ Yes=Yes
 No=No
 
 #: resources/public/include/chat.js
+!Silent\ (no\ purge\ message)=
+
+#: resources/public/include/chat.js
 Custom\ reason=Custom reason
 
 #: resources/public/include/chat.js resources/public/include/lookup.js

--- a/resources/Localization_bg.properties
+++ b/resources/Localization_bg.properties
@@ -1414,6 +1414,9 @@ Failed\ to\ ignore\ user.\ Either\ they\\'re\ already\ ignored,\ or\ an\ error\ 
 !No=
 
 #: resources/public/include/chat.js
+!Silent\ (no\ purge\ message)=
+
+#: resources/public/include/chat.js
 !Custom\ reason=
 
 #: resources/public/include/chat.js resources/public/include/lookup.js

--- a/resources/Localization_fr.properties
+++ b/resources/Localization_fr.properties
@@ -1414,6 +1414,9 @@ Yes=Oui
 No=Non
 
 #: resources/public/include/chat.js
+!Silent\ (no\ purge\ message)=
+
+#: resources/public/include/chat.js
 Custom\ reason=Raison personalis\u00e9e
 
 #: resources/public/include/chat.js resources/public/include/lookup.js

--- a/resources/Localization_ru.properties
+++ b/resources/Localization_ru.properties
@@ -1414,6 +1414,9 @@ Yes=\u0414\u0430
 No=\u041d\u0435\u0442
 
 #: resources/public/include/chat.js
+!Silent\ (no\ purge\ message)=
+
+#: resources/public/include/chat.js
 Custom\ reason=\u0414\u0440\u0443\u0433\u0430\u044f \u043f\u0440\u0438\u0447\u0438\u043d\u0430
 
 #: resources/public/include/chat.js resources/public/include/lookup.js

--- a/resources/public/include/chat.js
+++ b/resources/public/include/chat.js
@@ -1767,6 +1767,7 @@ const chat = (function() {
             const isUnban = _selBanLength.value === '-3';
             _reasonWrap.style.display = isUnban ? 'none' : 'block';
             _purgeWrap.style.display = isUnban ? 'none' : 'block';
+            _silentPurgeWrap.style.display = isUnban ? 'none' : 'block';
             _btnOK.innerHTML = isUnban ? __('Unban') : __('Ban');
           });
           _selCustomLength.selectedIndex = 1; // minutes
@@ -1904,6 +1905,12 @@ const chat = (function() {
         case 'purge': {
           const txtPurgeReason = crel('input', { type: 'text', onkeydown: e => e.stopPropagation() });
 
+          const cbSilentPurge = crel('input', {
+            type: 'checkbox',
+            name: 'cbSilentPurge',
+            style: 'display: inline; width: initial; margin-right: 5px;'
+          });
+
           const btnPurge = crel('button', { class: 'text-button dangerous-button', type: 'submit' }, __('Purge'));
 
           const messageTable = mode
@@ -1931,6 +1938,7 @@ const chat = (function() {
               crel('h5', __('Purge Reason')),
               txtPurgeReason
             ),
+            crel('label', { style: 'display: inline;' }, cbSilentPurge, __('Silent (no purge message)')),
             crel('div', { class: 'buttons' },
               crel('button', {
                 class: 'text-button',
@@ -1948,7 +1956,8 @@ const chat = (function() {
 
             $.post('/admin/chatPurge', {
               who: reportingTarget,
-              reason: txtPurgeReason.value
+              reason: txtPurgeReason.value,
+              silent: cbSilentPurge.checked
             }, function() {
               purgeWrapper.remove();
               modal.showText(__('User purged'));

--- a/src/main/java/space/pxls/App.java
+++ b/src/main/java/space/pxls/App.java
@@ -604,7 +604,7 @@ public class App {
                         }
                         Boolean messageRemoval = token[3].equals("1") || token[3].equalsIgnoreCase("yes") || token[3].equalsIgnoreCase("true");
                         String reason = line.substring(token[0].length() + token[1].length() + token[2].length() + token[3].length() + 4);
-                        Chatban.TEMP(user, null, System.currentTimeMillis() + banLength * 1000L, reason, messageRemoval, Integer.MAX_VALUE).commit();
+                        Chatban.TEMP(user, null, System.currentTimeMillis() + banLength * 1000L, reason, messageRemoval, Integer.MAX_VALUE, true).commit();
                     }
                 } else {
                     System.out.println("chatban USER BAN_LENGTH MESSAGE_REMOVAL REASON\n    USER: The name of the user\n    BAN_LENGTH: The length in seconds of the chatban. For permas, see 'PermaChatBan' command.\n    MESSAGE_REMOVAL: Boolean (1|0) of whether or not to purge the user from chat.\n    REASON: The reason for the chatban. Will be displayed to the user");
@@ -616,7 +616,7 @@ public class App {
                     else {
                         Boolean messageRemoval = token[2].equals("1") || token[2].equalsIgnoreCase("yes") || token[2].equalsIgnoreCase("true");
                         String reason = line.substring(token[0].length() + token[1].length() + token[2].length() + 3);
-                        Chatban.PERMA(user, null, reason, messageRemoval, Integer.MAX_VALUE).commit();
+                        Chatban.PERMA(user, null, reason, messageRemoval, Integer.MAX_VALUE, true).commit();
                     }
                 } else {
                     System.out.println("PermaChatBan USER MESSAGE_REMOVAL REASON\n    USER: The name of the user\n    MESSAGE_REMOVAL: Boolean (1|0) of whether or not to purge the user from chat.\n    REASON: The reason for the chatban. Will be displayed to the user");
@@ -651,7 +651,7 @@ public class App {
                         }
 
                         if (toPurge > 0) {
-                            App.getDatabase().purgeChat(user, null, toPurge, reason, true);
+                            App.getDatabase().purgeChat(user, null, toPurge, reason, true, true);
                         } else {
                             System.out.printf("Invalid toPurge. Should be >0, got %s%n", toPurge);
                         }

--- a/src/main/java/space/pxls/data/Database.java
+++ b/src/main/java/space/pxls/data/Database.java
@@ -1491,7 +1491,7 @@ public class Database {
      * @param reason The reason for the purge.
      * @param broadcast Whether or not to broadcast a purge message.
      */
-    public void purgeChat(User target, User initiator, int amount, String reason, boolean broadcast) {
+    public void purgeChat(User target, User initiator, int amount, String reason, boolean broadcast, boolean announce) {
         jdbi.useHandle(handle -> handle.createUpdate("UPDATE chat_messages SET purged = true, purged_by = :initiator, purge_reason = :reason WHERE author = :who")
                 .bind("initiator", initiator == null ? 0 : initiator.getId())
                 .bind("who", target.getId())
@@ -1507,7 +1507,7 @@ public class Database {
             insertAdminLog(initiatorID, logMessage);
         }
         if (broadcast) {
-            App.getServer().getPacketHandler().sendChatPurge(target, initiator, amount, reason);
+            App.getServer().getPacketHandler().sendChatPurge(target, initiator, amount, reason, announce);
         }
     }
 
@@ -1519,7 +1519,7 @@ public class Database {
      * @param reason The reason for the purge.
      * @param broadcast Whether or not to broadcast a purge message.
      */
-    public void purgeChatID(User target, User initiator, Integer id, String reason, boolean broadcast) {
+    public void purgeChatID(User target, User initiator, Integer id, String reason, boolean broadcast, boolean announce) {
         jdbi.useHandle(handle -> handle.createUpdate("UPDATE chat_messages SET purged = true, purged_by = :initiator, purge_reason = :reason WHERE id = :id")
                 .bind("initiator", initiator.getId())
                 .bind("id", id)
@@ -1535,7 +1535,7 @@ public class Database {
             insertAdminLog(initiatorID, logMessage);
         }
         if (broadcast) {
-            App.getServer().getPacketHandler().sendSpecificPurge(target, initiator, id, reason);
+            App.getServer().getPacketHandler().sendSpecificPurge(target, initiator, id, reason, announce);
         }
     }
 

--- a/src/main/java/space/pxls/server/PacketHandler.java
+++ b/src/main/java/space/pxls/server/PacketHandler.java
@@ -580,18 +580,18 @@ public class PacketHandler {
         server.send(user, chatban);
     }
 
-    public void sendChatPurge(User target, User initiator, int amount, String reason) {
-        var barePacket = new ServerChatPurge(target.getName(), initiator == null ? "CONSOLE" : initiator.getName(), amount, reason);
+    public void sendChatPurge(User target, User initiator, int amount, String reason, boolean announce) {
+        var barePacket = new ServerChatPurge(target.getName(), initiator == null ? "CONSOLE" : initiator.getName(), amount, reason, announce);
         var redactedPacket = App.getSnipMode() ? barePacket.asSnipRedacted() : barePacket;
         server.broadcastSeparateForStaff(redactedPacket, barePacket);
     }
 
-    public void sendSpecificPurge(User target, User initiator, Integer cmid, String reason) {
-        sendSpecificPurge(target, initiator, Collections.singletonList(cmid), reason);
+    public void sendSpecificPurge(User target, User initiator, Integer cmid, String reason, boolean announce) {
+        sendSpecificPurge(target, initiator, Collections.singletonList(cmid), reason, announce);
     }
 
-    public void sendSpecificPurge(User target, User initiator, List<Integer> cmids, String reason) {
-        var barePacket = new ServerChatSpecificPurge(target.getName(), initiator == null ? "CONSOLE" : initiator.getName(), cmids, reason);
+    public void sendSpecificPurge(User target, User initiator, List<Integer> cmids, String reason, boolean announce) {
+        var barePacket = new ServerChatSpecificPurge(target.getName(), initiator == null ? "CONSOLE" : initiator.getName(), cmids, reason, announce);
         var redactedPacket = App.getSnipMode() ? barePacket.asSnipRedacted() : barePacket;
         server.broadcastSeparateForStaff(redactedPacket, barePacket);
     }

--- a/src/main/java/space/pxls/server/WebHandler.java
+++ b/src/main/java/space/pxls/server/WebHandler.java
@@ -1027,7 +1027,7 @@ public class WebHandler {
 
         try {
             FormData.FormValue formSilent = data.getFirst("silent");
-            silent = formSilent.getValue().equals("on");
+            silent = Boolean.parseBoolean(formSilent.getValue());
         } catch (NullPointerException npe) {
             silent = false;
         }
@@ -1087,7 +1087,7 @@ public class WebHandler {
             return;
         }
 
-        App.getDatabase().purgeChat(target, user, Integer.MAX_VALUE, reasonData.getValue(), true, silentData.getValue().equals("on"));
+        App.getDatabase().purgeChat(target, user, Integer.MAX_VALUE, reasonData.getValue(), true, !Boolean.parseBoolean(silentData.getValue()));
 
         exchange.setStatusCode(200);
         exchange.getResponseSender().send("{}");

--- a/src/main/java/space/pxls/server/packets/chat/ServerChatPurge.java
+++ b/src/main/java/space/pxls/server/packets/chat/ServerChatPurge.java
@@ -6,12 +6,14 @@ public class ServerChatPurge {
     public String initiator;
     public Integer amount;
     public String reason;
+    public boolean announce;
 
-    public ServerChatPurge(String target, String initiator, Integer amount, String reason) {
+    public ServerChatPurge(String target, String initiator, Integer amount, String reason, boolean announce) {
         this.target = target;
         this.initiator = initiator;
         this.amount = amount;
         this.reason = reason;
+        this.announce = announce;
     }
 
     public String getType() {
@@ -34,7 +36,11 @@ public class ServerChatPurge {
         return reason;
     }
 
+    public boolean shouldAnnounce() {
+        return announce;
+    }
+
     public ServerChatPurge asSnipRedacted() {
-        return new ServerChatPurge("-snip-", "-snip-", this.amount, this.reason);
+        return new ServerChatPurge("-snip-", "-snip-", this.amount, this.reason, this.announce);
     }
 }

--- a/src/main/java/space/pxls/server/packets/chat/ServerChatSpecificPurge.java
+++ b/src/main/java/space/pxls/server/packets/chat/ServerChatSpecificPurge.java
@@ -8,12 +8,14 @@ public class ServerChatSpecificPurge {
     public String initiator;
     public List<Integer> IDs;
     public String reason;
+    public boolean announce;
 
-    public ServerChatSpecificPurge(String target, String initiator, List<Integer> IDs, String reason) {
+    public ServerChatSpecificPurge(String target, String initiator, List<Integer> IDs, String reason, Boolean announce) {
         this.target = target;
         this.initiator = initiator;
         this.IDs = IDs;
         this.reason = reason;
+        this.announce = announce;
     }
 
     public String getType() {
@@ -36,7 +38,11 @@ public class ServerChatSpecificPurge {
         return reason;
     }
 
+    public boolean shouldAnnounce() {
+        return announce;
+    }
+
     public ServerChatSpecificPurge asSnipRedacted() {
-        return new ServerChatSpecificPurge("-snip-", "-snip-", this.IDs, this.reason);
+        return new ServerChatSpecificPurge("-snip-", "-snip-", this.IDs, this.reason, this.announce);
     }
 }

--- a/src/main/java/space/pxls/user/Chatban.java
+++ b/src/main/java/space/pxls/user/Chatban.java
@@ -9,7 +9,8 @@ public class Chatban {
     public final boolean purge;
     public final int purgeAmount;
     public final long instantiatedMS;
-    private Chatban(User target, User initiator, Type type, long expiryTimeMS, String reason, boolean purge, int purgeAmount) {
+    public final boolean announce;
+    private Chatban(User target, User initiator, Type type, long expiryTimeMS, String reason, boolean purge, int purgeAmount, boolean announce) {
         //assert target != null
         instantiatedMS = System.currentTimeMillis();
         this.target = target;
@@ -19,6 +20,7 @@ public class Chatban {
         this.reason = reason;
         this.purge = purge;
         this.purgeAmount = purgeAmount;
+        this.announce = announce;
     }
 
     /**
@@ -29,8 +31,8 @@ public class Chatban {
      * @param purgeAmount The amount of messages to purge.
      * @return A {@link Chatban} object denoting this user should be permanently banned
      */
-    public static Chatban PERMA(User target, User initiator, String reason, boolean purge, int purgeAmount) {
-        return new Chatban(target, initiator, Type.PERMA, 5000000L, reason, purge, purgeAmount);
+    public static Chatban PERMA(User target, User initiator, String reason, boolean purge, int purgeAmount, boolean announce) {
+        return new Chatban(target, initiator, Type.PERMA, 5000000L, reason, purge, purgeAmount, announce);
     }
 
     /**
@@ -42,8 +44,8 @@ public class Chatban {
      * @param purgeAmount   The amount of messages to purge.
      * @return A {@link Chatban} object denoting this user should be temporarily banned
      */
-    public static Chatban TEMP(User target, User initiator, long chatbanExpiry, String reason, boolean purge, int purgeAmount) {
-        return new Chatban(target, initiator, Type.TEMP, chatbanExpiry, reason, purge, purgeAmount);
+    public static Chatban TEMP(User target, User initiator, long chatbanExpiry, String reason, boolean purge, int purgeAmount, boolean announce) {
+        return new Chatban(target, initiator, Type.TEMP, chatbanExpiry, reason, purge, purgeAmount, announce);
     }
 
     /**
@@ -53,7 +55,7 @@ public class Chatban {
      * @return A {@link Chatban} object denoting this user should be unbanned
      */
     public static Chatban UNBAN(User target, User initiator, String reason) {
-        return new Chatban(target, initiator, Type.UNBAN, System.currentTimeMillis(), reason, false, 0);
+        return new Chatban(target, initiator, Type.UNBAN, System.currentTimeMillis(), reason, false, 0, false);
     }
 
     public void commit() {

--- a/src/main/java/space/pxls/user/User.java
+++ b/src/main/java/space/pxls/user/User.java
@@ -458,7 +458,7 @@ public class User {
         App.getDatabase().updateChatBanExpiry(getId(), chatbanExpiryTime);
 
         if (chatban.purge && chatban.purgeAmount > 0) {
-            App.getDatabase().purgeChat(chatban.target, chatban.initiator, chatban.purgeAmount, "Chatban purge: " + chatban.reason, true);
+            App.getDatabase().purgeChat(chatban.target, chatban.initiator, chatban.purgeAmount, "Chatban purge: " + chatban.reason, true, chatban.announce);
         }
 
         if (doLog) {


### PR DESCRIPTION
### Description

Adds a checkbox to chat-related banning, purging, and deleting. Defaults to false. Something to consider is defaulting to true and changing the purpose to announce rather than silence (the inverse).

### Images

<img src="https://files.f66.dev/uploads/chrome_yXIcFNJh05.png">

<img src="https://files.f66.dev/uploads/chrome_DVjNzKyAa3.png">

<img src="https://files.f66.dev/uploads/chrome_VND0tHg0lB.png">

(Non-silently deleted 2, silently deleted 3)