### PR TITLE
Improve the info bubble

### DIFF
--- a/resources/public/include/timer.js
+++ b/resources/public/include/timer.js
@@ -8,6 +8,7 @@ module.exports.timer = (function() {
   const self = {
     elements: {
       palette: $('#palette'),
+      placement_info: $('#placement-info'),
       timer_container: $('#cooldown'),
       timer_countdown: $('#cooldown-timer'),
       timer_chat: $('#txtMobileChatCooldown')
@@ -27,6 +28,7 @@ module.exports.timer = (function() {
 
       if (self.runningTimer === false) {
         self.elements.timer_container.hide();
+        self.elements.placement_info.show();
       }
 
       if (self.status) {
@@ -52,6 +54,7 @@ module.exports.timer = (function() {
 
       if (delta > 0) {
         self.elements.timer_container.show();
+        self.elements.placement_info.hide();
         delta++; // real people don't count seconds zero-based (programming is more awesome)
         const secs = Math.floor(delta % 60);
         const secsStr = secs < 10 ? '0' + secs : secs;
@@ -78,6 +81,7 @@ module.exports.timer = (function() {
 
       document.title = uiHelper.getTitle();
       self.elements.timer_container.hide();
+      self.elements.placement_info.show();
       self.elements.timer_chat.text('');
 
       if (alertDelay > 0 && !self.hasFiredNotification) {
@@ -115,6 +119,7 @@ module.exports.timer = (function() {
     init: function() {
       self.title = document.title;
       self.elements.timer_container.hide();
+      self.elements.placement_info.show();
       self.elements.timer_chat.text('');
 
       setTimeout(function() {

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -777,6 +777,10 @@ dt {
     transform: rotate(0);
 }
 
+#pixel-counts, #user-info {
+    margin-block-end: 0.5rem;
+}
+
 #pixel-counts .fas {
     vertical-align: top;
 }
@@ -786,6 +790,14 @@ dt {
     padding: 0;
     list-style: none;
     display: inline-block;
+}
+
+#pixel-counts li span:first-child {
+    font-weight: bold;
+}
+
+#pixel-counts li:first-child {
+    margin-block-end: 2px;
 }
 
 #coords-info {


### PR DESCRIPTION
Add some margin to pixel count and username.
Make the keys of pixel counts bold.
Hide the placeable count 
while the cooldown is visible, and make the placeable count visible again otherwise.

Current:
![image](https://github.com/pxlsspace/Pxls/assets/106761295/3918ae8d-8ffd-4d43-be8b-941d04ac2e67)

Improved:
![image](https://github.com/pxlsspace/Pxls/assets/106761295/48c64ce9-4d77-46a7-a9ec-9a18fc8c8152)
