### PR TITLE
Fix popup messages clipping off screen

### DIFF
--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -535,7 +535,9 @@ dt {
     bottom: 0;
 
     display: flex;
-    flex-direction: column;
+    flex-direction: column-reverse;
+    flex-wrap: wrap;
+    gap: 0.5em;
     align-items: center;
     justify-content: center;
     pointer-events: none;


### PR DESCRIPTION
This will cause messages which cannot stack vertically to be displayed side-by-side. There's a bundled change which adds some padding between messages and reverses the vertical order to hopefully make the ordering more intuitive.