### PR TITLE
Disable links in reply-preview

### DIFF
--- a/resources/public/include/chat.js
+++ b/resources/public/include/chat.js
@@ -1391,6 +1391,10 @@ const chat = (function() {
         };
       }
 
+      // [int3nse] Remove href from links in the preview, so that we can jump to the message instead
+      // (removing this also causes issues with coordinate / template links in the reply-preview, we would need to apply a click event to them)
+      Array.from(targetPart[0].querySelectorAll('.content a')).forEach(elem => elem.removeAttribute('href'));
+
       const targetUsername = replyTarget[0].dataset.author;
       // Replies to you should ping you
       if (targetUsername === user.getUsername() && !hasPing) {


### PR DESCRIPTION
As it says, to disable links in the preview, so that instead the reply-preview click event will jump to the message. Actually, currently both happen which is a bit weird, so this fixes that.

Also, coordinate / template links are currently acting weird in the reply-preview, because they're followed by href and not the usualy handler, so by disabling this is also fixed.

This is how I think it should work, but if you think that links should work properly instead, I have another branch that would only need a little more work to be done.