### PR TITLE
Fix error when displaying a truncated template url in chat

### DIFF
--- a/resources/public/include/chat.js
+++ b/resources/public/include/chat.js
@@ -1464,11 +1464,12 @@ const chat = (function() {
     _makeCoordinatesElement: (raw, x, y, scale, template, title) => {
       let text = `(${x}, ${y}${scale != null ? `, ${scale}x` : ''})`;
       if (template != null && template.length >= 11) { // we have a template, should probably make that known
-        let tmplName = decodeURIComponent(
-          settings.chat.links.templates.preferurls.get() !== true && title && title.trim()
-            ? title
-            : template
-        );
+        let tmplName = settings.chat.links.templates.preferurls.get() !== true && title && title.trim() ? title : template;
+        try {
+          tmplName = decodeURIComponent(tmplName);
+        } catch (e) {
+          if (!(e instanceof URIError)) throw e;
+        }
         if (tmplName.length > 25) {
           tmplName = `${tmplName.substr(0, 22)}...`;
         }


### PR DESCRIPTION
When a template url is truncated, it can cause its name to become an invalid URI component if a percent encoded character is truncated in the middle.
This causes the whole message to fail the markdown processing and be received as a raw string.
We now catch that error and fall back to the (improperly) encoded name, which may look weird but is still better than the raw url.