### PR TITLE
Wait to load recaptcha until it is actually requested

### DIFF
--- a/resources/public/include/board.js
+++ b/resources/public/include/board.js
@@ -463,8 +463,6 @@ const board = (function() {
         chromeOffsetWorkaround.update();
         if (data.captchaKey) {
           $('.g-recaptcha').attr('data-sitekey', data.captchaKey);
-
-          $.getScript('https://www.google.com/recaptcha/api.js');
         }
         self.elements.board.attr({
           width: self.width,

--- a/resources/public/include/place.js
+++ b/resources/public/include/place.js
@@ -272,11 +272,23 @@ module.exports.place = (function() {
           self.switch(-1);
         }
       });
-      socket.on('captcha_required', function(data) {
+      let captchaScriptLoad = null;
+      socket.on('captcha_required', async function(data) {
+        if (captchaScriptLoad == null) {
+          captchaScriptLoad = new Promise((resolve, reject) => {
+            $.getScript('https://www.google.com/recaptcha/api.js')
+              .done(() => grecaptcha.ready(resolve))
+              .fail(reject);
+          });
+        }
+
         if (!self.isDoingCaptcha) {
+          self.isDoingCaptcha = true;
           uiHelper.toggleCaptchaLoading(true);
+          await captchaScriptLoad;
           grecaptcha.reset();
         }
+        await captchaScriptLoad;
         // always execute captcha in case the user closed a captcha popup
         // and couldn't bring it back up.
         grecaptcha.execute();


### PR DESCRIPTION
This minimizes network usage and also stops bugs in recaptcha from affecting users when captchas aren't enabled.