### PR TITLE
Add console endpoint

### DIFF
--- a/resources/roles-reference.conf
+++ b/resources/roles-reference.conf
@@ -66,6 +66,7 @@ developer {
     board.palette.all
     board.placemap.ignore
     chat.usercolor.rainbow
+    management.console
   ]
 }
 

--- a/src/main/java/space/pxls/App.java
+++ b/src/main/java/space/pxls/App.java
@@ -152,7 +152,7 @@ public class App {
         saveMap();
     }
 
-    private static void handleCommand(String line) {
+    public static void handleCommand(String line) {
         try {
             String[] token = line.split(" ");
             if (token[0].equalsIgnoreCase("reload")) {

--- a/src/main/java/space/pxls/server/UndertowServer.java
+++ b/src/main/java/space/pxls/server/UndertowServer.java
@@ -90,6 +90,7 @@ public class UndertowServer {
                 .addPermGatedPrefixPath("/sendNotificationToDiscord", "notification.discord", webHandler::sendNotificationToDiscord)
                 .addPermGatedPrefixPath("/setNotificationExpired", "notification.expired", webHandler::setNotificationExpired)
                 .addPermGatedPrefixPath("/notifications", "notification.list", webHandler::notificationsList)
+                .addPermGatedPrefixPath("/console", "management.console", new AllowedMethodsHandler(webHandler::webConsole, Methods.POST))
                 .addExactPath("/", webHandler::index)
                 .addExactPath("/index.html", webHandler::index)
                 .addExactPath("/factions", new AllowedMethodsHandler(webHandler::getRequestingUserFactions, Methods.GET))

--- a/src/main/java/space/pxls/server/WebHandler.java
+++ b/src/main/java/space/pxls/server/WebHandler.java
@@ -2103,6 +2103,17 @@ public class WebHandler {
         }
     }
 
+    public void webConsole(HttpServerExchange exchange) {
+        FormData data = exchange.getAttachment(FormDataParser.FORM_DATA);
+
+        try {
+            App.handleCommand(data.getFirst("command").getValue());
+            exchange.setStatusCode(StatusCodes.OK);
+        } catch (NullPointerException ex) {
+            exchange.setStatusCode(StatusCodes.BAD_REQUEST);
+        }
+    }
+
     private User parseUserFromForm(HttpServerExchange exchange) {
         FormData data = exchange.getAttachment(FormDataParser.FORM_DATA);
         if (data != null) {


### PR DESCRIPTION
This adds an exceedingly simple way to interface with the console as a Pxls user as per #688. This is gated behind the `management.console` permission which is granted to developers in the reference roles.

While a more comprehensive solution would be nice, this is quick and easy for now.