### PR TITLE
Bleeped out the n-word

### DIFF
--- a/resources/public/pebble_templates/info.html
+++ b/resources/public/pebble_templates/info.html
@@ -15,7 +15,7 @@
 	<div class="pad-wrapper" id="rules-content">
 		<p>{{i18n('Localization', 'We pride ourselves on trying to keep an open canvas for all free from outside interference on our end, and especially censorship. However, for the good of the community and on accounts of our own beliefs, please acknowledge and obey the following guidelines:') | raw}}</p>
 		<ol>
-			<li>{{i18n('Localization', 'No hateful imagery or derogatory speech. This includes but is not limited to words such as <i>faggot</i>, <i>nigger</i>, etc; as well as the Swastika, Hammer and Sickle, and any symbols of terrorism.') | raw}}</li>
+			<li>{{i18n('Localization', 'No hateful imagery or derogatory speech. This includes but is not limited to words such as <i>f****t</i>, <i>n****r</i>, etc; as well as the Swastika, Hammer and Sickle, and any symbols of terrorism.') | raw}}</li>
 			<li>{{i18n('Localization', 'No NSFW or NSFL content.') | raw}}
 				<ul>
 					<li>{{i18n('Localization', 'No nudity or otherwise sexually explicit content') | raw}}


### PR DESCRIPTION
I think this is probably best for this to be enabled by default, there's no reason why the n-word should be spelled out fully like that.