### PR TITLE
Show reported username as "-snip-" when snip mode is enabled

### DIFF
--- a/src/main/java/space/pxls/data/DBCanvasReport.java
+++ b/src/main/java/space/pxls/data/DBCanvasReport.java
@@ -35,6 +35,7 @@ public class DBCanvasReport {
     }
 
     public String getReportedName() {
+    	if (App.getSnipMode()) return "-snip-";
         User u = App.getUserManager().getByID(reported);
         return u == null ? "" : u.getName();
     }

--- a/src/main/java/space/pxls/data/DBChatReport.java
+++ b/src/main/java/space/pxls/data/DBChatReport.java
@@ -31,6 +31,7 @@ public class DBChatReport {
     }
 
     public String getReportedName() {
+        if (App.getSnipMode()) return "-snip-";
         User u = App.getUserManager().getByID(target);
         return u == null ? "" : u.getName();
     }


### PR DESCRIPTION
Users were previously able to report users in snip mode, then visit their own profile, view the list of reports, and finally see the real username of the reported pixel or message.

This patch simply checks if snip mode is enabled when preparing the data and replacing the username with "-snip-" if it is.