### PR TITLE
Add accent colors for themes

### DIFF
--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -162,6 +162,8 @@ html {
     --emoji-picker-search-no-results-color: #666666;
     --emoji-picker-variant-overlay-background: rgba(0, 0, 0, 0.8);
     --emoji-picker-variant-popup-background: #FFFFFF;
+
+    accent-color: #4F81E5;
 }
 
 /*//////////////////////////*\

--- a/resources/public/themes/blue.css
+++ b/resources/public/themes/blue.css
@@ -80,7 +80,8 @@ html {
     --chat-typeahead-item-background-active: #0012b0;
 
     --notification-expiry-color: #995050;
-    
+
+    accent-color: #0050ff;
 }
 
 hr {

--- a/resources/public/themes/green.css
+++ b/resources/public/themes/green.css
@@ -77,6 +77,8 @@ html {
     --chat-typeahead-item-background-active: #038a3a;
 
     --notification-expiry-color: #995050;
+    
+    accent-color: #35c248;
 }
 
 hr {

--- a/resources/public/themes/purple.css
+++ b/resources/public/themes/purple.css
@@ -123,6 +123,8 @@ html {
     --emoji-picker-search-no-results-color: var(--text-muted-color);
     --emoji-picker-variant-overlay-background: rgba(0, 0, 0, 0.7);
     --emoji-picker-variant-popup-background: var(--floating-panel-background);
+    
+    accent-color: #c458ff;
 }
 
 .button:disabled {

--- a/resources/public/themes/red.css
+++ b/resources/public/themes/red.css
@@ -90,7 +90,8 @@ html {
     --chat-typeahead-item-background-active: #b00000;
 
     --notification-expiry-color: #ff8d31;
-    
+
+    accent-color: #ff6e00;
 }
 
 hr {


### PR DESCRIPTION
This changes how the native input elements look to match the theme colors. Some themes overwrite the styling of inputs and have not been given accent colors.

I'm not 100% sure about the colors chosen; while I spend a bit of time on it, the contrast is not always quite what I think is ideal, and theme authors should probably also have a say in what color would fit best for their theme.

![default](https://user-images.githubusercontent.com/64389261/234840691-5b25b43d-0a9f-47b3-bc3c-63164b2404dc.png)
![dark](https://user-images.githubusercontent.com/64389261/234840698-77a7b76b-da3c-4204-8b4c-581257da4046.png)
![darker](https://user-images.githubusercontent.com/64389261/234840701-ab05d738-736f-44ce-bb9e-08764a7ee0f1.png)
![blue](https://user-images.githubusercontent.com/64389261/234840703-739b10c2-eca7-4411-bf42-29cd4d1b5232.png)
![purple](https://user-images.githubusercontent.com/64389261/234840706-077ae9d0-5c9b-44e8-aa2f-91a31fa316ce.png)
![green](https://user-images.githubusercontent.com/64389261/234840708-c8988eee-f166-4f9d-b23c-0d5fb94c3be0.png)
![red](https://user-images.githubusercontent.com/64389261/234840711-a0f82187-733d-425e-9597-106140fbf0a4.png)
