### PR TITLE
Allow admins to make users join factions

### DIFF
--- a/docs/roles.md
+++ b/docs/roles.md
@@ -104,7 +104,8 @@ roleID {
 | `faction.create` | `/factions` | Create faction | user |
 | `faction.data` | `/factions/{fid}` | Access faction data | user |
 | `faction.delete` | `/factions/{fid}` | Delete own faction | user |
-| `faction.delete.other` | `/admin/faction/delete` | Delete other factions | staff |
+| `faction.delete.other` | `/admin/faction/delete` | Delete other factions | administrator |
+| `faction.join.other` | `/admin/faction/join` | Make other user join a faction | administrator |
 | `faction.edit` | `/factions/{fid}` | Edit own faction | user |
 | `faction.edit.other` | `/admin/faction/edit` | Edit other factions | staff |
 | `faction.setblocked` | `/admin/setFactionBlocked` | Set block status on factions | staff |

--- a/resources/roles-reference.conf
+++ b/resources/roles-reference.conf
@@ -126,6 +126,7 @@ administrator {
     board.placemap.ignore
     user.shadowban
     faction.delete.other
+    faction.join.other
     faction.edit.other
     faction.setblocked
     notification.create

--- a/src/main/java/space/pxls/server/UndertowServer.java
+++ b/src/main/java/space/pxls/server/UndertowServer.java
@@ -87,6 +87,7 @@ public class UndertowServer {
                 .addPermGatedPrefixPath("/admin/forceNameChange", "user.namechange.force", webHandler::forceNameChange)
                 .addPermGatedPrefixPath("/admin/faction/edit", "faction.edit.other", new JsonReader(webHandler::adminEditFaction))
                 .addPermGatedPrefixPath("/admin/faction/delete", "faction.delete.other", new JsonReader(webHandler::adminDeleteFaction))
+                .addPermGatedPrefixPath("/admin/faction/join", "faction.join.other", new JsonReader(webHandler::adminJoinFaction))
                 .addPermGatedPrefixPath("/admin/setFactionBlocked", "faction.setblocked", new AllowedMethodsHandler(webHandler::setFactionBlocked, Methods.POST))
                 .addPermGatedPrefixPath("/createNotification", "notification.create", webHandler::createNotification)
                 .addPermGatedPrefixPath("/sendNotificationToDiscord", "notification.discord", webHandler::sendNotificationToDiscord)


### PR DESCRIPTION
I recently ran an event using your codebase (thanks!). My community was already split in small groups, which I wanted represented as factions on the canvas. I needed a way to automatically assign factions to users.

I think this endpoint might prove useful to others in the future