### PR TITLE
Fix to clear purged reply preview title

### DIFF
--- a/resources/public/include/chat.js
+++ b/resources/public/include/chat.js
@@ -374,6 +374,7 @@ const chat = (function() {
           elem.removeChild(elem.lastChild);
         }
         elem.appendChild(document.createTextNode('Message was purged'));
+        elem.title = '';
       };
       const _purgeSelector = (selector, e, isReplyPreview) => {
         const lines = Array.from(self.elements.body[0].querySelectorAll(selector));


### PR DESCRIPTION
Replies to purged messages still show the purged message content on hover, this PR fixes that