### PR TITLE
Prevent user from displaying a faction they're not a member of

### DIFF
--- a/src/main/java/space/pxls/server/WebHandler.java
+++ b/src/main/java/space/pxls/server/WebHandler.java
@@ -313,6 +313,11 @@ public class WebHandler {
                         sendBadRequest(exchange, "Missing data");
                     } else {
                         if (dataObj.has("displayed")) { // user is attempting to update displayed status
+                            if (!faction.fetchMembers().stream().anyMatch(fUser -> fUser.getId() == user.getId())) {
+                                sendBadRequest(exchange, "You are not in the faction and cannot set it as displayed.");
+                                return;
+                            }
+
                             boolean displaying = false;
                             try {
                                 displaying = dataObj.get("displayed").getAsBoolean();


### PR DESCRIPTION
Without this check, users can set any displayed faction they wish by using direct http requests.