### PR TITLE
Feat base64 link warning

### DIFF
--- a/po/Localization.po
+++ b/po/Localization.po
@@ -1718,6 +1718,10 @@ msgid "Jump to coordinates without replacing template"
 msgstr "Jump to coordinates without replacing template"
 
 #: resources/public/include/chat.js
+msgid "Please upload your template image to a third-party image host."
+msgstr "Please upload your template image to a third-party image host."
+
+#: resources/public/include/chat.js
 msgid "You must be logged in to chat."
 msgstr "You must be logged in to chat."
 

--- a/po/Localization.pot
+++ b/po/Localization.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Pxls\n"
-"POT-Creation-Date: 2022-04-09T16:49:48.488Z\n"
+"POT-Creation-Date: 2022-05-05T21:00:41.313Z\n"
 "Language: \n"
 "Content-Type: text/plain; charset=UTF-8\n"
 
@@ -1697,6 +1697,10 @@ msgstr ""
 msgid "Alert"
 msgstr ""
 
+#: resources/public/include/board.js
+msgid "The canvas is now locked. Press L to unlock."
+msgstr ""
+
 #. Snapshot save name
 #: resources/public/include/board.js
 msgid "pxls canvas"
@@ -1717,6 +1721,10 @@ msgstr ""
 
 #: resources/public/include/chat.js
 msgid "Jump to coordinates without replacing template"
+msgstr ""
+
+#: resources/public/include/chat.js
+msgid "Please upload your template image to a third-party image host."
 msgstr ""
 
 #: resources/public/include/chat.js

--- a/po/Localization_bg.po
+++ b/po/Localization_bg.po
@@ -1714,6 +1714,10 @@ msgid "Jump to coordinates without replacing template"
 msgstr "Посети координатите без смяна на шаблона"
 
 #: resources/public/include/chat.js
+msgid "Please upload your template image to a third-party image host."
+msgstr ""
+
+#: resources/public/include/chat.js
 msgid "You must be logged in to chat."
 msgstr ""
 

--- a/po/Localization_fr.po
+++ b/po/Localization_fr.po
@@ -1714,6 +1714,10 @@ msgid "Jump to coordinates without replacing template"
 msgstr "Aller aux coordonnées sans remplacer le modèle"
 
 #: resources/public/include/chat.js
+msgid "Please upload your template image to a third-party image host."
+msgstr ""
+
+#: resources/public/include/chat.js
 msgid "You must be logged in to chat."
 msgstr ""
 

--- a/po/Localization_lv.po
+++ b/po/Localization_lv.po
@@ -1730,6 +1730,10 @@ msgid "Jump to coordinates without replacing template"
 msgstr "Aizlekt uz koordināti neaizstājot šablonu"
 
 #: resources/public/include/chat.js
+msgid "Please upload your template image to a third-party image host."
+msgstr ""
+
+#: resources/public/include/chat.js
 msgid "You must be logged in to chat."
 msgstr "Jums ir nepieciešams pierakstīties lai izmantotu čatu."
 

--- a/po/Localization_ru.po
+++ b/po/Localization_ru.po
@@ -1714,6 +1714,10 @@ msgid "Jump to coordinates without replacing template"
 msgstr "Перейти к координатам без замены шаблона"
 
 #: resources/public/include/chat.js
+msgid "Please upload your template image to a third-party image host."
+msgstr ""
+
+#: resources/public/include/chat.js
 msgid "You must be logged in to chat."
 msgstr "Вы должны быть авторизованы в чате."
 

