### PR TITLE
Save if articles are collapsed to local storage

### DIFF
--- a/resources/public/include/uiHelper.js
+++ b/resources/public/include/uiHelper.js
@@ -126,9 +126,24 @@ const uiHelper = (function() {
         new SLIDEIN.Slidein(__(`A new ${type} report has been received.`), 'info-circle').show().closeAfter(3000);
       });
 
+      const _states = ls.get('settings.collapse.states');
+      if (_states) {
+        for (const [sectionId, state] of Object.entries(_states)) {
+          if (state) $(`article[data-id=${sectionId}] > header`).next().addClass('hidden');
+        }
+      }
+
       $('article > header').on('click', event => {
         const body = $(event.currentTarget).next();
-        body.toggleClass('hidden');
+        const sectionId = event.currentTarget.parentNode.dataset.id;
+        // In case id is unset, we should fallback to toggling the class
+        if (!sectionId) return body.toggleClass('hidden');
+        let states = ls.get('settings.collapse.states');
+        if (states === null) states = {};
+        const currentState = (states[sectionId] !== undefined) ? !states[sectionId] : true;
+        states[sectionId] = currentState;
+        currentState ? body.addClass('hidden') : body.removeClass('hidden');
+        ls.set('settings.collapse.states', states);
       });
 
       settings.ui.palette.numbers.enable.listen(function(value) {

--- a/resources/public/pebble_templates/index.html
+++ b/resources/public/pebble_templates/index.html
@@ -245,7 +245,7 @@
     </header>
     <div class="panel-body">
         <input id="settings-search-input" type="search" placeholder="{{i18n('Localization', 'Search') | raw}}" class="fullwidth" />
-        <article class="no-p-margin" data-keywords="{{i18n('Localization', 'keybinds;keys;keyboard;hotkeys') | raw}}">
+        <article data-id="keybinds" class="no-p-margin" data-keywords="{{i18n('Localization', 'keybinds;keys;keyboard;hotkeys') | raw}}">
             <header>
                 <h3>{{i18n('Localization', 'Keybinds') | raw}}</h3>
             </header>
@@ -286,7 +286,7 @@
                 </small>
             </div>
         </article>
-        <article data-keywords="{{i18n('Localization', 'templates;overlays;guides') | raw}}">
+        <article data-id="templates" data-keywords="{{i18n('Localization', 'templates;overlays;guides') | raw}}">
             <header>
                 <h3>{{i18n('Localization', 'Template') | raw}}</h3>
             </header>
@@ -371,7 +371,7 @@
                 </section>
             </div>
         </article>
-        <article data-keywords="{{i18n('Localization', 'ui;interface') | raw}}">
+        <article data-id="ui" data-keywords="{{i18n('Localization', 'ui;interface') | raw}}">
             <header>
                 <h3>{{i18n('Localization', 'UI Settings') | raw}}</h3>
             </header>
@@ -478,7 +478,7 @@
                 </section>
             </div>
         </article>
-        <article data-keywords="{{i18n('Localization', 'chat;message;ping sound') | raw}}">
+        <article data-id="chat" data-keywords="{{i18n('Localization', 'chat;message;ping sound') | raw}}">
             <header>
                 <h3>{{i18n('Localization', 'Chat Settings') | raw}}</h3>
             </header>
@@ -583,7 +583,7 @@
                 </section>
             </div>
         </article>
-        <article data-keywords="{{i18n('Localization', 'overlays;virginmap;heatmap;grid') | raw}}">
+        <article data-id="overlays" data-keywords="{{i18n('Localization', 'overlays;virginmap;heatmap;grid') | raw}}">
             <header>
                 <h3>{{i18n('Localization', 'Overlay Settings') | raw}}</h3>
             </header>
@@ -646,7 +646,7 @@
                 </section>
             </div>
         </article>
-        <article data-keywords="{{i18n('Localization', 'controls;zooming;panning;movement') | raw}}">
+        <article data-id="controls" data-keywords="{{i18n('Localization', 'controls;zooming;panning;movement') | raw}}">
             <header>
                 <h3>{{i18n('Localization', 'Control Settings') | raw}}</h3>
             </header>
@@ -705,7 +705,7 @@
                 </section>
             </div>
         </article>
-        <article data-keywords="{{i18n('Localization', 'snapshots;screenshot;download;picture;canvas') | raw}}">
+        <article data-id="snapshots" data-keywords="{{i18n('Localization', 'snapshots;screenshot;download;picture;canvas') | raw}}">
             <header>
                 <h3>{{i18n('Localization', 'Snapshot Settings') | raw}}</h3>
             </header>
@@ -724,7 +724,7 @@
                 </section>
             </div>
         </article>
-        <article data-keywords="{{i18n('Localization', 'sound;notification;alert;notify;ping') | raw}}">
+        <article data-id="sound" data-keywords="{{i18n('Localization', 'sound;notification;alert;notify;ping') | raw}}">
             <header>
                 <h3>{{i18n('Localization', 'Sound and Notification Settings') | raw}}</h3>
             </header>
@@ -799,7 +799,7 @@
                 </section>
             </div>
         </article>
-        <article data-keywords="{{i18n('Localization', 'personal account') | raw}}">
+        <article data-id="personal-account" data-keywords="{{i18n('Localization', 'personal account') | raw}}">
             <header>
                 <h3>{{i18n('Localization', 'Account Settings') | raw}}</h3>
             </header>

--- a/resources/public/pebble_templates/info.html
+++ b/resources/public/pebble_templates/info.html
@@ -1,4 +1,4 @@
-<article>
+<article data-id="welcome">
 	<header>
 		<h3>{{i18n('Localization', 'Welcome!') | raw}}</h3>
 	</header>
@@ -8,7 +8,7 @@
 		<p>{{i18n('Localization', 'Check out our social media pages, and please take the time to read the rules below. Have fun creating (or changing) art!') | raw}}</p>
 	</div>
 </article>
-<article id="canvas-rules">
+<article data-id="canvas-rules" id="canvas-rules">
 	<header>
 		<h3 class="text-red">{{i18n('Localization', 'Canvas Rules') | raw}}</h3>
 	</header>
@@ -38,7 +38,7 @@
 		<p>{{i18n('Localization', 'If you believe you have been falsely banned you may contact a moderator or administrator.') | raw}}</p>
 	</div>
 </article>
-<article id="chat-rules">
+<article data-id="chat-rules" id="chat-rules">
 	<header>
 		<h3 class="text-red">{{i18n('Localization', 'Chat Rules') | raw}}</h3>
 	</header>
@@ -67,7 +67,7 @@
 		</ol>
 	</div>
 </article>
-<article>
+<article data-id="links">
 	<header>
 		<h3>{{i18n('Localization', 'Links') | raw}}</h3>
 	</header>
@@ -90,7 +90,7 @@
 		</ul>
 	</div>
 </article>
-<article>
+<article data-id="donate">
 	<header>
 		<h3>{{i18n('Localization', 'Donate') | raw}}</h3>
 	</header>


### PR DESCRIPTION
Requested in discord by beeqlass (axolotl#9278):
> may be a silly but qol, 'saving' when you close the right bar menus? the [ keybinds template ui settings chat overlay control snapshot ] stuff. bc i close almost all of it except template/overlay but everytime i refresh/open new pxls tab it resets to when theyre open

* Saves if articles are collapsed to local storage
* Collapses them on init if they should be