### PR TITLE
Updated chat.js so message's bg isn't flickering

### DIFF
--- a/resources/public/include/chat.js
+++ b/resources/public/include/chat.js
@@ -1212,7 +1212,7 @@ const chat = (function() {
 
       // Truncate older chat messages by removing the diff of the current message count and the maximum count.
       const diff = self.elements.body.children().length - settings.chat.truncate.max.get();
-      if (diff > 0) {
+      if (diff > 1) {
         self.elements.body.children().slice(0, diff).remove();
       }
 


### PR DESCRIPTION
Changing 0 to 1 means it will delete 2 chat messages at ones, when it hits the maximum of messages. 
So it's no longer causes flickering because of ::nth-child(odd) css pseudostyle.