### PR TITLE
Update the piskel URL so it isn't a broken link

### DIFF
--- a/resources/public/pebble_templates/info.html
+++ b/resources/public/pebble_templates/info.html
@@ -78,7 +78,7 @@
 			<li><a href="https://twitter.com/pxlsspace" target="_blank">{{i18n('Localization', 'Twitter') | raw}}</a></li>
 			<li><a href="https://github.com/pxlsspace/Pxls" target="_blank">{{i18n('Localization', 'GitHub') | raw}}</a></li>
 			{# link to piskelapp.com #}
-			<li><a href="http://www.piskelapp.com/p/create" target="_blank">{{i18n('Localization', 'Single-player mode') | raw}}</a></li>
+			<li><a href="http://www.piskelapp.com/p/create/sprite" target="_blank">{{i18n('Localization', 'Single-player mode') | raw}}</a></li>
 		</ul>
 		<ul>
 			<li><a href="https://pxls.space/stats" target="_blank">{{i18n('Localization', 'Statistics') | raw}}</a></li>


### PR DESCRIPTION
Piskel's URL has changed from /p/create to /p/create/sprite, the old one is a dead link