### PR TITLE
Fetch overlay data in parallel

### DIFF
--- a/resources/public/include/overlays.js
+++ b/resources/public/include/overlays.js
@@ -143,10 +143,8 @@ module.exports.overlays = (function() {
       // create default overlays
 
       async function createOverlayImageData(fetchOverlayData, fetchPlacemapData, color, dataXOR = 0) {
-        // we use xhr directly because of jquery being weird on raw binary
-        const overlayData = await fetchOverlayData;
+        const [overlayData, placemapData] = await Promise.all([fetchOverlayData, fetchPlacemapData]);
         const imageData = createImageData(width, height);
-        const placemapData = await fetchPlacemapData;
 
         const intView = new Uint32Array(imageData.data.buffer);
         for (let i = 0; i < width * height; i++) {


### PR DESCRIPTION
In a previous commit, overlay data was changed to be lazier, but this also had the side effect of making the 2 http calls required to load an overlay happen one after another.
We now just use `Promise.all` to fetch them in parallel.