### PR TITLE
Fix race condition on concurrent board access

### DIFF
--- a/src/main/java/space/pxls/App.java
+++ b/src/main/java/space/pxls/App.java
@@ -979,28 +979,33 @@ public class App {
     }
 
     public static ByteBuffer getHeatmapData() {
-        heatmap.rewind();
-        return heatmap;
+        ByteBuffer copy = heatmap.asReadOnlyBuffer();
+        copy.rewind();
+        return copy;
     }
 
     public static ByteBuffer getVirginmapData() {
-        virginmap.rewind();
-        return virginmap;
+        ByteBuffer copy = virginmap.asReadOnlyBuffer();
+        copy.rewind();
+        return copy;
     }
 
     public static ByteBuffer getPlacemapData() {
-        placemap.rewind();
-        return placemap;
+        ByteBuffer copy = placemap.asReadOnlyBuffer();
+        copy.rewind();
+        return copy;
     }
 
     public static ByteBuffer getBoardData() {
-        board.rewind();
-        return board;
+        ByteBuffer copy = board.asReadOnlyBuffer();
+        copy.rewind();
+        return copy;
     }
 
     public static ByteBuffer getDefaultBoardData() {
-        defaultBoard.rewind();
-        return defaultBoard;
+        ByteBuffer copy = defaultBoard.asReadOnlyBuffer();
+        copy.rewind();
+        return copy;
     }
 
     public static Path getStorageDir() {

--- a/src/main/java/space/pxls/App.java
+++ b/src/main/java/space/pxls/App.java
@@ -979,31 +979,47 @@ public class App {
     }
 
     public static ByteBuffer getHeatmapData() {
-        ByteBuffer copy = heatmap.asReadOnlyBuffer();
+        ByteBuffer copy;
+        synchronized (heatmap) {
+            copy = heatmap.asReadOnlyBuffer();
+        }
         copy.rewind();
         return copy;
     }
 
     public static ByteBuffer getVirginmapData() {
-        ByteBuffer copy = virginmap.asReadOnlyBuffer();
+        ByteBuffer copy;
+        synchronized (virginmap) {
+            copy = virginmap.asReadOnlyBuffer();
+        }
+        copy.rewind();
         copy.rewind();
         return copy;
     }
 
     public static ByteBuffer getPlacemapData() {
-        ByteBuffer copy = placemap.asReadOnlyBuffer();
+        ByteBuffer copy;
+        synchronized (placemap) {
+            copy = placemap.asReadOnlyBuffer();
+        }
         copy.rewind();
         return copy;
     }
 
     public static ByteBuffer getBoardData() {
-        ByteBuffer copy = board.asReadOnlyBuffer();
+        ByteBuffer copy;
+        synchronized (board) {
+            copy = board.asReadOnlyBuffer();
+        }
         copy.rewind();
         return copy;
     }
 
     public static ByteBuffer getDefaultBoardData() {
-        ByteBuffer copy = defaultBoard.asReadOnlyBuffer();
+        ByteBuffer copy;
+        synchronized (defaultBoard) {
+            copy = defaultBoard.asReadOnlyBuffer();
+        }
         copy.rewind();
         return copy;
     }
@@ -1025,19 +1041,27 @@ public class App {
     }
 
     public static byte getPixel(int x, int y) {
-        return board.get(x + y * width);
+        synchronized (board) {
+            return board.get(x + y * width);
+        }
     }
 
     public static byte getPlacemap(int x, int y) {
-        return placemap.get(x + y * width);
+        synchronized (placemap) {
+            return placemap.get(x + y * width);
+        }
     }
 
     public static byte getVirginmap(int x, int y) {
-        return virginmap.get(x + y * width);
+        synchronized (virginmap) {
+            return virginmap.get(x + y * width);
+        }
     }
 
     public static byte getDefaultPixel(int x, int y) {
-        return defaultBoard.get(x + y * width);
+        synchronized (defaultBoard) {
+            return defaultBoard.get(x + y * width);
+        }
     }
 
     public static boolean getCanPlace(int x, int y) {
@@ -1090,9 +1114,15 @@ public class App {
             action = mod_action ? "mod overwrite" : "user place";
         }
 
-        board.put(x + y * width, (byte) color);
-        heatmap.put(x + y * width, (byte) 0xFF);
-        virginmap.put(x + y * width, (byte) 0x00);
+        synchronized (board) {
+            board.put(x + y * width, (byte) color);
+        }
+        synchronized (heatmap) {
+            heatmap.put(x + y * width, (byte) 0xFF);
+        }
+        synchronized (virginmap) {
+            virginmap.put(x + y * width, (byte) 0x00);
+        }
         pixelLogger.log(Level.INFO, String.format("%s\t%d\t%d\t%d\t%s", userName, x, y, color, action));
         if (updateDatabase) {
             database.placePixel(x, y, color, user, mod_action);
@@ -1368,10 +1398,12 @@ public class App {
     }
 
     public static void updateHeatmap() {
-        for (int i = 0; i < width * height; i++) {
-            byte value = heatmap.get(i);
-            if (value != 0) {
-                heatmap.put(i, (byte) (value - 1));
+        synchronized (heatmap) {
+            for (int i = 0; i < width * height; i++) {
+                byte value = heatmap.get(i);
+                if (value != 0) {
+                    heatmap.put(i, (byte) (value - 1));
+                }
             }
         }
     }


### PR DESCRIPTION
Pxls sometimes returns corrupted board data when multiple clients are fetching `/boarddata` or one of the other memory-mapped buffers. [This script](https://gist.github.com/shuni64/80b244d62c94275d29e8f3fcf7dc4a5d) very reliably reproduces the issue on my machine, but due to the nature of race conditions some parameters may have to be tweaked if it doesn't work (namely, increase the number of workers and the number of requests).

I believe the cause of this to be that ByteBuffers have an internal cursor/position that gets reset when a new request starts reading the buffer. Since this value is shared by all readers, existing readers start from the beginning even though they're already halfway through the buffer and have sent that data to the client. In theory this may cause all kinds of weird issues, but this is the behavior I've seen manifest on pxls.space.
There is a likely related issue that, after running the above script, causes the returned board data to be corrupted until Pxls is relaunched, but I haven't been able to determine the root cause of that.
Additionally, [ByteBuffers are not thread-safe](https://docs.oracle.com/en/java/javase/16/docs/api/java.base/java/nio/Buffer.html), meaning that concurrent access must generally be synchronized.

This PR solves the problem by:
- creating new read-only ByteBuffers with a shared underlying buffer but separate cursors
- synchronizing most other board data accesses

There is still a theoretical issue that could cause slight corruption of reads while a pixel is being set because access to the buffer itself is not synchronized, but I think that, in practice, this does not occur at a high enough rate to warrant locking the board during reads.