### PR TITLE
Fix message not found from outdated clients

### DIFF
--- a/resources/public/include/chat.js
+++ b/resources/public/include/chat.js
@@ -447,7 +447,7 @@ const chat = (function() {
             const replyShouldMention = self.elements.toggle_mention_button[0].dataset.state === 'On';
             self.cancelReply();
             self.typeahead.lastLength = -1;
-            self._send({ message: trimmed, replyingToId: replyTargetId !== undefined ? replyTargetId : -1, replyShouldMention });
+            self._send({ message: trimmed, replyingToId: replyTargetId !== undefined ? replyTargetId : 0, replyShouldMention });
             self.elements.input.val('');
           }
         } else if (e.originalEvent.key === 'Tab' || e.originalEvent.which === 9) {
@@ -1362,7 +1362,7 @@ const chat = (function() {
       return content;
     },
     _generateReplyPreview: (replyingToId, hasPing) => {
-      if (replyingToId === -1) return { div: [], hasPing };
+      if (replyingToId === 0) return { div: [], hasPing };
 
       const replyTarget = $(`[data-id=${replyingToId}]`);
       if (!replyTarget[0]) {

--- a/src/main/java/space/pxls/data/Database.java
+++ b/src/main/java/space/pxls/data/Database.java
@@ -188,7 +188,7 @@ public class Database {
                     "sent BIGINT NOT NULL," +
                     "content VARCHAR(2048) NOT NULL," +
                     "filtered VARCHAR(2048) NOT NULL DEFAULT ''," +
-                    "replying_to_id BIGINT NOT NULL DEFAULT -1," +
+                    "replying_to_id BIGINT NOT NULL DEFAULT 0," +
                     "reply_should_mention BOOL NOT NULL DEFAULT true," +
                     "purged BOOL NOT NULL DEFAULT false," +
                     "purged_by INT," +


### PR DESCRIPTION
Changes the "no reply" id to 0 from -1, so that if a client doesn't send one, it will count as 0, and no "message not found" will happen on old clients. Since the DB currently contains 0s from these clients, this will even fix existing bugged messages

# Required database change
```sql
UPDATE chat_messages SET replying_to_id = 0 WHERE replying_to_id = -1;
```