### PR TITLE
Fix stickToBottom not working while replying

### DIFF
--- a/resources/public/include/chat.js
+++ b/resources/public/include/chat.js
@@ -189,7 +189,7 @@ const chat = (function() {
             if (isChatOpen && uiHelper.tabHasFocus()) {
               ls.set('chat-last_seen_id', e.message.id);
             }
-            self._doScroll(chatLine);
+            self.elements.body[0].scrollTop = self.elements.body[0].scrollHeight;
           }
         }
       });


### PR DESCRIPTION
Also makes it so that the scroll actually sticks directly to the bottom instead of sometimes being slightly above the bottom but not at it