### PR TITLE
Properly transact user signups

### DIFF
--- a/src/main/java/space/pxls/data/Database.java
+++ b/src/main/java/space/pxls/data/Database.java
@@ -701,8 +701,7 @@ public class Database {
      * @return The user.
      */
     public DBUser createUser(String name, UserLogin login, String ip) {
-        // TODO(netux): use jdbi.inTransaction
-        return jdbi.withHandle(handle -> {
+        return jdbi.inTransaction(handle -> {
             DBUser user = handle.createQuery("INSERT INTO users (username, login_with_ip, signup_ip, last_ip, chat_name_color) VALUES (:username, :login_with_ip, :ip::INET, :ip::INET, :chat_name_color) RETURNING *")
                 .bind("username", name)
                 .bind("ip", ip)

--- a/src/main/java/space/pxls/user/UserManager.java
+++ b/src/main/java/space/pxls/user/UserManager.java
@@ -90,12 +90,11 @@ public class UserManager {
     }
 
     public User signUp(String name, String token, String ip) {
-        UserLogin login = userSignupTokens.get(token);
+        UserLogin login = userSignupTokens.remove(token);
         if (login == null) return null;
 
         if (!App.getDatabase().getUserByName(name).isPresent()) {
             DBUser user = App.getDatabase().createUser(name, login, ip);
-            userSignupTokens.remove(token);
             return getByDB(Optional.of(user));
         }
         return null;


### PR DESCRIPTION
This solves two potential issues:
1. A race condition where a signup token is obtained and then used multiple times at once. If the multithreading is unfortunately timed, it may be possible that some threads pass the hashmap lookup check before the key is removed.
2. A user could obtain multiple signup tokens before using one, then later use them all. This would fail to insert the login details but would create the user, leaving things in an incorrect state since this was not handled in a transaction.