### PR TITLE
Add slide-in for locking canvas by hotkey

### DIFF
--- a/po/Localization.po
+++ b/po/Localization.po
@@ -1694,6 +1694,10 @@ msgstr "The action you attempted to perform is not allowed or resulted in an err
 msgid "Alert"
 msgstr "Alert"
 
+#: resources/public/include/board.js
+msgid "The canvas is now locked. Press L to unlock."
+msgstr "The canvas is now locked. Press L to unlock."
+
 #. Snapshot save name
 #: resources/public/include/board.js
 msgid "pxls canvas"

--- a/po/Localization.pot
+++ b/po/Localization.pot
@@ -1695,6 +1695,10 @@ msgstr ""
 msgid "Alert"
 msgstr ""
 
+#: resources/public/include/board.js
+msgid "The canvas is now locked. Press L to unlock."
+msgstr ""
+
 #. Snapshot save name
 #: resources/public/include/board.js
 msgid "pxls canvas"

--- a/po/Localization_bg.po
+++ b/po/Localization_bg.po
@@ -1694,6 +1694,10 @@ msgstr "Действието, което се опитвате да извърш
 msgid "Alert"
 msgstr "Внимание"
 
+#: resources/public/include/board.js
+msgid "The canvas is now locked. Press L to unlock."
+msgstr ""
+
 #. Snapshot save name
 #: resources/public/include/board.js
 msgid "pxls canvas"

--- a/po/Localization_fr.po
+++ b/po/Localization_fr.po
@@ -1694,6 +1694,10 @@ msgstr "L'action que tu essayes d'effectuer n'est pas permise ou une erreur est 
 msgid "Alert"
 msgstr "Alerte"
 
+#: resources/public/include/board.js
+msgid "The canvas is now locked. Press L to unlock."
+msgstr ""
+
 #. Snapshot save name
 #: resources/public/include/board.js
 msgid "pxls canvas"

--- a/po/Localization_ru.po
+++ b/po/Localization_ru.po
@@ -1694,6 +1694,10 @@ msgstr "Действие, которое вы пытались выполнит�
 msgid "Alert"
 msgstr "Предупреждение"
 
+#: resources/public/include/board.js
+msgid "The canvas is now locked. Press L to unlock."
+msgstr ""
+
 #. Snapshot save name
 #: resources/public/include/board.js
 msgid "pxls canvas"

--- a/resources/Localization.properties
+++ b/resources/Localization.properties
@@ -1276,6 +1276,9 @@ The\ action\ you\ attempted\ to\ perform\ is\ not\ allowed\ or\ resulted\ in\ an
 #: resources/public/pxls.js
 Alert=Alert
 
+#: resources/public/include/board.js
+The\ canvas\ is\ now\ locked.\ Press\ L\ to\ unlock.=The canvas is now locked. Press L to unlock.
+
 #. Snapshot save name
 #: resources/public/include/board.js
 pxls\ canvas=pxls canvas

--- a/resources/Localization_bg.properties
+++ b/resources/Localization_bg.properties
@@ -1276,6 +1276,9 @@ The\ action\ you\ attempted\ to\ perform\ is\ not\ allowed\ or\ resulted\ in\ an
 #: resources/public/pxls.js
 Alert=\u0412\u043d\u0438\u043c\u0430\u043d\u0438\u0435
 
+#: resources/public/include/board.js
+!The\ canvas\ is\ now\ locked.\ Press\ L\ to\ unlock.=
+
 #. Snapshot save name
 #: resources/public/include/board.js
 !pxls\ canvas=

--- a/resources/Localization_fr.properties
+++ b/resources/Localization_fr.properties
@@ -1276,6 +1276,9 @@ The\ action\ you\ attempted\ to\ perform\ is\ not\ allowed\ or\ resulted\ in\ an
 #: resources/public/pxls.js
 Alert=Alerte
 
+#: resources/public/include/board.js
+!The\ canvas\ is\ now\ locked.\ Press\ L\ to\ unlock.=
+
 #. Snapshot save name
 #: resources/public/include/board.js
 pxls\ canvas=canvas de pxls

--- a/resources/Localization_ru.properties
+++ b/resources/Localization_ru.properties
@@ -1276,6 +1276,9 @@ The\ action\ you\ attempted\ to\ perform\ is\ not\ allowed\ or\ resulted\ in\ an
 #: resources/public/pxls.js
 Alert=\u041f\u0440\u0435\u0434\u0443\u043f\u0440\u0435\u0436\u0434\u0435\u043d\u0438\u0435
 
+#: resources/public/include/board.js
+!The\ canvas\ is\ now\ locked.\ Press\ L\ to\ unlock.=
+
 #. Snapshot save name
 #: resources/public/include/board.js
 pxls\ canvas=\u043f\u043e\u043b\u043e\u0442\u043d\u043e pxls

--- a/resources/public/include/board.js
+++ b/resources/public/include/board.js
@@ -159,7 +159,7 @@ const board = (function() {
           case 'L':
             settings.board.lock.enable.toggle();
             if (settings.board.lock.enable.get()) {
-              new SLIDEIN.Slidein(__('The canvas is now locked. Press L to unlock.'), 'info-circle').show().closeAfter(3000);
+              new SLIDEIN.Slidein(__('The canvas is now locked. Press L to unlock.'), 'lock').show().closeAfter(3000);
             }
             break;
           case 'KeyR':

--- a/resources/public/include/board.js
+++ b/resources/public/include/board.js
@@ -158,6 +158,9 @@ const board = (function() {
           case 'l':
           case 'L':
             settings.board.lock.enable.toggle();
+            if (settings.board.lock.enable.get()) {
+              new SLIDEIN.Slidein(__('The canvas is now locked. Press L to unlock.'), 'info-circle').show().closeAfter(3000);
+            }
             break;
           case 'KeyR':
           case 82: // R


### PR DESCRIPTION
Since there've been an uptick in users asking why their canvas wasn't moving/zooming after accidentally hitting L, this adds a three second slide-in mentioning that the canvas has been locked and to press L to unlock it.  It will go away after 3 seconds.

<img src="https://files.f66.dev/uploads/chrome_MeTgC4Ropz.png">