### PR TITLE
Update database pixel info and user pixel counts simultaneously

### DIFF
--- a/src/main/java/space/pxls/App.java
+++ b/src/main/java/space/pxls/App.java
@@ -1056,9 +1056,9 @@ public class App {
         virginmap[x + y * width] = (byte) 0x00;
         pixelLogger.log(Level.INFO, String.format("%s\t%d\t%d\t%d\t%s", userName, x, y, color, action));
         if (updateDatabase) {
-            database.placePixel(x, y, color, user, mod_action);
-            if (!mod_action) {
-                user.increasePixelCounts();
+            var counts = database.placePixelAndUpdateCounts(x, y, color, user, mod_action);
+            if (counts != null) {
+                user.setPixelCounts(counts);
             }
         }
     }

--- a/src/main/java/space/pxls/user/User.java
+++ b/src/main/java/space/pxls/user/User.java
@@ -593,6 +593,11 @@ public class User {
         }
     }
 
+    public void setPixelCounts(DBUserPixelCounts newCounts) {
+        this.pixelCount = newCounts.pixelCount;
+        this.pixelCountAllTime = newCounts.pixelCountAllTime;
+    }
+
     private void modifyPixelCounts(int amount) {
         boolean increaseCurrent = App.getConfig().getBoolean("pixelCounts.countTowardsCurrent");
         boolean increaseAllTime = App.getConfig().getBoolean("pixelCounts.countTowardsAlltime");
@@ -603,8 +608,7 @@ public class User {
         }
 
         DBUserPixelCounts newCounts = App.getDatabase().modifyPixelCounts(this.id, amount, increaseCurrent, increaseAllTime);
-        this.pixelCount = newCounts.pixelCount;
-        this.pixelCountAllTime = newCounts.pixelCountAllTime;
+        this.setPixelCounts(newCounts);
     }
 
     public void increasePixelCounts() {


### PR DESCRIPTION
Performance on this is questionable at best, but it did seem to be faster by about a factor of 2, at least when running batches of 1000 pixels at a time.

It's also really ugly, I'm not sure I like this much at all.