### PR TITLE
7TV Integration + Move chat history to GET /chat/history

### DIFF
--- a/resources/reference.conf
+++ b/resources/reference.conf
@@ -246,6 +246,7 @@ chat {
     linkSendToStaff: false
     // Whether to enforce external link popups by default (overridable through user settings)
     defaultExternalLinkPopup: false
+    emoteSet7TV: ""
     customEmoji: [
       // Emoji only support a-z, A-Z, _, and -.
       // No two emoji may have the same name, this is case insensitive.

--- a/src/main/java/space/pxls/server/UndertowServer.java
+++ b/src/main/java/space/pxls/server/UndertowServer.java
@@ -70,6 +70,7 @@ public class UndertowServer {
                 .addPermGatedPrefixPath("/reportChat", "chat.report", webHandler::chatReport)
                 .addPermGatedPrefixPath("/whoami", "user.auth", webHandler::whoami)
                 .addPermGatedPrefixPath("/users", "user.online", webHandler::users)
+                .addPermGatedPrefixPath("/chat/history", "chat.history", new RateLimitingHandler(webHandler::chatHistory, "http:chatHistory", (int) App.getConfig().getDuration("server.limits.chatHistory.time", TimeUnit.SECONDS), App.getConfig().getInt("server.limits.chatHistory.count")))
                 .addPermGatedPrefixPath("/chat/setColor", "user.chatColorChange", new RateLimitingHandler(webHandler::chatColorChange, "http:chatColorChange", (int) App.getConfig().getDuration("server.limits.chatColorChange.time", TimeUnit.SECONDS), App.getConfig().getInt("server.limits.chatColorChange.count")))
                 .addPermGatedPrefixPath("/setDiscordName", "user.discordNameChange", new RateLimitingHandler(webHandler::discordNameChange, "http:discordName", (int) App.getConfig().getDuration("server.limits.discordNameChange.time", TimeUnit.SECONDS), App.getConfig().getInt("server.limits.discordNameChange.count")))
                 .addPermGatedPrefixPath("/admin", "user.admin", Handlers.resource(new ClassPathResourceManager(App.class.getClassLoader(), "public/admin/")).setCacheTime(10))

--- a/src/main/java/space/pxls/server/WebHandler.java
+++ b/src/main/java/space/pxls/server/WebHandler.java
@@ -1734,6 +1734,7 @@ public class WebHandler {
             App.getConfig().getBoolean("chat.canvasBanRespected"),
             App.getConfig().getStringList("chat.bannerText"),
             App.getSnipMode(),
+            App.getConfig().getString("chat.emoteSet7TV"),
             App.getConfig().getList("chat.customEmoji").unwrapped(),
             App.getConfig().getString("cors.proxyBase"),
             App.getConfig().getString("cors.proxyParam"),

--- a/src/main/java/space/pxls/server/WebHandler.java
+++ b/src/main/java/space/pxls/server/WebHandler.java
@@ -15,6 +15,8 @@ import space.pxls.App;
 import space.pxls.auth.*;
 import space.pxls.data.*;
 import space.pxls.palette.Color;
+import space.pxls.server.packets.chat.Badge;
+import space.pxls.server.packets.chat.ChatMessage;
 import space.pxls.server.packets.http.Error;
 import space.pxls.server.packets.http.*;
 import space.pxls.server.packets.socket.*;
@@ -931,6 +933,74 @@ public class WebHandler {
 
         exchange.setStatusCode(200);
         exchange.getResponseSender().send("{}");
+        exchange.endExchange();
+    }
+
+    public void chatHistory(HttpServerExchange exchange) {
+//        App.getUserManager().getByName("filipus098").ban(0, "polish <3", null);
+        exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "application/json");
+
+        if (!App.isChatEnabled()) {
+            sendForbidden(exchange, "Chatting and chat actions are disabled");
+            return;
+        }
+
+        User user = exchange.getAttachment(AuthReader.USER);
+        if (user == null) {
+            sendBadRequest(exchange);
+            return;
+        }
+
+        boolean includePurged = user.hasPermission("chat.history.purged");
+        var messages = App.getDatabase().getLastXMessages(100, includePurged).stream()
+                .map(dbChatMessage -> {
+                    List<Badge> badges = new ArrayList<>();
+                    String authorName = "CONSOLE";
+                    int nameColor = 0;
+                    Faction faction = null;
+                    List<String> nameClass = null;
+                    if (dbChatMessage.author_uid > 0) {
+                        authorName = "$Unknown";
+                        User author = App.getUserManager().getByID(dbChatMessage.author_uid);
+                        if (author != null) {
+                            authorName = author.getName();
+                            badges = author.getChatBadges();
+                            nameColor = author.getChatNameColor();
+                            nameClass = author.getChatNameClasses();
+                            faction = author.fetchDisplayedFaction();
+                        }
+                    }
+                    var message = new ChatMessage(
+                            dbChatMessage.id,
+                            authorName,
+                            dbChatMessage.sent,
+                            App.getConfig().getBoolean("textFilter.enabled") && dbChatMessage.filtered_content.length() > 0
+                                    ? dbChatMessage.filtered_content
+                                    : dbChatMessage.content,
+                            dbChatMessage.replying_to_id,
+                            dbChatMessage.reply_should_mention,
+                            dbChatMessage.purged
+                                    ? new ChatMessage.Purge(dbChatMessage.purged_by_uid, dbChatMessage.purge_reason)
+                                    : null,
+                            badges,
+                            nameClass,
+                            nameColor,
+                            dbChatMessage.author_was_shadow_banned,
+                            faction
+                    );
+                    if (user.isShadowBanned() && dbChatMessage.author_uid == user.getId()) {
+                        message = message.asShadowBanned();
+                    }
+                    if (!includePurged && App.getSnipMode()) {
+                        message = message.asSnipRedacted();
+                    }
+                    return message;
+                })
+                .filter(message -> !message.getAuthorWasShadowBanned() || user.hasPermission("chat.history.shadowbanned"))
+                .collect(Collectors.toList());
+
+        exchange.setStatusCode(200);
+        exchange.getResponseSender().send(App.getGson().toJson(messages));
         exchange.endExchange();
     }
 

--- a/src/main/java/space/pxls/server/packets/http/CanvasInfo.java
+++ b/src/main/java/space/pxls/server/packets/http/CanvasInfo.java
@@ -23,6 +23,7 @@ public class CanvasInfo {
     public Integer chatCharacterLimit;
     public List<String> chatBannerText;
     public Boolean snipMode;
+    public String emoteSet7TV;
     public List<Object> customEmoji;
     public String corsBase;
     public String corsParam;
@@ -32,7 +33,7 @@ public class CanvasInfo {
     public Boolean chatLinkSendToStaff;
     public Boolean chatDefaultExternalLinkPopup;
 
-    public CanvasInfo(String canvasCode, Integer width, Integer height, List<Color> palette, CooldownInfo cooldownInfo, String captchaKey, Integer heatmapCooldown, Integer maxStacked, Map<String, AuthService> authServices, Boolean registrationEnabled, Boolean chatEnabled, Integer chatCharacterLimit, boolean chatRespectsCanvasBan, List<String> chatBannerText, boolean snipMode, List<Object> customEmoji, String corsBase, String corsParam, LegalInfo legal, String chatRatelimitMessage, Integer chatLinkMinimumPixelCount, boolean chatLinkSendToStaff, boolean chatDefaultExternalLinkPopup) {
+    public CanvasInfo(String canvasCode, Integer width, Integer height, List<Color> palette, CooldownInfo cooldownInfo, String captchaKey, Integer heatmapCooldown, Integer maxStacked, Map<String, AuthService> authServices, Boolean registrationEnabled, Boolean chatEnabled, Integer chatCharacterLimit, boolean chatRespectsCanvasBan, List<String> chatBannerText, boolean snipMode, String emoteSet7TV, List<Object> customEmoji, String corsBase, String corsParam, LegalInfo legal, String chatRatelimitMessage, Integer chatLinkMinimumPixelCount, boolean chatLinkSendToStaff, boolean chatDefaultExternalLinkPopup) {
         this.canvasCode = canvasCode;
         this.width = width;
         this.height = height;
@@ -48,6 +49,7 @@ public class CanvasInfo {
         this.chatRespectsCanvasBan = chatRespectsCanvasBan;
         this.chatBannerText = chatBannerText;
         this.snipMode = snipMode;
+        this.emoteSet7TV = emoteSet7TV;
         this.customEmoji = customEmoji;
         this.corsBase = corsBase;
         this.corsParam = corsParam;
@@ -112,6 +114,10 @@ public class CanvasInfo {
 
     public Boolean getSnipMode() {
         return snipMode;
+    }
+
+    public String getEmoteSet7TV() {
+        return emoteSet7TV;
     }
 
     public List<Object> getCustomEmoji() {


### PR DESCRIPTION
This PR adds the server-side component to 7TV emote integration. `chat.emoteSet7TV` must be set to an emote set ID.