### PR TITLE
Add CAS auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Edit configuration files as necessary. The following `pxls.conf` keys MUST be co
 * `database.url`
 * `host`
 * `oauth` (necessary for any form of user authentication)
-    * [Reddit][redditapps], [Google][googleconsole], [Discord][discordapps], [VK][vkapps], and [Tumblr][tumblrapps] are current supported.
+    * [Reddit][redditapps], [Google][googleconsole], [Discord][discordapps], [VK][vkapps], [Tumblr][tumblrapps], and [CAS applications](https://apereo.github.io/cas/7.0.x/index.html) are current supported.
 
 Run with `java -jar pxls*.jar`
 

--- a/resources/reference.conf
+++ b/resources/reference.conf
@@ -227,6 +227,18 @@ oauth {
     enabled: true
     registrationEnabled: true
   }
+  
+  // Create your CAS app with documentation https://apereo.github.io/cas/7.0.x/index.html
+  // WARNING: Cas tokens cannot be revoked by the user through the provider website.
+  // This login method is only suitable for short-lived events.
+  cas {
+    name: "CAS" // Custom name for this login method
+    loginUrl: "" // https://example.com/cas/login
+    validateUrl: "" // https://example.com/cas/serviceValidate
+    usernameField: "user"
+    enabled: true
+    registrationEnabled: true
+  }
 }
 
 textFilter {

--- a/src/main/java/space/pxls/auth/AuthService.java
+++ b/src/main/java/space/pxls/auth/AuthService.java
@@ -128,7 +128,15 @@ public abstract class AuthService {
     }
 
     public boolean use() {
-        return enabled && !App.getConfig().getString("oauth."+id+".key").isEmpty();
+        if (id.equals("cas")) {
+            return enabled
+                && !App.getConfig().getString("oauth.cas.loginUrl").isEmpty()
+                && !App.getConfig().getString("oauth.cas.validateUrl").isEmpty()
+                && !App.getConfig().getString("oauth.cas.usernameField").isEmpty();
+        } else {
+            return enabled
+                && !App.getConfig().getString("oauth."+id+".key").isEmpty();
+        }
     }
 
     public abstract String getName();

--- a/src/main/java/space/pxls/auth/CasAuthService.java
+++ b/src/main/java/space/pxls/auth/CasAuthService.java
@@ -1,0 +1,78 @@
+package space.pxls.auth;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+import kong.unirest.HttpResponse;
+import kong.unirest.Unirest;
+import kong.unirest.UnirestException;
+import space.pxls.App;
+
+public class CasAuthService extends AuthService {
+    public CasAuthService(String id) {
+        super(id, App.getConfig().getBoolean("oauth.cas.enabled"), App.getConfig().getBoolean("oauth.cas.registrationEnabled"));
+    }
+
+    @Override
+    public String getRedirectUrl(String state) {
+        try {
+            state = URLEncoder.encode(state, StandardCharsets.UTF_8.toString());
+        } catch (UnsupportedEncodingException e) {
+            return "";
+        }
+        String service = getCallbackUrl() + "?state=" + state;
+        try {
+            service = URLEncoder.encode(service, StandardCharsets.UTF_8.toString());
+        } catch (UnsupportedEncodingException e) {
+            return "";
+        }
+        return App.getConfig().getString("oauth.cas.loginUrl") + "?service=" + service;
+    }
+
+    @Override
+    public String getToken(String token) throws UnirestException {
+        HttpResponse<String> response = Unirest.get(App.getConfig().getString("oauth.cas.validateUrl"))
+            .queryString("service", getCallbackUrl())
+            .queryString("ticket", token)
+            .asString();
+
+        if (response.getStatus() != 200) {
+            throw new UnirestException("CAS validation failed: " + response.getStatusText());
+        }
+
+        String username;
+        try {
+            String start_username_field = "<cas:" + App.getConfig().getString("oauth.cas.usernameField") + ">";
+            String end_username_field = "</cas:" + App.getConfig().getString("oauth.cas.usernameField") + ">";
+            username = response.getBody().split(start_username_field)[1].split(end_username_field)[0];
+        } catch (Exception e) {
+            throw new UnirestException("CAS validation failed: " + e.getMessage());
+        }
+
+        return username;
+    }
+
+    @Override
+    public String getIdentifier(String token) throws UnirestException {
+        return token;
+    }
+
+    public String getName() {
+        try {
+            String custom_name = App.getConfig().getString("oauth.cas.name");
+            if (custom_name != null && !custom_name.isEmpty()) {
+                return custom_name;
+            }
+        } catch (Exception e) {
+            // ignore
+        }
+        return "CAS";
+    }
+
+    @Override
+    public void reloadEnabledState() {
+        this.enabled = App.getConfig().getBoolean("oauth.cas.enabled");
+        this.registrationEnabled = App.getConfig().getBoolean("oauth.cas.registrationEnabled");
+    }
+}

--- a/src/main/java/space/pxls/server/WebHandler.java
+++ b/src/main/java/space/pxls/server/WebHandler.java
@@ -43,6 +43,7 @@ public class WebHandler {
         addServiceIfAvailable("vk", new VKAuthService("vk"));
         addServiceIfAvailable("tumblr", new TumblrAuthService("tumblr"));
         addServiceIfAvailable("twitch", new TwitchAuthService("twitch"));
+        addServiceIfAvailable("cas", new CasAuthService("cas"));
     }
 
     public void getRequestingUserFactions(HttpServerExchange exchange) throws Exception {
@@ -1687,7 +1688,12 @@ public class WebHandler {
             }
 
             // Get the one-time authorization code from the request
-            String code = extractOAuthCode(exchange);
+            String code;
+            if ("cas".equals(id)) {
+                code = exchange.getQueryParameters().get("ticket").element();
+            } else {
+                code = extractOAuthCode(exchange);
+            }
             if (code == null) {
                 if (redirect) {
                     redirect(exchange, doneBase + "?nologin=1");


### PR DESCRIPTION
I recently ran an event using your codebase (thanks!). I had to gate the canvas to my community so I implemented it in a way that can be useful to others.

CAS is a very simple auth protocol that anyone can implement. The client implementation I made here isn't particularly robust as it doesn't have any expiration mechanism for logins, but it's very well suited for short-lived events.