### PR TITLE
Fix timer with positive alert delay

### DIFF
--- a/resources/public/include/timer.js
+++ b/resources/public/include/timer.js
@@ -80,18 +80,23 @@ module.exports.timer = (function() {
       self.elements.timer_container.hide();
       self.elements.timer_chat.text('');
 
-      if (alertDelay > 0) {
+      if (alertDelay > 0 && !self.hasFiredNotification) {
         setTimeout(() => {
-          self.playAudio();
-          if (!document.hasFocus()) {
-            const notif = nativeNotifications.maybeShow(__(`Your next pixel has been available for ${alertDelay} seconds!`));
-            if (notif) {
-              $(window).one('pxls:ack:place', () => notif.close());
+          if (!this.runningTimer) {
+            self.playAudio();
+            if (!document.hasFocus()) {
+              const notif = nativeNotifications.maybeShow(__(`Your next pixel has been available for ${alertDelay} seconds!`));
+              if (notif) {
+                $(window).one('pxls:ack:place', () => notif.close());
+              }
             }
           }
-          uiHelper.setPlaceableText(1);
+
           self.hasFiredNotification = true;
         }, alertDelay * 1000);
+        setTimeout(() => {
+          uiHelper.setPlaceableText(1);
+        }, delta * 1000);
         return;
       }
 


### PR DESCRIPTION
If im not being dumb this should fix or improve 3 things:
1. Placing stacked pixels also triggers the notification (also updating the pixel counter text to 1/6)
2. The pixel counter will get stuck at 0/6 even when a pixel is already available
3. Placing a pixel with the 0/6 pixel counter wouldn't prevent the notification from playing