### PR TITLE
Make cursor appear on top of reticule

### DIFF
--- a/resources/public/pebble_templates/index.html
+++ b/resources/public/pebble_templates/index.html
@@ -125,10 +125,10 @@
 
 <div id="lookup" class="floating-panel"></div>
 <div id="loading"><span>{{i18n('Localization', 'Loading...') | raw}}</span></div>
+<div id="reticule"></div>
 <div id="cursor">
     <div id="cursor-text"><i class="fas fa-spinner fa-spin captcha-loading-icon"></i> <span id="placeableCount-cursor">{{i18n('Localization', 'N/A') | raw}}</span></div>
 </div>
-<div id="reticule"></div>
 <div id="messages">
     <div id="prompt" class="message floating-panel"></div>
     <div id="signup" class="message floating-panel">


### PR DESCRIPTION
This prevents the reticule from covering the cursor when zoomed in.