### PR TITLE
Fix user count by removing `initialAuthTime` field for users

### DIFF
--- a/src/main/java/space/pxls/App.java
+++ b/src/main/java/space/pxls/App.java
@@ -1420,9 +1420,8 @@ public class App {
         for (User user : server.getAuthedUsers().values()) {
             if (user.isIdled()) continue;
 
-            Long toUse = user.getLastPixelTime() == 0L ? user.getInitialAuthTime() : user.getLastPixelTime();
-            Long delta = loopStart - toUse;
-            boolean isIdled = userIdleTimeout - delta <= 0;
+            Long delta = loopStart - user.getLastPixelTime();
+            boolean isIdled = delta > userIdleTimeout;
 
             if (isIdled) {
                 anyIdled = true;

--- a/src/main/java/space/pxls/server/PacketHandler.java
+++ b/src/main/java/space/pxls/server/PacketHandler.java
@@ -96,7 +96,6 @@ public class PacketHandler {
             user.flagForCaptcha();
             server.addAuthedUser(user);
 
-            user.setInitialAuthTime(System.currentTimeMillis());
             user.tickStack(false); // pop the whole pixel stack
             sendAvailablePixels(channel, user, "connect");
         }

--- a/src/main/java/space/pxls/user/User.java
+++ b/src/main/java/space/pxls/user/User.java
@@ -46,7 +46,6 @@ public class User {
     private String chatbanReason;
     private long cooldownExpiry;
     private long lastPixelTime = 0;
-    private long initialAuthTime = 0L;
     private Timestamp signup_time;
     private Integer displayedFaction;
     private Boolean factionBlocked;
@@ -565,14 +564,6 @@ public class User {
         App.getDatabase().updateUserStacked(this, stacked);
     }
 
-    public long getInitialAuthTime() {
-        return initialAuthTime;
-    }
-
-    public void setInitialAuthTime(long initialAuthTime) {
-        this.initialAuthTime = initialAuthTime;
-    }
-
     public boolean lastPlaceWasStack() {
         return lastPlaceWasStack;
     }
@@ -599,17 +590,16 @@ public class User {
 
         int curCD = App.getServer().getPacketHandler().getCooldown();
 
-        long lastPixelTime = getLastPixelTime() == 0 ? (this.cooldownExpiry == 0 ? getInitialAuthTime() : (this.cooldownExpiry - (curCD*1000))) : getLastPixelTime();
-        if (lastPixelTime == 0) {
-            return;
+        long lastPixelTime;
+        if (getLastPixelTime() != 0) {
+            lastPixelTime = getLastPixelTime();
+        } else {
+            lastPixelTime = this.cooldownExpiry - (curCD*1000);
         }
+
         long delta = (System.currentTimeMillis()-lastPixelTime) / 1000;
-        //App.getLogger().debug("=======");
         while(true) {
             int target = (curCD * multiplier) * (2 + getStacked() + addToN(getStacked()));
-            //App.getLogger().debug(delta);
-            //App.getLogger().debug(" : ");
-            //App.getLogger().debug(target);
             if (delta >= target && getStacked() < maxStacked) {
                 setStacked(getStacked() + 1);
                 if (sendRes) {


### PR DESCRIPTION
This field has a misleading name, since it represents the last time that a user connected via websocket and not their actual initial signup time. This means that in both places where it was used it caused subtle bugs:

1. When calculating the idle users, a user who has not yet placed this session would be counted as active for the idle timeout period after every connection.

2. When calculating stacked pixels for a user who has never placed before, the cooldown was based on the last connection time. This means if they continuously reconnected, they would never gain any stacked pixels.

The far more impactful issue here is (1), but by removing the field entirely (2) is also fixed.

The way in which (2) is fixed here does have one significant effect, however: new users start with a full stack initially. Hopefully this isn't an issue.