### PR TITLE
Prevent input losing focus when pressing chat related buttons

### DIFF
--- a/resources/public/include/chat.js
+++ b/resources/public/include/chat.js
@@ -573,11 +573,14 @@ const chat = (function() {
       });
 
       self.elements.jump_button[0].addEventListener('click', self.scrollToBottom);
+      self.elements.jump_button[0].addEventListener('mousedown', (e) => e.preventDefault()); // Prevent loss of focus from input
       self.elements.cancel_reply_button[0].addEventListener('click', self.cancelReply);
       self.elements.reply_label_username[0].addEventListener('click', () => {
         self.scrollToCMID(self.elements.input[0].dataset.replyTarget);
       });
+      self.elements.reply_label_username[0].addEventListener('mousedown', (e) => e.preventDefault()); // Prevent loss of focus from input
       self.elements.toggle_mention_button[0].addEventListener('click', self.toggleMention);
+      self.elements.toggle_mention_button[0].addEventListener('mousedown', (e) => e.preventDefault()); // Prevent loss of focus from input
 
       const notifBody = document.querySelector('.panel[data-panel="notifications"] .panel-body');
 
@@ -983,11 +986,10 @@ const chat = (function() {
       self.elements.body[0].scrollTop = self.elements.body[0].scrollHeight;
       self.stickToBottom = true;
     },
-    toggleMention() {
+    toggleMention(e) {
       const btnNode = self.elements.toggle_mention_button[0];
       btnNode.dataset.state = (btnNode.dataset.state === 'On' ? 'Off' : 'On');
       self.elements.toggle_mention_label[0].innerHTML = btnNode.dataset.state === 'On' ? __('On') : __('Off');
-      self.elements.input.focus();
     },
     cancelReply() {
       const replyTargetId = self.elements.input[0].dataset.replyTarget;
@@ -1311,7 +1313,8 @@ const chat = (function() {
         title: __('Reply'),
         onclick: () => {
           self._addReplyToChatbox(packet.id, userDisplay);
-        }
+        },
+        onmousedown: (e) => e.preventDefault() // Prevent loss of focus from input
       },
       crel('i', {
         class: 'fas fa-reply'
@@ -1405,7 +1408,8 @@ const chat = (function() {
             'data-author': replyTarget[0].dataset.author,
             'data-date': replyTarget[0].dataset.date,
             title: `${targetUsername}: ${replyTarget[0].dataset.messageRaw}`,
-            onclick: self._handlePingJumpClick
+            onclick: self._handlePingJumpClick,
+            onmousedown: (e) => e.preventDefault() // Prevent loss of focus from input
           },
           crel('i', {
             class: 'fas fa-reply fa-flip-horizontal'

--- a/resources/public/include/chat.js
+++ b/resources/public/include/chat.js
@@ -986,7 +986,7 @@ const chat = (function() {
       self.elements.body[0].scrollTop = self.elements.body[0].scrollHeight;
       self.stickToBottom = true;
     },
-    toggleMention(e) {
+    toggleMention() {
       const btnNode = self.elements.toggle_mention_button[0];
       btnNode.dataset.state = (btnNode.dataset.state === 'On' ? 'Off' : 'On');
       self.elements.toggle_mention_label[0].innerHTML = btnNode.dataset.state === 'On' ? __('On') : __('Off');

--- a/resources/public/include/chat.js
+++ b/resources/public/include/chat.js
@@ -987,6 +987,7 @@ const chat = (function() {
       const btnNode = self.elements.toggle_mention_button[0];
       btnNode.dataset.state = (btnNode.dataset.state === 'On' ? 'Off' : 'On');
       self.elements.toggle_mention_label[0].innerHTML = btnNode.dataset.state === 'On' ? __('On') : __('Off');
+      self.elements.input.focus();
     },
     cancelReply() {
       const replyTargetId = self.elements.input[0].dataset.replyTarget;


### PR DESCRIPTION
Applies to:
* #toggle-mention
* #jump to bottom
* #reply-label
* .reply-button (already sets focus, but this prevents the flickering when pressing again)
* .reply-preview