### PR TITLE
Use permission chat.read to block users from recieving chat messages

### DIFF
--- a/src/main/java/space/pxls/server/PacketHandler.java
+++ b/src/main/java/space/pxls/server/PacketHandler.java
@@ -26,6 +26,7 @@ import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import java.util.function.Predicate;
 
 import static org.apache.commons.text.StringEscapeUtils.escapeHtml4;
 
@@ -488,7 +489,10 @@ public class PacketHandler {
                     staffPacket = App.getConfig().getBoolean("chat.showShadowBannedMessagesToStaff") ? staffPacket : null;
                 }
                 if (userPacket != null || staffPacket != null) {
-                    server.broadcastSeparateForStaff(userPacket, staffPacket);
+                    Predicate<PxlsWebSocketConnection> userCanReadChat = con -> con.getUser()
+                        .map(predicateUser -> predicateUser.hasPermission("chat.read"))
+                        .orElse(false);
+                    server.broadcastPredicateSeparateForStaff(userPacket, staffPacket, userCanReadChat);
                     if(userPacket != null) {
                         relayChatMessageToWebhooks(userPacket.getMessage(), App.getConfig().getStringList("chat.publicWebhooks"));
                     }

--- a/src/main/java/space/pxls/server/UndertowServer.java
+++ b/src/main/java/space/pxls/server/UndertowServer.java
@@ -234,12 +234,7 @@ public class UndertowServer {
     }
 
     public void broadcastSeparateForStaff(Object nonStaffObj, Object staffObj) {
-        String nonStaffJSON = nonStaffObj != null ? App.getGson().toJson(nonStaffObj) : null;
-        String staffJSON = staffObj != null ? App.getGson().toJson(staffObj) : null;
-        broadcastMapped(con -> {
-            boolean sendStaffObject = con.getUser().isPresent() && userCanReceiveStaffBroadcasts.test(con.getUser().get());
-            return sendStaffObject ? staffJSON : nonStaffJSON;
-        });
+        broadcastPredicateSeparateForStaff(nonStaffObj, staffObj, con -> true);
     }
 
     public void broadcastPredicateSeparateForStaff(Object nonStaffObj, Object staffObj, Predicate<PxlsWebSocketConnection> predicate) {

--- a/src/main/java/space/pxls/server/UndertowServer.java
+++ b/src/main/java/space/pxls/server/UndertowServer.java
@@ -242,6 +242,19 @@ public class UndertowServer {
         });
     }
 
+    public void broadcastPredicateSeparateForStaff(Object nonStaffObj, Object staffObj, Predicate<PxlsWebSocketConnection> predicate) {
+        String nonStaffJSON = nonStaffObj != null ? App.getGson().toJson(nonStaffObj) : null;
+        String staffJSON = staffObj != null ? App.getGson().toJson(staffObj) : null;
+        broadcastMapped(con -> {
+            if (predicate.test(con)) {
+                boolean sendStaffObject = con.getUser().isPresent() && userCanReceiveStaffBroadcasts.test(con.getUser().get());
+                return sendStaffObject ? staffJSON : nonStaffJSON;
+            } else {
+                return null;
+            }
+        });
+    }
+
     public void broadcastMapped(Function<PxlsWebSocketConnection, String> mapper) {
         connections.parallelStream()
                 .forEach(con -> {


### PR DESCRIPTION
It seems this permission has existed for a while but has not been taken advantage of.

**Note**: since this is not granted to guests by default, unauthenticated users will stop seeing chat messages after this change if using the reference roles configuration.