### PR TITLE
Log lookup pixel

### DIFF
--- a/src/main/java/space/pxls/data/Database.java
+++ b/src/main/java/space/pxls/data/Database.java
@@ -131,7 +131,8 @@ public class Database {
                     "id SERIAL NOT NULL PRIMARY KEY," +
                     "who INT," +
                     "time TIMESTAMP DEFAULT CURRENT_TIMESTAMP," +
-                    "ip INET)")
+                    "ip INET," +
+                    "pixel INT REFERENCES pixels(id))")
                     .execute();
             // admin_log
             handle.createUpdate("CREATE TABLE IF NOT EXISTS admin_log (" +
@@ -1288,12 +1289,14 @@ public class Database {
     /**
      * @param who The {@link User}'s ID.
      * @param ip The {@link User}'s IP.
+     * @param pixel The {@link DBPixelPlacement} given to the user by the lookup.
      * @return The inserted row ID.
      */
-    public Integer insertLookup(Integer who, String ip) {
-        return jdbi.withHandle(handle -> handle.createUpdate("INSERT INTO lookups (who, ip) VALUES (:who, :ip::INET)")
+    public Integer insertLookup(Integer who, String ip, Integer pixel) {
+        return jdbi.withHandle(handle -> handle.createUpdate("INSERT INTO lookups (who, ip, pixel) VALUES (:who, :ip::INET, :pixel)")
                 .bind("who", who)
                 .bind("ip", ip)
+                .bind("pixel", pixel)
                 .execute());
     }
 

--- a/src/main/java/space/pxls/server/WebHandler.java
+++ b/src/main/java/space/pxls/server/WebHandler.java
@@ -1950,11 +1950,6 @@ public class WebHandler {
         exchange.getResponseHeaders()
                 .put(Headers.CONTENT_TYPE, "application/json")
                 .put(HttpString.tryFromString("Access-Control-Allow-Origin"), "*");
-        if (user == null) {
-            App.getDatabase().insertLookup(null, exchange.getAttachment(IPReader.IP));
-        } else {
-            App.getDatabase().insertLookup(user.getId(), exchange.getAttachment(IPReader.IP));
-        }
 
         Lookup lookup;
         if (user != null && user.hasPermission("board.check")) {
@@ -1965,6 +1960,20 @@ public class WebHandler {
                 lookup = lookup.asSnipRedacted();
             }
         }
+        
+        Integer id;
+        if (lookup == null) {
+            id = null;
+        } else {
+            id = lookup.id;
+        }
+
+        if (user == null) {
+            App.getDatabase().insertLookup(null, exchange.getAttachment(IPReader.IP), id);
+        } else {
+            App.getDatabase().insertLookup(user.getId(), exchange.getAttachment(IPReader.IP), id);
+        }
+
         exchange.getResponseSender().send(App.getGson().toJson(lookup));
     }
 

--- a/src/main/java/space/pxls/server/WebHandler.java
+++ b/src/main/java/space/pxls/server/WebHandler.java
@@ -1925,7 +1925,7 @@ public class WebHandler {
     public void lookup(HttpServerExchange exchange) {
         User user = exchange.getAttachment(AuthReader.USER);
 
-        if (user.isBanned()) {
+        if (user != null && user.isBanned()) {
             send(StatusCodes.FORBIDDEN, exchange, "");
             return;
         }


### PR DESCRIPTION
Adds pixel id to the lookup log. This makes timing correlation analysis feasible for detecting abuse.

I would have tested this, but my local DB is still out of sync because of #528, meaning lookups cause an exception and auth also doesn't work.

## Database changes
```sql
ALTER TABLE lookups ADD pixel INT REFERENCES pixels(id);
```