--- a/resources/Localization.properties
+++ b/resources/Localization.properties
@@ -1295,6 +1295,9 @@ Open\ in\ current\ tab\ (replacing\ template)=Open in current tab (replacing tem
 Jump\ to\ coordinates\ without\ replacing\ template=Jump to coordinates without replacing template
 
 #: resources/public/include/chat.js
+Please\ upload\ your\ template\ image\ to\ a\ third-party\ image\ host.=Please upload your template image to a third-party image host.
+
+#: resources/public/include/chat.js
 You\ must\ be\ logged\ in\ to\ chat.=You must be logged in to chat.
 
 #: resources/public/include/chat.js

--- a/resources/Localization_bg.properties
+++ b/resources/Localization_bg.properties
@@ -1292,6 +1292,9 @@ Open\ in\ current\ tab\ (replacing\ template)=\u041e\u0442\u0432\u043e\u0440\u04
 Jump\ to\ coordinates\ without\ replacing\ template=\u041f\u043e\u0441\u0435\u0442\u0438 \u043a\u043e\u043e\u0440\u0434\u0438\u043d\u0430\u0442\u0438\u0442\u0435 \u0431\u0435\u0437 \u0441\u043c\u044f\u043d\u0430 \u043d\u0430 \u0448\u0430\u0431\u043b\u043e\u043d\u0430
 
 #: resources/public/include/chat.js
+!Please\ upload\ your\ template\ image\ to\ a\ third-party\ image\ host.=
+
+#: resources/public/include/chat.js
 !You\ must\ be\ logged\ in\ to\ chat.=
 
 #: resources/public/include/chat.js

--- a/resources/Localization_fr.properties
+++ b/resources/Localization_fr.properties
@@ -1292,6 +1292,9 @@ Open\ in\ current\ tab\ (replacing\ template)=Ouvrir dans cet onglet (en rempla\
 Jump\ to\ coordinates\ without\ replacing\ template=Aller aux coordonn\u00e9es sans remplacer le mod\u00e8le
 
 #: resources/public/include/chat.js
+!Please\ upload\ your\ template\ image\ to\ a\ third-party\ image\ host.=
+
+#: resources/public/include/chat.js
 !You\ must\ be\ logged\ in\ to\ chat.=
 
 #: resources/public/include/chat.js

--- a/resources/Localization_lv.properties
+++ b/resources/Localization_lv.properties
@@ -1305,6 +1305,9 @@ Open\ in\ current\ tab\ (replacing\ template)=Atv\u0113rt pa\u0161reiz\u0113j\u0
 Jump\ to\ coordinates\ without\ replacing\ template=Aizlekt uz koordin\u0101ti neaizst\u0101jot \u0161ablonu
 
 #: resources/public/include/chat.js
+!Please\ upload\ your\ template\ image\ to\ a\ third-party\ image\ host.=
+
+#: resources/public/include/chat.js
 You\ must\ be\ logged\ in\ to\ chat.=Jums ir nepiecie\u0161ams pierakst\u012bties lai izmantotu \u010datu.
 
 #: resources/public/include/chat.js

--- a/resources/Localization_ru.properties
+++ b/resources/Localization_ru.properties
@@ -1292,6 +1292,9 @@ Open\ in\ current\ tab\ (replacing\ template)=\u041e\u0442\u043a\u0440\u044b\u04
 Jump\ to\ coordinates\ without\ replacing\ template=\u041f\u0435\u0440\u0435\u0439\u0442\u0438 \u043a \u043a\u043e\u043e\u0440\u0434\u0438\u043d\u0430\u0442\u0430\u043c \u0431\u0435\u0437 \u0437\u0430\u043c\u0435\u043d\u044b \u0448\u0430\u0431\u043b\u043e\u043d\u0430
 
 #: resources/public/include/chat.js
+!Please\ upload\ your\ template\ image\ to\ a\ third-party\ image\ host.=
+
+#: resources/public/include/chat.js
 You\ must\ be\ logged\ in\ to\ chat.=\u0412\u044b \u0434\u043e\u043b\u0436\u043d\u044b \u0431\u044b\u0442\u044c \u0430\u0432\u0442\u043e\u0440\u0438\u0437\u043e\u0432\u0430\u043d\u044b \u0432 \u0447\u0430\u0442\u0435.
 
 #: resources/public/include/chat.js

--- a/resources/public/include/chat.js
+++ b/resources/public/include/chat.js
@@ -57,6 +57,7 @@ const chat = (function() {
       rate_limit_overlay: $('.chat-ratelimit-overlay'),
       rate_limit_counter: $('#chat-ratelimit'),
       chat_panel: $('.panel[data-panel=chat]'),
+      chat_hints: $('.chat-hints'),
       chat_hint: $('#chat-hint'),
       chat_settings_button: $('#btnChatSettings'),
       pings_button: $('#btnPings'),
@@ -427,12 +428,30 @@ const chat = (function() {
 
       self.elements.rate_limit_overlay.hide();
 
-      self.elements.input.on('keydown', e => {
+      let allowSend = true;
+
+      self.elements.input.on('keydown keyup paste', e => {
         e.stopPropagation();
-        const toSend = self.elements.input[0].value;
+        let toSend = self.elements.input[0].value;
+        if (e.originalEvent.clipboardData) {
+          toSend = e.originalEvent.clipboardData.getData('text');
+        }
         const trimmed = toSend.trim();
+
+        if (decodeURIComponent(trimmed).includes('data:image')) {
+          allowSend = false;
+          self.showHint(__('Please upload your template image to a third-party image host.'), true);
+        } else {
+          allowSend = true;
+          self.hideHints();
+        }
+
         if ((e.originalEvent.key === 'Enter' || e.originalEvent.which === 13) && !e.shiftKey) {
           e.preventDefault();
+
+          if (!allowSend) {
+            return;
+          }
 
           if (trimmed.length === 0) {
             return;
@@ -1037,7 +1056,11 @@ const chat = (function() {
       return needle >= (haystack - drift) && needle <= (haystack + drift);
     },
     showHint: (msg, isError = false) => {
+      self.elements.chat_hints.show();
       self.elements.chat_hint.toggleClass('text-red', isError === true).text(msg);
+    },
+    hideHints: () => {
+      self.elements.chat_hints.hide();
     },
     addServerAction: msg => {
       const when = moment();

--- a/resources/public/include/chat.js
+++ b/resources/public/include/chat.js
@@ -430,12 +430,9 @@ const chat = (function() {
 
       let allowSend = true;
 
-      self.elements.input.on('keydown keyup paste', e => {
+      self.elements.input.on('keydown keyup', e => {
         e.stopPropagation();
-        let toSend = self.elements.input[0].value;
-        if (e.originalEvent.clipboardData) {
-          toSend = e.originalEvent.clipboardData.getData('text');
-        }
+        const toSend = self.elements.input[0].value;
         const trimmed = toSend.trim();
 
         if (decodeURIComponent(trimmed).includes('data:image')) {

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -1654,14 +1654,16 @@ li.chat-line[data-id] .reply-button:hover {
 }
 
 .chat-wrapper .chat-hints {
-    font-family: monospace;
-    font-size: 1.3rem;
+    display: none;
     font-weight: bold;
-    position: absolute;
-    bottom: 3.5rem;
+    transform: translateY(-100%);
+    position: relative;
     width: calc(100% - 16px);
-    background-color: #555d;
+    background-color: var(--input-background);
     color: #ff8c00;
+    padding: 5px;
+    z-index: 2;
+    border-radius: 5px;
 }
 
 .chat-wrapper .chat-controls textarea {


### PR DESCRIPTION
When `data:image` is detected in the chat input box, the user is prevented from sending the message and an error will be displayed above. The error tells the user to upload the template image to a third-party image host.

<img src="https://files.f66.dev/uploads/chrome_VK2cVAwUGE.png">
<img src="https://files.f66.dev/uploads/chrome_tVaQrZa4Mt.png">

### Translation
- [ ] Bulgarian
- [ ] French
- [ ] Latvian
- [ ] Russian